### PR TITLE
Intelmqctl

### DIFF
--- a/intelmq/bin/intelmqctl
+++ b/intelmq/bin/intelmqctl
@@ -161,24 +161,25 @@ class IntelMQContoller():
 
         parser.add_argument('-v', '--version',
                             action='version', version=VERSION)
-        parser.add_argument("--id", dest='bot_id', default=None, help='bot ID')
+        parser.add_argument('--id', '-i',
+                            dest='bot_id', default=None, help='bot ID')
         parser.add_argument('--type', choices=RETURN_TYPES,
                             default=RETURN_TYPES[0],
                             help='choose if it should return regular text or '
                                  'other forms of output')
 
-        group_list.add_argument('--log',
+        group_list.add_argument('--log', '-l',
                                 metavar='[log-level]:[number-of-lines]',
                                 default=None)
-        group_list.add_argument('--bot',
+        group_list.add_argument('--bot', '-b',
                                 choices=['start', 'stop', 'restart', 'status'],
                                 metavar='[start|stop|restart|status]',
                                 default=None)
-        group_list.add_argument('--botnet',
+        group_list.add_argument('--botnet', '-n',
                                 choices=['start', 'stop', 'restart', 'status'],
                                 metavar='[start|stop|restart|status]',
                                 default=None)
-        group_list.add_argument('--list',
+        group_list.add_argument('--list', '-s',
                                 choices=['bots', 'queues'],
                                 metavar='[bots|queues]',
                                 default=None)

--- a/intelmq/bin/intelmqctl
+++ b/intelmq/bin/intelmqctl
@@ -48,7 +48,6 @@ ERROR_MESSAGES = {
 }
 
 LOG_LEVEL = {
-    'default': -1,
     'DEBUG': 0,
     'INFO': 1,
     'ERROR': 2,
@@ -83,6 +82,17 @@ def log_botnet_error(status):
 def log_botnet_message(status):
     if RETURN_TYPE == 'text':
         print(MESSAGES[status].format('Botnet'))
+
+
+def log_log_messages(messages):
+    if RETURN_TYPE == 'text':
+        for message in messages:
+            print(' - '.join([message['date'], message['bot_id'],
+                              message['log_level'], message['message']]))
+            try:
+                print(message['extended_message'])
+            except KeyError:
+                pass
 
 
 def write_pidfile(bot_id, pid):
@@ -170,7 +180,15 @@ class IntelMQContoller():
 
         group_list.add_argument('--log', '-l',
                                 metavar='[log-level]:[number-of-lines]',
-                                default=None)
+                                default=None,
+                                help='''Reads the last lines from bot log, or
+                                from system log if no bot ID was given.
+                                Log level should be one of DEBUG, INFO, ERROR
+                                or CRTICAL. Default is INFO
+                                Number of lines defaults to 10.
+
+                                Reading from system log is not implemented yet.
+                                ''')
         group_list.add_argument('--bot', '-b',
                                 choices=['start', 'stop', 'restart', 'status'],
                                 metavar='[start|stop|restart|status]',
@@ -403,10 +421,23 @@ class IntelMQContoller():
         split_log_level = log_level.split(':')
 
         if len(split_log_level) != 2:
-            return
-
-        number_of_lines = int(split_log_level[1])
-        log_level = LOG_LEVEL[split_log_level[0]]
+            print("Invalid parameter for log, defaulting to 'INFO:10'")
+            number_of_lines = 10
+            log_level = LOG_LEVEL['INFO']
+        else:
+            try:
+                number_of_lines = int(split_log_level[1])
+            except ValueError:
+                number_of_lines = 10
+            if not len(split_log_level[0]):
+                log_level = LOG_LEVEL['INFO']
+            else:
+                try:
+                    log_level = LOG_LEVEL[split_log_level[0].upper()]
+                except KeyError:
+                    print("Invalid log_level. Must be one of {}"
+                          "".format(', '.join(LOG_LEVEL.iterkeys())))
+                    return[]
 
         if bot_id is None:
             return self.read_system_log(log_level, number_of_lines)
@@ -417,55 +448,46 @@ class IntelMQContoller():
         raise NotImplementedError
 
     def read_bot_log(self, bot_id, log_level, number_of_lines):
-        basepath = self.system['logging_path']
-        if not self.system['logging_path'].endswith('/'):
-            basepath += '/'
-
-        bot_log_path = basepath + bot_id + '.log'
-
+        bot_log_path = os.path.join(self.system['logging_path'],
+                                    bot_id + '.log')
         if not os.path.isfile(bot_log_path):
+            print("Log path not found: {}".format(bot_log_path))
             return []
 
-        with open(bot_log_path, 'r') as bot_log_file:
-            messages = list()
+        messages = list()
 
-            extended_message = ''
-            last_message = {}
-            added_messages = 0
-            line_number = 0
+        message_overflow = ''
+        message_count = 0
 
-            for line in bot_log_file:
-                line_number += 1
-                splitted_line = line.split(' - ')
+        for line in utils.reverse_readline(bot_log_path):
+            splitted_line = line.split(' - ', 3)
 
-                if len(splitted_line) >= 4:
-                    if splitted_line[1] == bot_id:
-                        log_message = {
-                            'line_number': line_number,
-                            'date': splitted_line[0],
-                            'bot_id': splitted_line[1],
-                            'log_level': splitted_line[2],
-                            'message': ' - '.join(splitted_line[3:])
-                        }
+            if (len(splitted_line) < 4 or splitted_line[1] != bot_id or
+               splitted_line[2] not in LOG_LEVEL):
+                message_overflow = '\n'.join([line, message_overflow])
+                continue
+            if LOG_LEVEL[splitted_line[2]] < log_level:
+                continue
 
-                        if extended_message != '':
-                            last_message['extended_message'] = extended_message
-                            extended_message = ''
+            log_message = {
+                'date': splitted_line[0],
+                'bot_id': splitted_line[1],
+                'log_level': splitted_line[2],
+                'message': ' - '.join(splitted_line[3:])
+            }
 
-                        last_message = log_message
+            if message_overflow:
+                log_message['extended_message'] = message_overflow
+                message_overflow = ''
 
-                        if (log_message['log_level'] not in LOG_LEVEL) or (LOG_LEVEL[log_message['log_level']] >= log_level):
-                            added_messages += 1
-                            messages.append(log_message)
+            message_count += 1
+            messages.append(log_message)
 
-                            if added_messages > number_of_lines:
-                                del messages[0]
-                    else:
-                        extended_message += line
-                else:
-                    extended_message += line
+            if message_count >= number_of_lines:
+                break
 
-        return messages
+        log_log_messages(messages[::-1])
+        return messages[::-1]
 
 
 if __name__ == "__main__":

--- a/intelmq/bin/intelmqctl
+++ b/intelmq/bin/intelmqctl
@@ -413,7 +413,7 @@ class IntelMQContoller():
             return self.read_bot_log(bot_id, log_level, number_of_lines)
 
     def read_system_log(self, log_level, number_of_lines):
-        pass
+        raise NotImplementedError
 
     def read_bot_log(self, bot_id, log_level, number_of_lines):
         basepath = self.system['logging_path']

--- a/intelmq/bin/intelmqctl
+++ b/intelmq/bin/intelmqctl
@@ -180,7 +180,7 @@ class IntelMQContoller():
                             action='version', version=VERSION)
         parser.add_argument('--id', '-i',
                             dest='bot_id', default=None, help='bot ID')
-        parser.add_argument('--type', choices=RETURN_TYPES,
+        parser.add_argument('--type', '-t', choices=RETURN_TYPES,
                             default=RETURN_TYPES[0],
                             help='choose if it should return regular text or '
                                  'other forms of output')

--- a/intelmq/bin/intelmqctl
+++ b/intelmq/bin/intelmqctl
@@ -192,8 +192,8 @@ class IntelMQContoller():
                                 help='''Reads the last lines from bot log, or
                                 from system log if no bot ID was given.
                                 Log level should be one of DEBUG, INFO, ERROR
-                                or CRTICAL. Default is INFO
-                                Number of lines defaults to 10.
+                                or CRTICAL. Default is INFO.
+                                Number of lines defaults to 10, -1 gives all.
 
                                 Reading from system log is not implemented yet.
                                 ''')
@@ -480,7 +480,7 @@ class IntelMQContoller():
             return self.read_bot_log(bot_id, log_level, number_of_lines)
 
     def read_system_log(self, log_level, number_of_lines):
-        raise NotImplementedError
+        logger.error("Reading from system log is not implemented yet")
 
     def read_bot_log(self, bot_id, log_level, number_of_lines):
         bot_log_path = os.path.join(self.system['logging_path'],
@@ -518,7 +518,7 @@ class IntelMQContoller():
             message_count += 1
             messages.append(log_message)
 
-            if message_count >= number_of_lines:
+            if message_count >= number_of_lines and number_of_lines != -1:
                 break
 
         log_log_messages(messages[::-1])

--- a/intelmq/bin/intelmqctl
+++ b/intelmq/bin/intelmqctl
@@ -9,12 +9,12 @@ import inspect
 import psutil
 import signal
 import argparse
-from intelmq.lib.pipeline import PipelineFactory, Redis
+from intelmq.lib.pipeline import PipelineFactory
 from intelmq import DEFAULTS_CONF_FILE
-from intelmq import STARTUP_CONF_FILE
 from intelmq import PIPELINE_CONF_FILE
-from intelmq import SYSTEM_CONF_FILE
 from intelmq import RUNTIME_CONF_FILE
+from intelmq import STARTUP_CONF_FILE
+from intelmq import SYSTEM_CONF_FILE
 from intelmq import DEFAULT_LOGGING_PATH
 from intelmq.lib import utils
 
@@ -230,19 +230,18 @@ class IntelMQContoller():
         self.parameters = Parameters()
         self.load_system_configuration()
         self.load_defaults_configuration()
+        self.pipepline_configuration = utils.load_configuration(PIPELINE_CONF_FILE)
+        self.runtime_configuration = utils.load_configuration(RUNTIME_CONF_FILE)
+        self.startup_configuration = utils.load_configuration(STARTUP_CONF_FILE)
 
     def load_system_configuration(self):
-
         config = utils.load_configuration(SYSTEM_CONF_FILE)
         for option, value in config.iteritems():
             setattr(self.parameters, option, value)
 
     def load_defaults_configuration(self):
-
         # Load defaults configuration section
-
         config = utils.load_configuration(DEFAULTS_CONF_FILE)
-
         for option, value in config.iteritems():
             setattr(self.parameters, option, value)
 
@@ -380,14 +379,10 @@ class IntelMQContoller():
                 for bot_id in sorted(self.startup.keys())]
 
     def list_queues(self):
-        with open(PIPELINE_CONF_FILE, 'r') as fp:
-            conf = json.load(fp)
-            fp.close()
-
         source_queues = set()
         destination_queues = set()
 
-        for key, value in conf.iteritems():
+        for key, value in self.pipepline_configuration.iteritems():
             if 'source-queue' in value:
                 source_queues.add(value['source-queue'])
             if 'destination-queues' in value:
@@ -402,7 +397,7 @@ class IntelMQContoller():
         log_list_queues(counters)
 
         return_dict = dict()
-        for bot_id, info in conf.iteritems():
+        for bot_id, info in self.pipepline_configuration.iteritems():
             return_dict[bot_id] = dict()
 
             if 'source-queue' in info:

--- a/intelmq/bin/intelmqctl
+++ b/intelmq/bin/intelmqctl
@@ -15,6 +15,7 @@ from intelmq import STARTUP_CONF_FILE
 from intelmq import PIPELINE_CONF_FILE
 from intelmq import SYSTEM_CONF_FILE
 from intelmq import RUNTIME_CONF_FILE
+from intelmq import DEFAULT_LOGGING_PATH
 from intelmq.lib import utils
 
 
@@ -33,7 +34,7 @@ STATUSES = {
 
 MESSAGES = {
     'starting': 'Starting {}...',
-    'running': '{} is already running.',
+    'running': '{} is running.',
     'stopped': '{} is stopped.',
     'stopping': 'Stopping {}...',
 }
@@ -58,39 +59,39 @@ RETURN_TYPES = ['text', 'json']
 RETURN_TYPE = None
 
 
-def log_list_queus(queues):
+def log_list_queues(queues):
     if RETURN_TYPE == 'text':
         for queue, counter in sorted(queues.iteritems()):
-            print("{} - {}".format(queue, counter))
+            logger.info("{} - {}".format(queue, counter))
 
 
 def log_bot_error(status, *args):
     if RETURN_TYPE == 'text':
-        print(ERROR_MESSAGES[status].format(*args))
+        logger.error(ERROR_MESSAGES[status].format(*args))
 
 
 def log_bot_message(status, *args):
     if RETURN_TYPE == 'text':
-        print(MESSAGES[status].format(*args))
+        logger.info(MESSAGES[status].format(*args))
 
 
 def log_botnet_error(status):
     if RETURN_TYPE == 'text':
-        print(ERROR_MESSAGES[status].format('Botnet'))
+        logger.error(ERROR_MESSAGES[status].format('Botnet'))
 
 
 def log_botnet_message(status):
     if RETURN_TYPE == 'text':
-        print(MESSAGES[status].format('Botnet'))
+        logger.info(MESSAGES[status].format('Botnet'))
 
 
 def log_log_messages(messages):
     if RETURN_TYPE == 'text':
         for message in messages:
-            print(' - '.join([message['date'], message['bot_id'],
-                              message['log_level'], message['message']]))
+            logger.info(' - '.join([message['date'], message['bot_id'],
+                                    message['log_level'], message['message']]))
             try:
-                print(message['extended_message'])
+                logger.info(message['extended_message'])
             except KeyError:
                 pass
 
@@ -151,10 +152,16 @@ class IntelMQContoller():
 
     def __init__(self):
         global RETURN_TYPE
+        global logger
+        logger = utils.log(DEFAULT_LOGGING_PATH, 'intelmqctl', 'DEBUG')
+        self.logger = logger
 
         APPNAME = "intelmqctl"
         VERSION = "0.0.0"
-        DESCRIPTION = "description: intelmqctl is the tool to control intelmq system"
+        DESCRIPTION = """
+        description: intelmqctl is the tool to control intelmq system.
+
+        Outputs are logged to /opt/intelmq/var/log/intelmqctl"""
         USAGE = '''
         intelmqctl --bot [start|stop|restart|status] --id=cymru-expert
         intelmqctl --botnet [start|stop|restart|status]
@@ -308,6 +315,7 @@ class IntelMQContoller():
         if status_process(pid):
             log_bot_error('running', bot_id)
             return 'running'
+        log_bot_message('stopped', bot_id)
         return 'stopped'
 
     def __bot_stop(self, bot_id, pid):
@@ -353,7 +361,7 @@ class IntelMQContoller():
         log_botnet_message('starting')
         for bot_id in sorted(self.startup.keys()):
             botnet_status[bot_id] += tuple(self.bot_start(bot_id))
-        log_botnet_message('started')
+        log_botnet_message('running')
         return botnet_status
 
     def botnet_status(self):
@@ -363,22 +371,15 @@ class IntelMQContoller():
         return botnet_status
 
     def list_bots(self):
-        title = "\n\nList of Bots:\n"
-        title += "-" * (len(title) - 1)
-        title += "\n"
-        print(title)
+        print("List of Bots:\n-------------")
         for bot_id in sorted(self.startup.keys()):
-            print("Bot ID: {}\nDescription: {}\n".format(bot_id,
-                                         self.startup[bot_id]['description']))
+            print("\nBot ID: {}\nDescription: {}"
+                  "".format(bot_id, self.startup[bot_id]['description']))
+        return [{'id': bot_id,
+                 'description': self.startup[bot_id]['description']}
+                for bot_id in sorted(self.startup.keys())]
 
     def list_queues(self):
-        with open(DEFAULTS_CONF_FILE, 'r') as fp:
-            conf = json.load(fp)
-            #pipeline_host = conf[""]
-            # pipeline_port =
-            # pipeline_db =
-            fp.close()
-
         with open(PIPELINE_CONF_FILE, 'r') as fp:
             conf = json.load(fp)
             fp.close()
@@ -398,7 +399,7 @@ class IntelMQContoller():
 
         queues = source_queues.union(destination_queues)
         counters = pipeline.count_queued_messages(queues)
-        log_list_queus(counters)
+        log_list_queues(counters)
 
         return_dict = dict()
         for bot_id, info in conf.iteritems():
@@ -421,7 +422,7 @@ class IntelMQContoller():
         split_log_level = log_level.split(':')
 
         if len(split_log_level) != 2:
-            print("Invalid parameter for log, defaulting to 'INFO:10'")
+            logger.error("Invalid parameter for log, defaulting to 'INFO:10'")
             number_of_lines = 10
             log_level = LOG_LEVEL['INFO']
         else:
@@ -435,8 +436,8 @@ class IntelMQContoller():
                 try:
                     log_level = LOG_LEVEL[split_log_level[0].upper()]
                 except KeyError:
-                    print("Invalid log_level. Must be one of {}"
-                          "".format(', '.join(LOG_LEVEL.iterkeys())))
+                    logger.error("Invalid log_level. Must be one of {}"
+                                 "".format(', '.join(LOG_LEVEL.iterkeys())))
                     return[]
 
         if bot_id is None:
@@ -451,7 +452,7 @@ class IntelMQContoller():
         bot_log_path = os.path.join(self.system['logging_path'],
                                     bot_id + '.log')
         if not os.path.isfile(bot_log_path):
-            print("Log path not found: {}".format(bot_log_path))
+            logger.error("Log path not found: {}".format(bot_log_path))
             return []
 
         messages = list()

--- a/intelmq/bin/intelmqctl
+++ b/intelmq/bin/intelmqctl
@@ -8,6 +8,7 @@ import shlex
 import inspect
 import psutil
 import signal
+import traceback
 import argparse
 from intelmq.lib.pipeline import PipelineFactory
 from intelmq import DEFAULTS_CONF_FILE
@@ -208,6 +209,8 @@ class IntelMQContoller():
                                 choices=['bots', 'queues'],
                                 metavar='[bots|queues]',
                                 default=None)
+        group_list.add_argument('--clear', '-c', metavar='queue', default=None,
+                                help='''Clears the given queue in broker''')
 
         self.args = parser.parse_args()
 
@@ -228,8 +231,8 @@ class IntelMQContoller():
         # stolen functions from the bot file
         # this will not work with various instances of REDIS
         self.parameters = Parameters()
-        self.load_system_configuration()
         self.load_defaults_configuration()
+        self.load_system_configuration()
         self.pipepline_configuration = utils.load_configuration(PIPELINE_CONF_FILE)
         self.runtime_configuration = utils.load_configuration(RUNTIME_CONF_FILE)
         self.startup_configuration = utils.load_configuration(STARTUP_CONF_FILE)
@@ -270,6 +273,9 @@ class IntelMQContoller():
 
         elif self.args.log:
             results = self.read_log(self.args.log, self.args.bot_id)
+
+        elif self.args.clear:
+            results = self.clear_queue(self.args.clear,)
 
         if self.args.type == 'json':
             print(json.dumps(results))
@@ -411,6 +417,39 @@ class IntelMQContoller():
                         (dest_queue, counters[dest_queue]))
 
         return return_dict
+
+    def clear_queue(self, queue):
+        """
+        Clears an exiting queue.
+
+        First checks if the queue does exist in the pipeline configuration.
+        """
+        logger.info("Clearing queue {}".format(queue))
+        source_queues = set()
+        destination_queues = set()
+        for key, value in self.pipepline_configuration.iteritems():
+            if 'source-queue' in value:
+                source_queues.add(value['source-queue'])
+            if 'destination-queues' in value:
+                destination_queues.update(value['destination-queues'])
+
+        pipeline = PipelineFactory.create(self.parameters)
+        pipeline.set_queues(source_queues, "source")
+        pipeline.connect()
+
+        queues = source_queues.union(destination_queues)
+        if queue not in queues:
+            logger.error("Queue {} does not exist!".format(queue))
+            return 'not-found'
+
+        try:
+            pipeline.clear_queue(queue)
+            logger.info("Successfully cleared queue {}".format(queue))
+            return 'success'
+        except Exception:
+            logger.error("Error while clearing queue {}:\n{}"
+                         "".format(queue, traceback.format_exc()))
+            return 'error'
 
     def read_log(self, log_level, bot_id):
         # TODO: Parse number of lines

--- a/intelmq/bin/intelmqctl
+++ b/intelmq/bin/intelmqctl
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from __future__ import print_function
 import os
 import sys
 import json
@@ -61,27 +62,27 @@ RETURN_TYPE = None
 def log_list_queus(queues):
     if RETURN_TYPE == 'text':
         for queue, counter in sorted(queues.iteritems()):
-            print "{} - {}".format(queue, counter)
+            print("{} - {}".format(queue, counter))
 
 
 def log_bot_error(status, *args):
     if RETURN_TYPE == 'text':
-        print ERROR_MESSAGES[status].format(*args)
+        print(ERROR_MESSAGES[status].format(*args))
 
 
 def log_bot_message(status, *args):
     if RETURN_TYPE == 'text':
-        print MESSAGES[status].format(*args)
+        print(MESSAGES[status].format(*args))
 
 
 def log_botnet_error(status):
     if RETURN_TYPE == 'text':
-        print ERROR_MESSAGES[status].format('Botnet')
+        print(ERROR_MESSAGES[status].format('Botnet'))
 
 
 def log_botnet_message(status):
     if RETURN_TYPE == 'text':
-        print MESSAGES[status].format('Botnet')
+        print(MESSAGES[status].format('Botnet'))
 
 
 def write_pidfile(bot_id, pid):
@@ -246,7 +247,7 @@ class IntelMQContoller():
             results = self.read_log(self.args.log, self.args.bot_id)
 
         if self.args.type == 'json':
-            print json.dumps(results)
+            print(json.dumps(results))
 
     def bot_start(self, bot_id):
         if bot_id is None:
@@ -346,10 +347,10 @@ class IntelMQContoller():
         title = "\n\nList of Bots:\n"
         title += "-" * (len(title) - 1)
         title += "\n"
-        print title
+        print(title)
         for bot_id in sorted(self.startup.keys()):
-            print "Bot ID: {}\nDescription: {}\n".format(bot_id,
-                                        self.startup[bot_id]['description'])
+            print("Bot ID: {}\nDescription: {}\n".format(bot_id,
+                                         self.startup[bot_id]['description']))
 
     def list_queues(self):
         with open(DEFAULTS_CONF_FILE, 'r') as fp:

--- a/intelmq/lib/utils.py
+++ b/intelmq/lib/utils.py
@@ -1,6 +1,7 @@
 import logging
 import json
 import base64
+import os
 
 
 def decode(text, encodings=["utf-8"], force=False):
@@ -12,7 +13,7 @@ def decode(text, encodings=["utf-8"], force=False):
             return text.decode(encoding)
         except ValueError as e:
             pass
-        
+
     if force:
         for encoding in encodings:
             try:
@@ -28,7 +29,7 @@ def encode(text, encodings=["utf-8"], force=False):
             return text.encode(encoding)
         except ValueError as e:
             pass
-        
+
     if force:
         for encoding in encodings:
             try:
@@ -54,12 +55,44 @@ def load_configuration(configuration_filepath):
 def log(logs_path, name, loglevel="DEBUG"):
     logger = logging.getLogger(name)
     logger.setLevel(loglevel)
-    
+
     handler = logging.FileHandler("%s/%s.log" % (logs_path, name))
     handler.setLevel(loglevel)
-    
+
     formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
     handler.setFormatter(formatter)
-    
-    logger.addHandler(handler)    
+
+    logger.addHandler(handler)
     return logger
+
+
+def reverse_readline(filename, buf_size=8192):
+    """a generator that returns the lines of a file in reverse order
+    http://stackoverflow.com/a/23646049/2851664"""
+    with open(filename) as fh:
+        segment = None
+        offset = 0
+        fh.seek(0, os.SEEK_END)
+        total_size = remaining_size = fh.tell()
+        while remaining_size > 0:
+            offset = min(total_size, offset + buf_size)
+            fh.seek(-offset, os.SEEK_END)
+            buffer = fh.read(min(remaining_size, buf_size))
+            remaining_size -= buf_size
+            lines = buffer.split('\n')
+            # the first line of the buffer is probably not a complete line so
+            # we'll save it and append it to the last line of the next buffer
+            # we read
+            if segment is not None:
+                # if the previous chunk starts right from the beginning of line
+                # do not concact the segment to the last line of new chunk
+                # instead, yield the segment first
+                if buffer[-1] is not '\n':
+                    lines[-1] += segment
+                else:
+                    yield segment
+            segment = lines[0]
+            for index in range(len(lines) - 1, 0, -1):
+                if len(lines[index]):
+                    yield lines[index]
+        yield segment

--- a/intelmq/lib/utils.py
+++ b/intelmq/lib/utils.py
@@ -2,6 +2,7 @@ import logging
 import json
 import base64
 import os
+import sys
 
 
 def decode(text, encodings=["utf-8"], force=False):
@@ -52,6 +53,7 @@ def load_configuration(configuration_filepath):
         config = json.loads(fpconfig.read())
     return config
 
+
 def log(logs_path, name, loglevel="DEBUG"):
     logger = logging.getLogger(name)
     logger.setLevel(loglevel)
@@ -59,8 +61,15 @@ def log(logs_path, name, loglevel="DEBUG"):
     handler = logging.FileHandler("%s/%s.log" % (logs_path, name))
     handler.setLevel(loglevel)
 
-    formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+    formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - '
+                                  '%(message)s')
     handler.setFormatter(formatter)
+
+    console_formatter = logging.Formatter("%(name)s: %(message)s")
+    console_handler = logging.StreamHandler()
+    console_handler.setFormatter(console_formatter)
+    logger.addHandler(console_handler)
+    console_handler.setLevel(loglevel)
 
     logger.addHandler(handler)
     return logger


### PR DESCRIPTION
* ENH: intelmqctl uses print_function
* BUG: intelmqctl silently exits in undefined function
* ENH: intelmqctl command line argument shorthands
* ENH: intelmqctl log parsing/reading simplified

  The logs are read and parsed backwards, which is more efficient than reading and parsing the entire file from the beginning
The code to read the file is easier to read and understand now, however some code in utils reads the file backwards in chunks.
This change is currently not compatible with intelmq-manager as it wants to read the line number which is not read anymore as its not possible to get it by reading the file backwards. Yet a line number does not make sense in log files.

See certtools/intelmq-manager#53
* ENH: intelmqctl logs to file and add stream logger

  intelmqctl has a log file as requested in certtools/intelmq#218 (partial fix)
To achieve this, the logger got extended by a stream handler aside the existing file handler. This helps debugging bots as running them solely on the console, directly gives the log output in stderr (default of StreamHandler)

* ENH: `intelmqctl --type` alias `-t`
* ENH: read all configs using utils, fixes certtools/intelmq#257
* ENH: `intelmqctl --clear` queue added, fixes #244 
* BUG: intelmqctl Give all lines for -1