### PR TITLE
Missing dependency "libcurl4-gnutls-dev"

### DIFF
--- a/docs/User-Guide.md
+++ b/docs/User-Guide.md
@@ -23,7 +23,7 @@ The following instructions assume:
 ### Install Dependencies
 
 ```
-apt-get install python-pip git build-essential python-dev redis-server  python-zmq
+apt-get install python-pip git build-essential python-dev redis-server python-zmq libcurl4-gnutls-dev
 ```
 
 


### PR DESCRIPTION
Just tried to install v1.0 on a clean Ubuntu Server 14.0.4 and encountered this problem - error during "pip install -r REQUIREMENTS" telling me "please install the libcurl development files"
-> added "libcurl4-gnutls-dev" to the dependencies as this resolved the problem with REQUIREMENTS to me