### PR TITLE
Logging Improvements

### DIFF
--- a/intelmq/bots/inputs/arbor/harmonizer.py
+++ b/intelmq/bots/inputs/arbor/harmonizer.py
@@ -11,7 +11,7 @@ class ArborHarmonizerBot(Bot):
             ip_value = event.value('ip')
             event.add('source_ip', ip_value)
             event.add('reported_ip', ip_value)
-            event.adds('type', 'brute-force')
+            event.add('type', 'brute-force')
             
             self.send_message(event)
         self.acknowledge_message()


### PR DESCRIPTION
If bot crash, it will print the event(message) that was processing:

```
2014-07-25 00:58:47,297 - arbor-harmonizer - INFO - Connected to pipeline queues. Start processing.
2014-07-25 00:58:47,313 - arbor-harmonizer - ERROR - Current Message(event): 'ip=201.218.70.133'
2014-07-25 00:58:47,319 - arbor-harmonizer - ERROR - Check the following exception:
Traceback (most recent call last):
  File "intelmq/lib/bot.py", line 51, in start
    self.process()
  File "/tmp/new/intelmq/intelmq/bots/inputs/arbor/harmonizer.py", line 14, in process
    event.adds('type', 'brute-force')
AttributeError: 'Event' object has no attribute 'adds'
2014-07-25 00:58:47,319 - arbor-harmonizer - ERROR - Pipeline connection failed (AttributeError("'Event' object has no attribute 'adds'",))
2014-07-25 00:58:47,320 - arbor-harmonizer - INFO - Pipeline will reconnect in 30 seconds
```
