### PR TITLE
Sets default loglevel to INFO in beta

### DIFF
--- a/intelmq/conf/system.conf
+++ b/intelmq/conf/system.conf
@@ -1,5 +1,5 @@
 {
-  "logging_level": "DEBUG",
+  "logging_level": "INFO",
   "logging_path": "/opt/intelmq/var/log/",
   "http_proxy": null,
   "https_proxy": null


### PR DESCRIPTION
This PR sets the default loglevel to debug in beta,
it wasn't tested as it looked trivial.