### PR TITLE
Fix set default loglevel to INFO in conf/system.conf

### DIFF
--- a/intelmq/conf/system.conf
+++ b/intelmq/conf/system.conf
@@ -1,5 +1,5 @@
 {
-  "logging_level": "DEBUG",
+  "logging_level": "INFO",
   "logging_path": "/opt/intelmq/var/log/",
   "http_proxy": null,
   "https_proxy": null


### PR DESCRIPTION
Sets as #237 does the default loglevel in conf/system.conf to 
INFO as it was criticized by @aaronkaplan in #210 but for the master branch.