### PR TITLE
ASN lookup discarding events

### DIFF
--- a/intelmq/bots/BOTS
+++ b/intelmq/bots/BOTS
@@ -2,7 +2,7 @@
     "Collector": {
         "DShield AS": {
             "description": "DShield AS Collector is the bot responsible to get the report from source of information.", 
-            "module": "intelmq.bots.collector.url.collector", 
+            "module": "intelmq.bots.collectors.http.collector_http", 
             "parameters": {
                 "feed": "DShield", 
                 "url": "http://dshield.org/asdetailsascii.html?as=<AS Number>", 
@@ -11,7 +11,7 @@
         }, 
         "DShield Block": {
             "description": "DShield Block Collector is the bot responsible to get the report from source of information.", 
-            "module": "intelmq.bots.collector.url.collector", 
+            "module": "intelmq.bots.collectors.http.collector_http", 
             "parameters": {
                 "feed": "DShield", 
                 "url": "https://www.dshield.org/block.txt", 
@@ -20,7 +20,7 @@
         }, 
         "DShield Suspicious Domains": {
             "description": "DShield Suspicious Domains Collector is the bot responsible to get the report from source of information.", 
-            "module": "intelmq.bots.collector.url.collector", 
+            "module": "intelmq.bots.collectors.http.collector_http", 
             "parameters": {
                 "feed": "DShield", 
                 "url": "https://www.dshield.org/feeds/suspiciousdomains_High.txt", 

--- a/intelmq/bots/experts/asn_lookup/expert.py
+++ b/intelmq/bots/experts/asn_lookup/expert.py
@@ -34,7 +34,7 @@ class ASNLookupExpertBot(Bot):
                 if info[1]:
                     event.add(bgp_key, unicode(info[1]), sanitize=True, force=True)
 
-            self.send_message(event)
+        self.send_message(event)
         self.acknowledge_message()
 
 


### PR DESCRIPTION
An event without source.ip or destination.ip can't go through asn_lookup expert and is just discarded.