### PR TITLE
docs: User and Dev guide updates, generate time.observation in collectors

### DIFF
--- a/docs/Data-Harmonization.md
+++ b/docs/Data-Harmonization.md
@@ -12,8 +12,12 @@
 
 ## Overview
 
-The purpose of this document is to list and clearly define known **fields** in Abushelper as well as Intelmq or similar systems. A field is a ```key=value``` pair. For a clear and unique definition of a field, we must define the **key** (field-name) as well as the possible **values**. A field belongs to an **event**. An event is basically a  structured log record in the form ```key=value, key=value, key=value, …```. In the [List of known fields](#fields), each field is grouped by a **section**. We describe these sections briefly below. 
+The purpose of this document is to list and clearly define known **fields** in Abusehelper as well as Intelmq or similar systems. A field is a ```key=value``` pair. For a clear and unique definition of a field, we must define the **key** (field-name) as well as the possible **values**. A field belongs to an **event**. An event is basically a  structured log record in the form ```key=value, key=value, key=value, …```. In the [List of known fields](#fields), each field is grouped by a **section**. We describe these sections briefly below.
 Every event **MUST** contain a timestamp field.
+
+## Rules for keys
+
+The keys can be grouped together in sub-fields, e.g. `source.ip` or `source.geolocation.latitude`. Thus, keys must match `[a-z_.]`.
 
 ## EBNF
 To grasp the concept of fields, events, keys, values, etc. the following [EBNF](https://en.wikipedia.org/wiki/Extended_Backus%E2%80%93Naur_Form) description might help. _Do not take this as a literal instruction for implementations_. The formatting of events and fields (and how fields are separated from each other) might vary depending on the encapsulating format (JSON, CSV , etc.) . This EBNF description is here to illustrate how these concepts work together (and are not complete):
@@ -68,16 +72,16 @@ StringLiteral
 
 As stated above, every field is organised under some section. The following is a description of the sections and what they imply.
 
-#### Feed
+### Feed
 
 Fields listed under this grouping list details about the source feed where information came from.
 
-#### Time
+### Time
 
 The time section lists all fields related to time information.
 This document requires that all the timestamps MUST be normalized to UTC. If the source reports only a date, do not attempt to invent timestamps.
 
-#### Source Identity
+### Source Identity
 
 This section lists all fields related to identification of the source. **XXX FIXME: not clear!! XXX**
 The abuse type of an event defines the way these events needs to be interpreted. For example, for a botnet drone they refer to the compromised machine, whereas for a command and control server they refer the server itself.
@@ -90,9 +94,9 @@ We recognize that ip geolocation is not an exact science and analysis of the abu
 
 Some sources report an internal (NATed) IP address.
 
-#### Destination Identity
+### Destination Identity
 
-The abuse type of an event defines the way these IOCs needs to be interpreted. For a botnet drone they refer to the compromized machine, whereas for a command and control server they refer the server itself.
+The abuse type of an event defines the way these IOCs needs to be interpreted. For a botnet drone they refer to the compromised machine, whereas for a command and control server they refer the server itself.
 
 #### Destination Geolocation Identity
 
@@ -102,6 +106,7 @@ We recognize that ip geolocation is not an exact science and analysis of the abu
 
 Some sources report an internal (NATed) IP address.
 
+### Reported Identity
 
 #### Reported Source Identity
 
@@ -114,19 +119,16 @@ As stated above, each abuse handling organization should define a policy, which 
 
 #### Additional Fields
 
-... text ...
+TODO: description
 
 #### Malware Elements
 
-... text ...
+TODO: description
 
 #### Artifact Elements
 
-... text ...
+TODO: description
 
-#### Extra Elements
-
-... text ...
 
 #### Specific Elements
 
@@ -147,7 +149,7 @@ Note that this section does not yet define error handling and failure mechanisms
 |Name                                | SQL Data type     | Regexp and Syntax       | Cybox Equivalent |  Comment                           |
 |:-----------------------------------|:------------------|:------------------------|:-----------------|:-----------------------------------|
 |<a name="#datatype-feed"></a>feed   |varchar(2000)      |  ```[a-zA-Z0-9_.-]+```  |                  | no characters allowed which could be interpreted as CSV separators |
-|<a name="#datatype-url"></a>url     |varchar(2000)      | a valid URL (see [RFC3987](http://tools.ietf.org/html/rfc3987) or similar). | [URI](http://cybox.mitre.org/language/version2.1/xsddocs/objects/URI_Object.html)  | It is recommended to use libaries such as [faup](https://github.com/stricaud/faup) for validation since  |
+|<a name="#datatype-url"></a>url     |varchar(2000)      | a valid URL (see [RFC3987](http://tools.ietf.org/html/rfc3987) or similar). | [URI](http://cybox.mitre.org/language/version2.1/xsddocs/objects/URI_Object.html)  | TODO: It is recommended to use libaries such as [faup](https://github.com/stricaud/faup) for validation. |
 
 
 <a name="fields"></a>

--- a/docs/Developers-Guide.md
+++ b/docs/Developers-Guide.md
@@ -200,8 +200,7 @@ self.logger.info('Bot start processing')
 self.logger.error('Pipeline failed')
 self.logger.exception('Pipeline failed')
 ```
-The `exception` method automatically appends an exception traceback. The logger instance writes to the file `/opt/intelmq/var/log/[bot-id].log` and to stderr.
-
+The `exception` method automatically appends an exception traceback. The logger instance writes by default to the file `/opt/intelmq/var/log/[bot-id].log` and to stderr.
 
 
 <a name="system-overview"></a>
@@ -230,12 +229,12 @@ In the `intelmq/lib/` directory you can find some libraries:
 
 There's a dummy bot including tests at `intelmq/tests/bots/test_dummy_bot.py`.
 
-You can always start any parser directly from command line by either invoking the script or the python module. Don't forget to give an bot id as first argument.
+You can always start any parser directly from command line by either invoking the script or the python module. Don't forget to give an bot id as first argument. Also, running bots with other users than `intelmq` will raise permission errors.
 ```bash
+sudo -i intelmq
 python -m intelmq.bots.outputs.file.output file-output
 python intelmq/bots/outputs/file/output.py file-output
 ```
-
 
 ### Template
 Please adjust the doc strings accordingly and remove the in-line comments (`#`).

--- a/docs/Developers-Guide.md
+++ b/docs/Developers-Guide.md
@@ -5,22 +5,19 @@
 3. [Bot Developer Guide](#bot-developer-guide)
 
 <a name="code-and-repository-rules"></a>
-## Code and Repository Rules
+# Development Guide
 
-This "Code and Repository Rules" section lays out the rules which developers of intelmq ahder to.
-The purpose of this section is to clearly describe common coding styles and similar 
-rules for IntelMQ.
+If you are digging into the code of IntelMQ or want to write new bots, this document should give you an overview of the system, the responsibilities and how to adapt it to your needs. Please read the [User Guide](User-Guide.md) first.
 
-### Goals
+## Goals
 
-It is important, that developers agree and stick to these meta-guidelines. We expect you to
-always try to:
+It is important, that developers agree and stick to these meta-guidelines. We expect you to always try to:
 
 * reduce the complexity of system administration
 * reduce the complexity of writing new bots for new data feeds
 * make your code easily and pleasantly readable
 * reduce the probability of events lost in all process with persistence functionality (even system crash)
-* strictly adher to the existing [Data Harmonization Ontology](Data-Harmonization.md) for key-values in events
+* strictly adhere to the existing [Data Harmonization Ontology](Data-Harmonization.md) for key-values in events
 * always use JSON format for all messages internally
 * help and support the interconnection between IntelMQ and existing tools like AbuseHelper, CIF, etc. or new tools (in other words: we will not accept data-silos!)
 * provide an easy way to store data into Log Collectors like ElasticSearch, Splunk
@@ -28,69 +25,50 @@ always try to:
 * provide easy to understand interfaces with other systems via HTTP RESTFUL API
 
 The main take away point from the list above is: things **MUST** stay __intuitive__ and __easy__.
-How do you test if things are easy? Let them new programers test-drive your features and if it is not understandable in 15 minutes, go back to the drawing board.
+How do you test if things are easy? Let them new programmers test-drive your features and if it is not understandable in 15 minutes, go back to the drawing board.
 
 Similarly, if code does not get accepted upstream by the main developers, it is usually only because of the ease-of-use argument. Do not give up , go back to the drawing board, and re-submit again.
 
-### Testing
+## Testing
 
-All changes have to be tested and new contributions like must must be accompanied by according tests. You can run the tests by changing to the directory with intelmq repository and running either `unittest` or `nosetests`:
+All changes have to be tested and new contributions must must be accompanied by according tests. You can run the tests by changing to the directory with intelmq repository and running either `unittest` or `nosetests`:
 
     cd intelmq
-    python -m unittest discover
-    nosetests
+    python -m unittest [discover|filename]  # or
+    nosetests [filename]
 
-It may be necessary to switch the user to `intelmq` if the run-path (`/opt/intelmq/var/run/`) is not writeable by the current user.
+It may be necessary to switch the user to `intelmq` if the run-path (`/opt/intelmq/var/run/`) is not writeable by the current user. Some bots need local databases to succeed. If you don't mind about those and only want to test one explicit test file, you can give the filepath as argument.
 
-### Coding-Rules
+## Coding-Rules
 
-In general, we follow the [Style Guide for Python Code](https://www.python.org/dev/peps/pep-0008/).
-We recommend reading it before commiting code.
+In general, we follow the [Style Guide for Python Code (PEP8)](https://www.python.org/dev/peps/pep-0008/).
+We recommend reading it before committing code.
 
-#### Identation
+### Unicode
 
-Identation of the code must done using 4 spaces for each level of identation.
+* Each internal object in IntelMQ (Event, Report, etc) that has strings, their strings MUST be in UTF-8 Unicode format.
+* Any data received from external sources MUST be transformed into UTF-8 unicode format before add it to IntelMQ objects.
 
-#### Variable Names
+Inside the pipeline it may be necessary to convert to bytes (ASCII). Conversion back to UTF-8 is automatically done when data is brought back to Python. This is the case for Redis and ZeroMQ pipeline implementations.
 
-* name of variables MUST be clear, easy to understand and reasonably short;
-* it's not allowed to use acronyms which could be mistaken for a different word.
+### Back-end independence
 
-###### Example 1
+Any component of the IntelMQ MUST be independent of the message queue technology (Redis, RabbitMQ, etc...), except `lib/pipeline.py`. Intelmq bots MAY only assume to use the class specified in `lib/pipeline.py` for inter-process or inter-bot communications.
 
-Unclear variable name:
-```
-def process_line(self, evt):
-```
-Clear variable name:
-```
-def process_line(self, event):
-```
+### Compatibility
 
-Here, event is a short name, it is clear what it means ([Data Harmonization Ontology](Data-Harmonization.md) and better than ```evt```. 
+IntelMQ core (including intelmqctl) MUST be compatible with IntelMQ Manager, IntelMQ UI and IntelMQ Mailer.
 
-###### Example 2
 
-Unclear variable name:
-```
-n_evt = evt.deep_copy()
-```
-Clear variable name:
-```
-local_event = event.deep_copy()
-```
-
-**Reference:** [Style Guide for Python Code](https://www.python.org/dev/peps/pep-0008/)
-
-#### Event Harmonization
+## Event Harmonization
 
 Any component of IntelMQ MUST respect the "Data Harmonization Ontology".
 
 **Reference:** IntelMQ Data Harmonization - [Data Harmonization Ontology](Data-Harmonization.md)
 
 
-#### Directory layout in the repository
-```
+## Directory layout in the repository
+```bash
 intelmq\
   bin\
     intelmqctl
@@ -120,7 +98,8 @@ intelmq\
     startup.conf
     system.conf
 ```
-Note: assuming you want to create a bot for 'Abuse.ch Zeus' feed . But it turns out that here it is necessary to create different parsers for the respective kind of events (C&C, Binaries, Dropzones). Therefore, the hierarchy ‘intelmq\bots\parser\abusech\parser.py’ would not be suitable because it is necessary to have more parsers, as mentioned above. The solution is to use the same hierarchy with an additional "description" in the file name, separated by underscore. For better understanding, see the topic "Directories and Files Harmonization" on this page. 
+
+Assuming you want to create a bot for 'Abuse.ch Zeus' feed. It turns out that here it is necessary to create different parsers for the respective kind of events (C&C, Binaries, Dropzones). Therefore, the hierarchy ‘intelmq\bots\parser\abusech\parser.py’ would not be suitable because it is necessary to have more parsers, as mentioned above. The solution is to use the same hierarchy with an additional "description" in the file name, separated by underscore. Also see the section *Directories and Files naming*.
 
 Example:
 ```
@@ -130,7 +109,7 @@ Example:
 ```
 
 
-#### Directories Hierarchy on Default Installation
+### Directories Hierarchy on Default Installation
 
 Configuration Files Path:
 ```
@@ -142,23 +121,23 @@ PID Files Path:
 /opt/intelmq/var/run/
 ```
 
-Logs Files Path:
+Logs Files and dumps Path:
 ```
 /opt/intelmq/var/log/
-````
-
-Additional Bot Files Path:
 ```
-/opt/intelmq/var/lib/bots/
-````
 
-#### Directories and Files Harmonization
+Additional Bot Files Path, e.g. templates or databases:
+```
+/opt/intelmq/var/lib/bots/[bot-name]/
+```
 
-Any directory and file of IntelMQ **MUST** respect the "Directories and Files Harmonization". Any file name or folder name **MUST**:
+### Directories and Files naming
+
+Any directory and file of IntelMQ has to follow the Directories and Files naming. Any file name or folder name has to
 * be represented with lowercase and in case of the name has multiple words, the spaces between them must be replaced by underscores;
-* be self explained of the folder or file content;
+* be self-explaining what the content contains.
 
-In the bot directories name, the name **MUST** correspond to the feed name. If necessary, some words can be added to give context by joining together using underscores.
+In the bot directories name, the name must correspond to the feed name. If necessary, some words can be added to give context by joining together using underscores.
 
 Example (without context words):
 ```
@@ -172,107 +151,74 @@ intelmq/bots/parser/cymru_full_bogons
 intelmq/bots/parser/taichung_city_netflow
 ```
 
+#### Class Names
 
-#### Directories and  hard-coded file paths
+Class name of the bot (ex: PhishTank Parser) must correspond to the type of the bot (ex: Parser) e.g. `PhishTankParserBot`
 
-Any directory or  hard-coded file path **MUST** correspond to the IntelMQ default directories or files, following the "Directories Hierarchy on Default Installation".
-
-Example (intelmq/lib/bot.py):
-```
-import re
-import sys
-import json
-import time
-import ConfigParser
-
-SYSTEM_CONF_FILE = "/opt/intelmq/etc/system.conf"
-PIPELINE_CONF_FILE = "/opt/intelmq/etc/pipeline.conf"
-RUNTIME_CONF_FILE = "/opt/intelmq/etc/runtime.conf"
-DEFAULT_LOGGING_PATH = "/opt/intelmq/var/log/"
-
-class Bot(object):
-
-	def __init__(self):
-		self.message_counter = 0
-		self.check_bot_id(bot_id)
-```
-
-#### Licence and Author files
+### Licence and Author files
 
 License and Authors files can be found at the root of repository.
 * License file **MUST NOT** be modified except by the explicit written permission by CNCS/CERT.PT or CERT.at
 * Credit to the authors file must be always retained. When a new contributor (person and/or organization) improves in some way the repository content (code or documentation), he or she might add his name to the list of contributors.
 
-Note: license and authors MUST be only listed in an external file but not inside the code files.
+License and authors must be only listed in an external file but not inside the code files.
 
-#### Useless Code
+## Logging
+### Log Messages Format
 
-Code that is not being use (code that are as comment) or deprecated, **MUST** be removed from the main repository in order to keep the number of lines of code (LoCs) small.
-
-#### Log Messages Format
-
-Log messages **MUST** be clear and well formatted. The format is the following:
+Log messages have to be clear and well formatted. The format is the following:
 
 Format:
 ```
-<Timestamp> - <Name of bot> - <Level> - <Log message>
+<timestamp> - <bot id> - <log level> - <log message>
 ```
 
 Rules:
 * the Log message MUST follow the common rules of a sentence, beginning with uppercase and ending with period.
 * the sentence MUST describe the problem or has useful information to give to an unexperienced user a context. Pure stack traces without any further explanation are not helpful.
 
-#### What to log?
+When the logger instance is created, the bot id must be given as parameter anyway. The function call defines the log level, see below.
+
+### Log levels
+
+* *debug*: Debugging informations includes retrieved and sent messages, detailed status information. Can include sensitive information like passwords and amount can be huge.
+* *info*: Logs include loaded databases, fetched reports or waiting messages.
+* *warning*: Unexpected, but handled behavior.
+* *error*: Errors and Exceptions.
+* *critical* Program is failing.
+
+### What to log?
+
 * Try to keep a balance between obscuring the source code file with hundreds of log messages and having too little log messages. 
 * In general, a bot MUST report error conditions.
 
-#### Unicode
+### How to log
+The Bot class creates a logger with that should be used by bots. Other components won't log anyway currently. Examples:
 
-* Each internal object in IntelMQ (Event, Report, etc) that has strings, their strings MUST be in UTF-8 unicode format.
-* Any data received from external sources MUST be transformed into UTF-8 unicode format before add it to IntelMQ objects.
-
-#### Class Names
-
-Class name of the bot (ex: PhishTank Parser) must correspond to the type of the bot (ex: Parser). Example:
-
+```python
+self.logger.info('Bot start processing')
+self.logger.error('Pipeline failed')
+self.logger.exception('Pipeline failed')
 ```
-    class ExampleParserBot(Bot):
-        ....
-        
-    if __name__ == "__main__":
-        bot = ExampleParserBot(sys.argv[1])
-        bot.start()
-```    
-
-#### Coding style
-
-Any component of IntelMQ must follow the [Style Guide for Python Code](https://www.python.org/dev/peps/pep-0008/).
-
-```
-# pip install pep8
-# pep8 --show-source <filename>.py
-```
-
-#### Back-end independence
-
-Any component of the IntelMQ MUST be independent of the message queue technology (Redis, RabbitMQ, etc...), except 'lib/pipeline.py'. Intelmq bots MAY only assume to use the class specified in 'lib/pipeline.py' for inter-process or inter-bot communications.
-
-#### Compatibility
-
-IntelMQ core (including intelmqctl) MUST be compatible with IntelMQ Manager, IntelMQ UI and IntelMQ Mailer.
-
+The `exception` method automatically appends an exception traceback. The logger instance writes to the file `/opt/intelmq/var/log/[bot-id].log` and to stderr.
 
 
 
 <a name="system-overview"></a>
 ## System Overview
 
+In the `intelmq/lib/` directory you can find some libraries:
+ * Bots: Defines base structure for bots and handling of startup, stop, messages etc.
+ * Cache: For some expert bots it does make sense to cache external lookup results. Redis is used here.
+ * Harmonization: For defined types, checks and sanitation methods are implemented.
+ * Message: Defines Events and Reports classes, uses harmonization to check validity of keys and values according to config.
+ * Pipeline: Writes messages to message queues. Implemented for productions use is only Redis. A python-only solution is used by testing. A solution using ZMQ is in development.
+ * Test: Base class for bot tests with predefined test and assert methods.
+ * Utils: Utility functions used by system components.
 
-### Main Components
-Redis is used as:
-* message queue for pipeline
-* memcache for bots
+### Pipeline
 
+  * collector bot
 
 ### Code Architecture
 
@@ -282,40 +228,136 @@ Redis is used as:
 <a name="bot-developer-guide"></a>
 ## Bot Developer Guide
 
-### Template
+There's a dummy bot including tests at `intelmq/tests/bots/test_dummy_bot.py`.
 
+You can always start any parser directly from command line by either invoking the script or the python module. Don't forget to give an bot id as first argument.
+```bash
+python -m intelmq.bots.outputs.file.output file-output
+python intelmq/bots/outputs/file/output.py file-output
 ```
-from intelmq.lib.bot import Bot, sys
-from intelmq.lib.event import Event
-from intelmq.bots import utils
 
-class ExampleBot(Bot):
 
+### Template
+Please adjust the doc strings accordingly and remove the in-line comments (`#`).
+```python
+# -*- coding: utf-8 -*-
+"""
+ExampleParserBot parses data from example.com.
+
+Document possible necessary configurations.
+"""
+from __future__ import unicode_literals
+import sys  # imports of system libraries
+
+# imports for additional libraries and intelmq
+from intelmq.lib.bot import Bot
+
+
+class ExampleParserBot(Bot):
     def process(self):
-        
-        # get message from source queue in pipeline
-        message = self.receive_message()
+        report = self.receive_message()
+        if report is None:  # Can be a None object in case the received message is empty
+            self.acknowledge_message()
+            return
 
-        # ------
-        # write the code here to process the message
-        # ------
-                
-        # send message to destination queue in pipeline
-        self.send_message(new_message)
+        event = Event()
+        ... # implement the logic here
+        event.add('additional_information', 'Nothing here')
 
-        # acknowledge message received to source queue in pipeline
+        self.send_message(event)
         self.acknowledge_message()
 
+
 if __name__ == "__main__":
-    bot = ExampleBot(sys.argv[1])
+    bot = ExampleParserBot(sys.argv[1])
     bot.start()
 ```
 
-**Examples**
+### Pipeline interactions
+
+A can call three methods related to the pipeline:
+
+  - `self.receive_message()`: The pipeline handler pops one message from the internal queue if possible. Otherwise one message from the sources list is popped, and added it to an internal queue. In case of errors in process handling, the message can still be found in the internal queue and is not lost. The bot class unravels the message a creates an instance of the Event or Report class.
+  - `self.send_message(event)`: Processed message is sent to destination queues.
+  - `self.acknowledge_message()`: Message formerly received by `receive_message` is removed from the internal queue. This should always be done after processing and after the sending of the new message. In case of errors, this function is not called and the message will stay in the internal queue waiting to be processed again.
+
+### Error handling
+
+The bot class itself has error handling implemented. The bot itself is allowed to throw exceptions and **intended to fail**! The bot should fail in case of malicious messages, and in case of unavailable but necessary resources. The bot class handles the exception and will restart until the maximum number of tries is reached and fail then. Additionally, the message in question is dumped to the file `/opt/intelmq/var/log/[bot-id].dump` and removed from the queue.
+
+### Initialization
+
+Maybe it is necessary so setup a Cache instance or load a file into memory. Use the `init` function for this purpose: 
+
+```python
+class ExampleParserBot(Bot):
+    def init(self):
+        try:
+            self.database = pyasn.pyasn(self.parameters.database)
+        except IOError:
+            self.logger.error("pyasn data file does not exist or could not be "
+                              "accessed in '%s'." % self.parameters.database)
+            self.logger.error("Read 'bots/experts/asn_lookup/README' and "
+                              "follow the procedure.")
+            self.stop()
+```
+
+### Examples
 
 * Check [Expert Bots](../intelmq/bots/experts/)
 * Check [Parser Bots](../intelmq/bots/parsers/)
 
+### Tests
+
+In order to do automated tests on the bot, it is necessary to write tests including sample data. Have a look at some existing tests:
+
+ - The DummyParserBot in `intelmq/tests/bots/test_dummy_bot.py`. This test has the example data (report and event) inside the file, defined as dictionary.
+ - The parser for malwaregroup at `intelmq/tests/bots/parsers/malwaregroup/test_parser_*.py`. The latter loads a sample HTML file from the same directory, which is the raw report.
+ - The test for ASNLookupExpertBot has two event tests, one is an expected fail (IPv6).
+
+Ideally an example contains not only the ideal case which should succeed, but also a case where should fail instead. (TODO: Implement assertEventNotEqual or assertEventNotcontainsSubset or similar)
+Most existing bots are only tested with one message. For newly written test it is appreciable to have tests including more then one message, e.g. a parser fed with an report consisting of multiple events.
+
+```python
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+import json
+import unittest
+
+import intelmq.lib.test as test
+from intelmq.bots.parsers.exampleparser.parser import ExampleParserBot  # adjust bot class name and module
+
+
+class TestExampleParserBot(test.BotTestCase, unittest.TestCase):  # adjust test class name
+    """
+    A TestCase for ExampleParserBot.
+    """
+
+    @classmethod
+    def set_bot(cls):
+        cls.bot_reference = ExampleParserBot  # adjust bot class name
+        cls.default_input_message = json.dumps(EXAMPLE_EVENT)  # adjust source of the example event
+
+	# This is an example how to test the log output
+    def test_log_test_line(self):
+        """ Test if bot does log example message. """
+        self.run_bot()
+        self.assertRegexpMatches(self.loglines_buffer,
+                                 "INFO - Lorem ipsum dolor sit amet")
+
+    def test_event(self):
+        """ Test if correct Event has been produced. """
+        self.run_bot()
+        self.assertMessageEqual(0, EXAMPLE_REPORT)
+
+
+if __name__ == '__main__':
+    unittest.main()
+```
+
+When calling the file directly, only the tests in this file for the bot will be expected. Some default tests are always executed (via the `test.BotTestCase` class), such as pipeline and message checks, logging, bot naming or empty message handling.
+
 ### Configure IntelMQ
 
-In the end, the new information about the new bot should be added to BOTS file located at intelmq/intelmq/bots on repository.
+In the end, the new information about the new bot should be added to BOTS file located at `intelmq/bots`.

--- a/docs/User-Guide.md
+++ b/docs/User-Guide.md
@@ -55,7 +55,7 @@ are *reports* consisting of many individual data sets.
 giving them a defined structure, see also [Data-Harmonization](Data-Harmonization.md).
 * *ExpertBots* enrich the existing events by e.g. reverse records, geographic location
 information or abuse contacts.
-* *OutputBots* write events to files or databases.
+* *OutputBots* write events to files, databases, (REST)-APIs, etc.
 
 Each bot has one source queue (except collectors) and can have multiple
 destination queues (except outputs). But multiple bots can write to the same
@@ -68,7 +68,7 @@ being discussed, see this issue:
 [Multiprocessing per queue is not supported #186](https://github.com/certtools/intelmq/issues/186).
 
 
-## Web interface
+## Web interface: intelmq-manager
 
 IntelMQ has a tool called IntelMQ Manager that gives to user a easy way to 
 configure all pipeline with bots that your CERT needs. It is recommended to
@@ -161,6 +161,7 @@ and `runtime.conf`. Also read by the intelmq-manager.
 To configure a new BOT, you need to define it first in `startup.conf`.
 Then do the configuration in `runtime.conf` using the bot if.
 Configure source and destination queues in `pipeline.conf`.
+Use the intelmq-manager mentioned above to generate the configuration files if unsure.
 
 ## Additional Information
 

--- a/docs/User-Guide.md
+++ b/docs/User-Guide.md
@@ -58,7 +58,8 @@ information or abuse contacts.
 * *OutputBots* write events to files or databases.
 
 Each bot has one source queue (except collectors) and can have multiple
-destination queues (except outputs).
+destination queues (except outputs). But multiple bots can write to the same
+pipeline, resulting in multiple inputs for the next bot.
 
 Every bot runs in a separate process, they are uniquely identifiable by a *bot id*.
 

--- a/docs/User-Guide.md
+++ b/docs/User-Guide.md
@@ -3,9 +3,10 @@
 1. [Requirements](#requirements)
 2. [Installation](#installation)
 3. [Management](#management)
-4. [Upgrade](#upgrade)
-5. [Uninstall](#uninstall)
-6. [Frequently Asked Questions](#faq)
+4. [Configuration](#configuration)
+5. [Upgrade](#upgrade)
+6. [Uninstall](#uninstall)
+7. [Frequently Asked Questions](#faq)
 
 
 <a name="requirements"></a>
@@ -22,14 +23,14 @@ The following instructions assume:
 
 ### Install Dependencies
 
-```
+```bash
 apt-get install python-pip git build-essential python-dev redis-server python-zmq python-pycurl libcurl4-gnutls-dev
 ```
 
 
 ### Install IntelMQ
 
-```
+```bash
 sudo su -
 
 git clone https://github.com/certtools/intelmq.git
@@ -45,27 +46,38 @@ chown -R intelmq.intelmq /opt/intelmq
 <a name="management"></a>
 # Management
 
-### How it Works
+## How it Works
+Intelmq has a modular structure consisting of bots. There are four types of bots:
 
-Before start running all bots, user should know the system details that
-will help configure and start bots.
+* *CollectorBots* retrieve data from internal or external sources, the output
+are *reports* consisting of many individual data sets.
+* *ParserBots* parse the data by splitting it into individual *events* and
+giving them a defined structure, see also [Data-Harmonization](Data-Harmonization.md).
+* *ExpertBots* enrich the existing events by e.g. reverse records, geographic location
+information or abuse contacts.
+* *OutputBots* write events to files or databases.
 
-* Each bot instance starts completely independent and MUST have a 'bot id'.
-* The 'bot id' is used to reference in '/opt/intelmq/etc/pipeline.conf',
-  '/opt/intelmq/etc/startup.conf' and '/opt/intelmq/etc/runtime.conf'
-  the specific configurations for each bot instance.
-* Global configuration for intelmq is at file '/opt/intelmq/etc/system.conf'.
-  Please note that logger in DEBUG mode will write in logs all bots
-  parameteres configured, including passwords.
+Each bot has one source queue (except collectors) and can have multiple
+destination queues (except outputs).
+
+Every bot runs in a separate process, they are uniquely identifiable by a *bot id*.
+
+Currently only one instance of one bot can be run. Concepts for Multiprocessing are
+being discussed, see this issue:
+[Multiprocessing per queue is not supported #186](https://github.com/certtools/intelmq/issues/186).
 
 
-### Web interface
+## Web interface
 
 IntelMQ has a tool called IntelMQ Manager that gives to user a easy way to 
-configure all pipeline with bots that your CERT needs. 
-Click [here](https://github.com/certtools/intelmq-manager).
+configure all pipeline with bots that your CERT needs. It is recommended to
+use the Manager to become acquainted with the functionalities and concepts.
+The intelmq-manager has all possibilities of intelmqctl and has a graphical
+interface for startup and pipeline configuration.
 
-### Command-line interface
+See [github.com/certtools/intelmq-manager](https://github.com/certtools/intelmq-manager).
+
+## Command-line interface
 
 **Syntax:**
 
@@ -81,37 +93,77 @@ usage:
 optional arguments:
   -h, --help            show this help message and exit
   -v, --version         show program's version number and exit
-  --id BOT_ID           bot ID
-  --type {text,json}    choose if it should return regular text or other forms
+  --id BOT_ID, -i BOT_ID
+                        bot ID
+  --type {text,json}, -t {text,json}
+                        choose if it should return regular text or other forms
                         of output
-  --log [log-level]:[number-of-lines]
-  --bot [start|stop|restart|status]
-  --botnet [start|stop|restart|status]
-  --list [bots|queues]
+  --log [log-level]:[number-of-lines], -l [log-level]:[number-of-lines]
+                        Reads the last lines from bot log, or from system log
+                        if no bot ID was given. Log level should be one of
+                        DEBUG, INFO, ERROR or CRTICAL. Default is INFO. Number
+                        of lines defaults to 10, -1 gives all. Reading from
+                        system log is not implemented yet.
+  --bot [start|stop|restart|status], -b [start|stop|restart|status]
+  --botnet [start|stop|restart|status], -n [start|stop|restart|status]
+  --list [bots|queues], -s [bots|queues]
+  --clear queue, -c queue
+                        Clears the given queue in broker
 
-description: intelmqctl is the tool to control intelmq system
+description: intelmqctl is the tool to control intelmq system. Outputs are
+logged to /opt/intelmq/var/log/intelmqctl
 ```
 
+### Botnet
 
-### Utilities
+The botnet represents all currently configured bots. To get an overview which
+bots are running, use `intelmqctl -n status`.
 
-#### Monitoring Logs
+## Utilities
+
+### Monitoring Logs
+
+All bots and `intelmqctl` log to `/opt/intelmq/var/log/`. In case of failures,
+messages are dumped to the same directory with file ending `.dump`.
 
 ```
-$ tail -f /opt/intelmq/var/log/*
+$ tail -f /opt/intelmq/var/log/*.log
 ```
 
-#### Reset Pipeline and Cache (be careful)
+### Reset Pipeline and Cache (be careful)
 
 ```
 $ redis-cli FLUSHDB
 $ redis-cli FLUSHALL
 ```
 
+<a name="configuration"></a>
+# Configuration
 
-### Additional Information
+By default, one collector, one parser and one output are started. The default
+collector an parser handle data from malware domain list, the file output bot
+writes all data to `/opt/intelmq/var/lib/bots/file-output/events.txt`.
 
-#### Perfomance Tests
+The configuration directory is `/opt/intelmq/etc/`, all files are JSON.
+
+* `defaults.conf`: Some default values for bots and their behavior, e.g.
+error handling, log options and pipeline configuration. Will be removed in
+[future](https://github.com/certtools/intelmq/issues/267).
+* `system.conf`: System configuration for e.g. the logger and the pipeline.
+* `startup.conf`: Maps the bot ids to python modules.
+* `runtime.conf`: Configuration for the individual bots.
+* `pipeline.conf`: Defines source and destination queues per bot.
+* `BOTS`: Includes configuration hints for all bots. E.g. feed URLs or
+database connection parameters. Use this as a template for `startup.conf`
+and `runtime.conf`. Also read by the intelmq-manager.
+
+To configure a new BOT, you need to define it first in `startup.conf`.
+Then do the configuration in `runtime.conf` using the bot if.
+Configure source and destination queues in `pipeline.conf`.
+
+## Additional Information
+
+### Perfomance Tests
 
 Somes tests have been made with a virtual machine with 
 the following specifications:
@@ -121,13 +173,13 @@ the following specifications:
 * HDD: 10GB
 
 The entire solution didnt have any problem handling 2.000.000 
-queued events in memory with bots diggesting the messages.
+queued events in memory with bots digesting the messages.
 
 
 <a name="upgrade"></a>
 # Upgrade
 
-### Stop IntelMQ and Backup
+## Stop IntelMQ and Backup
 
 * Make sure that your IntelMQ system is completely stopped.
 * Create a backup of your configurations.
@@ -141,7 +193,7 @@ cp /opt/intelmq/etc/runtime.conf /opt/intelmq/etc/runtime.conf.bk
 cp /opt/intelmq/etc/pipeline.conf /opt/intelmq/etc/pipeline.conf.bk
 ```
 
-### Upgrade
+## Upgrade
 
 ```
 cd intelmq/
@@ -149,7 +201,7 @@ git pull
 python setup.py install
 ```
 
-### Restore Configurations
+## Restore Configurations
 
 * Apply your configurations backup.
 

--- a/intelmq/bin/intelmqctl
+++ b/intelmq/bin/intelmqctl
@@ -154,7 +154,7 @@ class IntelMQContoller():
     def __init__(self):
         global RETURN_TYPE
         global logger
-        logger = utils.log(DEFAULT_LOGGING_PATH, 'intelmqctl', 'DEBUG')
+        logger = utils.log('intelmqctl', log_level='DEBUG')
         self.logger = logger
 
         APPNAME = "intelmqctl"

--- a/intelmq/bots/collectors/http/collector_http.py
+++ b/intelmq/bots/collectors/http/collector_http.py
@@ -4,6 +4,7 @@ import sys
 
 from intelmq.bots.collectors.http.lib import fetch_url
 from intelmq.lib.bot import Bot
+from intelmq.lib.harmonization import DateTime
 from intelmq.lib.message import Report
 
 
@@ -24,6 +25,8 @@ class URLCollectorBot(Bot):
         report.add("raw", raw_report, sanitize=True)
         report.add("feed.name", self.parameters.feed, sanitize=True)
         report.add("feed.url", self.parameters.url, sanitize=True)
+        time_observation = DateTime().generate_datetime_now()
+        report.add('time.observation', time_observation, sanitize=True)
         self.send_message(report)
 
 

--- a/intelmq/bots/collectors/http/collector_http_stream.py
+++ b/intelmq/bots/collectors/http/collector_http_stream.py
@@ -4,6 +4,7 @@ import sys
 
 import pycurl
 from intelmq.lib.bot import Bot
+from intelmq.lib.harmonization import DateTime
 from intelmq.lib.message import Report
 
 
@@ -27,6 +28,8 @@ class HTTPStreamCollectorBot(Bot):
             report = Report()
             report.add("raw", str(line), sanitize=True)
             report.add("feed.name", self.parameters.feed, sanitize=True)
+            time_observation = DateTime().generate_datetime_now()
+            report.add('time.observation', time_observation, sanitize=True)
             self.send_message(report)
 
 

--- a/intelmq/bots/collectors/mail/collector_mail_attach.py
+++ b/intelmq/bots/collectors/mail/collector_mail_attach.py
@@ -6,6 +6,7 @@ import zipfile
 
 import imbox
 from intelmq.lib.bot import Bot
+from intelmq.lib.harmonization import DateTime
 from intelmq.lib.message import Report
 
 
@@ -46,8 +47,11 @@ class MailAttachCollectorBot(Bot):
 
                         report = Report()
                         report.add("raw", raw_report, sanitize=True)
-                        report.add(
-                            "feed.name", self.parameters.feed, sanitize=True)
+                        report.add("feed.name", self.parameters.feed,
+                                   sanitize=True)
+                        time_observation = DateTime().generate_datetime_now()
+                        report.add('time.observation', time_observation,
+                                   sanitize=True)
 
                         self.send_message(report)
 

--- a/intelmq/bots/collectors/mail/collector_mail_url.py
+++ b/intelmq/bots/collectors/mail/collector_mail_url.py
@@ -6,6 +6,7 @@ import sys
 import imbox
 from intelmq.bots.collectors.url.lib import fetch_url
 from intelmq.lib.bot import Bot
+from intelmq.lib.harmonization import DateTime
 from intelmq.lib.message import Report
 
 
@@ -42,6 +43,9 @@ class MailURLCollectorBot(Bot):
                         report.add("raw", raw_report, sanitize=True)
                         report.add("feed.name",
                                    self.parameters.feed, sanitize=True)
+                        time_observation = DateTime().generate_datetime_now()
+                        report.add('time.observation', time_observation,
+                                   sanitize=True)
                         self.send_message(report)
 
                 mailbox.mark_seen(uid)

--- a/intelmq/bots/parsers/abusech/parser_domain.py
+++ b/intelmq/bots/parsers/abusech/parser_domain.py
@@ -4,7 +4,6 @@ import sys
 
 from intelmq.lib import utils
 from intelmq.lib.bot import Bot
-from intelmq.lib.harmonization import DateTime
 from intelmq.lib.message import Event
 
 
@@ -29,8 +28,8 @@ class AbusechDomainParserBot(Bot):
 
             event.add('classification.type', u'c&c')
             event.add('source.fqdn', row, sanitize=True)
-            time_observation = DateTime().generate_datetime_now()
-            event.add('time.observation', time_observation, sanitize=True)
+            event.add('time.observation', report.value(
+                'time.observation'), sanitize=True)
             event.add('feed.name', report.value("feed.name"))
             event.add('feed.url', report.value("feed.url"))
             event.add("raw", row, sanitize=True)

--- a/intelmq/bots/parsers/abusech/parser_ip.py
+++ b/intelmq/bots/parsers/abusech/parser_ip.py
@@ -4,7 +4,6 @@ import sys
 
 from intelmq.lib import utils
 from intelmq.lib.bot import Bot
-from intelmq.lib.harmonization import DateTime
 from intelmq.lib.message import Event
 
 
@@ -29,8 +28,8 @@ class AbusechIPParserBot(Bot):
 
             event.add('source.ip', row, sanitize=True)
             event.add('classification.type', u'c&c')
-            time_observation = DateTime().generate_datetime_now()
-            event.add('time.observation', time_observation, sanitize=True)
+            event.add('time.observation', report.value(
+                'time.observation'), sanitize=True)
             event.add('feed.name', report.value("feed.name"))
             event.add('feed.url', report.value("feed.url"))
             event.add("raw", row, sanitize=True)

--- a/intelmq/bots/parsers/alienvault/parser.py
+++ b/intelmq/bots/parsers/alienvault/parser.py
@@ -4,7 +4,6 @@ import sys
 
 from intelmq.lib import utils
 from intelmq.lib.bot import Bot
-from intelmq.lib.harmonization import DateTime
 from intelmq.lib.message import Event
 
 CLASSIFICATION = {
@@ -70,8 +69,8 @@ class AlienVaultParserBot(Bot):
                 event.add('source.geolocation.longitude',
                           geo_longitude.strip(), sanitize=True)
 
-                time_observation = DateTime().generate_datetime_now()
-                event.add('time.observation', time_observation, sanitize=True)
+                event.add('time.observation', report.value(
+                    'time.observation'), sanitize=True)
                 event.add('feed.name', report.value("feed.name"))
                 event.add('feed.url', report.value("feed.url"))
                 event.add("raw", row, sanitize=True)

--- a/intelmq/bots/parsers/arbor/parser.py
+++ b/intelmq/bots/parsers/arbor/parser.py
@@ -4,7 +4,6 @@ import sys
 
 from intelmq.lib import utils
 from intelmq.lib.bot import Bot
-from intelmq.lib.harmonization import DateTime
 from intelmq.lib.message import Event
 
 
@@ -26,8 +25,8 @@ class ArborParserBot(Bot):
 
             event = Event()
 
-            time_observation = DateTime().generate_datetime_now()
-            event.add('time.observation', time_observation, sanitize=True)
+            event.add('time.observation', report.value(
+                'time.observation'), sanitize=True)
             event.add('feed.name', report.value("feed.name"))
             event.add('feed.url', report.value("feed.url"))
             event.add('classification.type', u'brute-force')

--- a/intelmq/bots/parsers/autoshun/parser.py
+++ b/intelmq/bots/parsers/autoshun/parser.py
@@ -5,7 +5,6 @@ import sys
 import HTMLParser
 from intelmq.lib import utils
 from intelmq.lib.bot import Bot
-from intelmq.lib.harmonization import DateTime
 from intelmq.lib.message import Event
 
 TAXONOMY = {
@@ -58,8 +57,8 @@ class AutoshunParserBot(Bot):
             if not event.contains("classification.type"):
                 event.add("classification.type", u'unknown')
 
-            time_observation = DateTime().generate_datetime_now()
-            event.add('time.observation', time_observation, sanitize=True)
+            event.add('time.observation', report.value(
+                'time.observation'), sanitize=True)
             event.add("time.source", last_seen, sanitize=True)
             event.add('feed.name', report.value("feed.name"))
             event.add('feed.url', report.value("feed.url"))

--- a/intelmq/bots/parsers/blocklistde/parser.py
+++ b/intelmq/bots/parsers/blocklistde/parser.py
@@ -6,7 +6,6 @@ import urlparse
 
 from intelmq.lib import utils
 from intelmq.lib.bot import Bot
-from intelmq.lib.harmonization import DateTime
 from intelmq.lib.message import Event
 
 MAPPING = {
@@ -88,8 +87,8 @@ class BlockListDEParserBot(Bot):
             event.add('source.ip', row.strip(), sanitize=True)
             event.add(key, classification_type, sanitize=True)
 
-            time_observation = DateTime().generate_datetime_now()
-            event.add('time.observation', time_observation, sanitize=True)
+            event.add('time.observation', report.value(
+                'time.observation'), sanitize=True)
             event.add('feed.name', report.value("feed.name"))
             event.add('feed.url', report.value("feed.url"))
             event.add("raw", row, sanitize=True)

--- a/intelmq/bots/parsers/ci_army/parser.py
+++ b/intelmq/bots/parsers/ci_army/parser.py
@@ -4,7 +4,6 @@ import sys
 
 from intelmq.lib import utils
 from intelmq.lib.bot import Bot
-from intelmq.lib.harmonization import DateTime
 from intelmq.lib.message import Event
 
 
@@ -26,8 +25,8 @@ class CIArmyParserBot(Bot):
 
             event = Event()
 
-            time_observation = DateTime().generate_datetime_now()
-            event.add('time.observation', time_observation, sanitize=True)
+            event.add('time.observation', report.value(
+                'time.observation'), sanitize=True)
             event.add('feed.name', report.value("feed.name"))
             event.add('feed.url', report.value("feed.url"))
             event.add('source.ip', row, sanitize=True)

--- a/intelmq/bots/parsers/cleanmx/parser_phishing.py
+++ b/intelmq/bots/parsers/cleanmx/parser_phishing.py
@@ -6,7 +6,6 @@ import sys
 
 from intelmq.lib import utils
 from intelmq.lib.bot import Bot
-from intelmq.lib.harmonization import DateTime, IPAddress
 from intelmq.lib.message import Event
 
 COLUMNS = {
@@ -71,8 +70,8 @@ class CleanMXPhishingParserBot(Bot):
 
                 event.add(key, value, sanitize=True)
 
-            time_observation = DateTime().generate_datetime_now()
-            event.add('time.observation', time_observation, sanitize=True)
+            event.add('time.observation', report.value(
+                'time.observation'), sanitize=True)
             event.add('feed.name', report.value("feed.name"))
             event.add('feed.url', report.value("feed.url"))
             event.add('classification.type', u'phishing')

--- a/intelmq/bots/parsers/cleanmx/parser_phishing.py
+++ b/intelmq/bots/parsers/cleanmx/parser_phishing.py
@@ -6,6 +6,7 @@ import sys
 
 from intelmq.lib import utils
 from intelmq.lib.bot import Bot
+from intelmq.lib.harmonization import IPAddress
 from intelmq.lib.message import Event
 
 COLUMNS = {

--- a/intelmq/bots/parsers/cleanmx/parser_virus.py
+++ b/intelmq/bots/parsers/cleanmx/parser_virus.py
@@ -6,6 +6,7 @@ import sys
 
 from intelmq.lib import utils
 from intelmq.lib.bot import Bot
+from intelmq.lib.harmonization import IPAddress
 from intelmq.lib.message import Event
 
 COLUMNS = {

--- a/intelmq/bots/parsers/cleanmx/parser_virus.py
+++ b/intelmq/bots/parsers/cleanmx/parser_virus.py
@@ -6,7 +6,6 @@ import sys
 
 from intelmq.lib import utils
 from intelmq.lib.bot import Bot
-from intelmq.lib.harmonization import DateTime, IPAddress
 from intelmq.lib.message import Event
 
 COLUMNS = {
@@ -82,8 +81,8 @@ class CleanMXVirusParserBot(Bot):
 
                 event.add(key, value, sanitize=True)
 
-            time_observation = DateTime().generate_datetime_now()
-            event.add('time.observation', time_observation, sanitize=True)
+            event.add('time.observation', report.value(
+                'time.observation'), sanitize=True)
             event.add('feed.name', report.value("feed.name"))
             event.add('feed.url', report.value("feed.url"))
             event.add('classification.type', u'malware')

--- a/intelmq/bots/parsers/cymru_full_bogons/parser.py
+++ b/intelmq/bots/parsers/cymru_full_bogons/parser.py
@@ -4,7 +4,6 @@ import sys
 
 from intelmq.lib import utils
 from intelmq.lib.bot import Bot
-from intelmq.lib.harmonization import DateTime, IPAddress
 from intelmq.lib.message import Event
 
 
@@ -34,8 +33,8 @@ class CymruFullBogonsParserBot(Bot):
             else:
                 event.add('source.network', value, sanitize=True)
 
-            time_observation = DateTime().generate_datetime_now()
-            event.add('time.observation', time_observation, sanitize=True)
+            event.add('time.observation', report.value(
+                'time.observation'), sanitize=True)
             event.add('classification.type', u'blacklist')
             event.add('feed.name', report.value("feed.name"))
             event.add('feed.url', report.value("feed.url"))

--- a/intelmq/bots/parsers/cymru_full_bogons/parser.py
+++ b/intelmq/bots/parsers/cymru_full_bogons/parser.py
@@ -4,6 +4,7 @@ import sys
 
 from intelmq.lib import utils
 from intelmq.lib.bot import Bot
+from intelmq.lib.harmonization import IPAddress
 from intelmq.lib.message import Event
 
 
@@ -33,8 +34,8 @@ class CymruFullBogonsParserBot(Bot):
             else:
                 event.add('source.network', value, sanitize=True)
 
-            event.add('time.observation', report.value(
-                'time.observation'), sanitize=True)
+            event.add('time.observation',
+                      report.value('time.observation'), sanitize=True)
             event.add('classification.type', u'blacklist')
             event.add('feed.name', report.value("feed.name"))
             event.add('feed.url', report.value("feed.url"))

--- a/intelmq/bots/parsers/danger_rulez/parser.py
+++ b/intelmq/bots/parsers/danger_rulez/parser.py
@@ -5,7 +5,6 @@ import sys
 
 from intelmq.lib import utils
 from intelmq.lib.bot import Bot
-from intelmq.lib.harmonization import DateTime
 from intelmq.lib.message import Event
 
 REGEX_IP = "^[^ \t]+"
@@ -37,8 +36,8 @@ class BruteForceBlockerParserBot(Bot):
             if match:
                 timestamp = match.group(1) + " UTC"
 
-            time_observation = DateTime().generate_datetime_now()
-            event.add('time.observation', time_observation, sanitize=True)
+            event.add('time.observation', report.value(
+                'time.observation'), sanitize=True)
             event.add('time.source', timestamp, sanitize=True)
             event.add('source.ip', ip, sanitize=True)
             event.add('feed.name', report.value("feed.name"))

--- a/intelmq/bots/parsers/dragonresearchgroup/parser_ssh.py
+++ b/intelmq/bots/parsers/dragonresearchgroup/parser_ssh.py
@@ -4,7 +4,6 @@ import sys
 
 from intelmq.lib import utils
 from intelmq.lib.bot import Bot
-from intelmq.lib.harmonization import DateTime
 from intelmq.lib.message import Event
 
 
@@ -41,8 +40,8 @@ class DragonResearchGroupSSHParserBot(Bot):
 
                 event.add(key, value, sanitize=True)
 
-            time_observation = DateTime().generate_datetime_now()
-            event.add('time.observation', time_observation, sanitize=True)
+            event.add('time.observation', report.value(
+                'time.observation'), sanitize=True)
             event.add('feed.name', report.value("feed.name"))
             event.add('feed.url', report.value("feed.url"))
             event.add('classification.type', u'brute-force')

--- a/intelmq/bots/parsers/dragonresearchgroup/parser_vnc.py
+++ b/intelmq/bots/parsers/dragonresearchgroup/parser_vnc.py
@@ -4,7 +4,6 @@ import sys
 
 from intelmq.lib import utils
 from intelmq.lib.bot import Bot
-from intelmq.lib.harmonization import DateTime
 from intelmq.lib.message import Event
 
 
@@ -39,8 +38,8 @@ class DragonResearchGroupVNCParserBot(Bot):
 
                 event.add(key, value, sanitize=True)
 
-            time_observation = DateTime().generate_datetime_now()
-            event.add('time.observation', time_observation, sanitize=True)
+            event.add('time.observation', report.value(
+                'time.observation'), sanitize=True)
             event.add('feed.name', report.value("feed.name"))
             event.add('feed.url', report.value("feed.url"))
             event.add('classification.type', u'brute-force')

--- a/intelmq/bots/parsers/dshield/parser_asn.py
+++ b/intelmq/bots/parsers/dshield/parser_asn.py
@@ -4,7 +4,6 @@ import sys
 
 from intelmq.lib import utils
 from intelmq.lib.bot import Bot
-from intelmq.lib.harmonization import DateTime
 from intelmq.lib.message import Event
 
 
@@ -47,8 +46,8 @@ class DShieldASNParserBot(Bot):
 
             event.add('source.ip', source_ip, sanitize=True)
             event.add('classification.type', u'brute-force')
-            time_observation = DateTime().generate_datetime_now()
-            event.add('time.observation', time_observation, sanitize=True)
+            event.add('time.observation', report.value(
+                'time.observation'), sanitize=True)
             event.add("time.source", last_seen, sanitize=True)
             event.add('feed.name', report.value("feed.name"))
             event.add('feed.url', report.value("feed.url"))

--- a/intelmq/bots/parsers/dshield/parser_block.py
+++ b/intelmq/bots/parsers/dshield/parser_block.py
@@ -4,7 +4,6 @@ import sys
 
 from intelmq.lib import utils
 from intelmq.lib.bot import Bot
-from intelmq.lib.harmonization import DateTime
 from intelmq.lib.message import Event
 
 
@@ -39,8 +38,8 @@ class DshieldBlockParserBot(Bot):
 
             event.add('source.network', network, sanitize=True)
             event.add('classification.type', u'blacklist')
-            time_observation = DateTime().generate_datetime_now()
-            event.add('time.observation', time_observation, sanitize=True)
+            event.add('time.observation', report.value(
+                'time.observation'), sanitize=True)
             event.add('feed.name', report.value("feed.name"))
             event.add('feed.url', report.value("feed.url"))
             event.add("raw", row, sanitize=True)

--- a/intelmq/bots/parsers/dshield/parser_domain.py
+++ b/intelmq/bots/parsers/dshield/parser_domain.py
@@ -4,7 +4,6 @@ import sys
 
 from intelmq.lib import utils
 from intelmq.lib.bot import Bot
-from intelmq.lib.harmonization import DateTime
 from intelmq.lib.message import Event
 
 
@@ -30,8 +29,8 @@ class DshieldDomainParserBot(Bot):
 
             event.add('classification.type', u'malware')
             event.add('source.fqdn', row, sanitize=True)
-            time_observation = DateTime().generate_datetime_now()
-            event.add('time.observation', time_observation, sanitize=True)
+            event.add('time.observation', report.value(
+                'time.observation'), sanitize=True)
             event.add('feed.name', report.value("feed.name"))
             event.add('feed.url', report.value("feed.url"))
             event.add("raw", row, sanitize=True)

--- a/intelmq/bots/parsers/dyn/parser.py
+++ b/intelmq/bots/parsers/dyn/parser.py
@@ -5,7 +5,6 @@ import sys
 
 from intelmq.lib import utils
 from intelmq.lib.bot import Bot
-from intelmq.lib.harmonization import DateTime
 from intelmq.lib.message import Event
 
 
@@ -36,9 +35,8 @@ class DynParserBot(Bot):
             compromised_url = splitted_row[1].split("seems to be INFECTED:")[1]
 
             event_infected = Event()
-            time_observation = DateTime().generate_datetime_now()
             event_infected.add('time.observation',
-                               time_observation, sanitize=True)
+                               report.value('time.observation'), sanitize=True)
             event_infected.add('classification.type', 'malware')
             event_infected.add('feed.name', report.value("feed.name"))
             event_infected.add('feed.url', report.value("feed.url"))
@@ -53,9 +51,9 @@ class DynParserBot(Bot):
             self.send_message(event_infected)
 
             event_compromised = Event()
-            time_observation = DateTime().generate_datetime_now()
             event_compromised.add('time.observation',
-                                  time_observation, sanitize=True)
+                                  report.value('time.observation'),
+                                  sanitize=True)
             event_compromised.add('classification.type', 'compromised')
             event_compromised.add('feed.name', report.value("feed.name"))
             event_compromised.add('feed.url', report.value("feed.url"))

--- a/intelmq/bots/parsers/hphosts/parser.py
+++ b/intelmq/bots/parsers/hphosts/parser.py
@@ -4,7 +4,6 @@ import sys
 
 from intelmq.lib import utils
 from intelmq.lib.bot import Bot
-from intelmq.lib.harmonization import DateTime, IPAddress
 from intelmq.lib.message import Event
 
 
@@ -44,9 +43,9 @@ class HpHostsParserBot(Bot):
             else:
                 event.add("source.fqdn", values[1], sanitize=True)
 
-            time_observation = DateTime().generate_datetime_now()
             event.add('classification.type', u'blacklist')
-            event.add('time.observation', time_observation, sanitize=True)
+            event.add('time.observation', report.value(
+                'time.observation'), sanitize=True)
             event.add('feed.name', report.value("feed.name"))
             event.add('feed.url', report.value("feed.url"))
             event.add("raw", row, sanitize=True)

--- a/intelmq/bots/parsers/hphosts/parser.py
+++ b/intelmq/bots/parsers/hphosts/parser.py
@@ -4,6 +4,7 @@ import sys
 
 from intelmq.lib import utils
 from intelmq.lib.bot import Bot
+from intelmq.lib.harmonization import IPAddress
 from intelmq.lib.message import Event
 
 

--- a/intelmq/bots/parsers/malc0de/parser_domain_blacklist.py
+++ b/intelmq/bots/parsers/malc0de/parser_domain_blacklist.py
@@ -4,7 +4,6 @@ import sys
 
 from intelmq.lib import utils
 from intelmq.lib.bot import Bot
-from intelmq.lib.harmonization import DateTime
 from intelmq.lib.message import Event
 
 
@@ -27,8 +26,8 @@ class Malc0deDomainBlacklistParserBot(Bot):
 
             event = Event()
 
-            time_observation = DateTime().generate_datetime_now()
-            event.add('time.observation', time_observation, sanitize=True)
+            event.add('time.observation', report.value(
+                'time.observation'), sanitize=True)
             event.add('classification.type', u'malware')
             event.add('feed.name', report.value("feed.name"))
             event.add('feed.url', report.value("feed.url"))

--- a/intelmq/bots/parsers/malc0de/parser_ip_blacklist.py
+++ b/intelmq/bots/parsers/malc0de/parser_ip_blacklist.py
@@ -4,7 +4,6 @@ import sys
 
 from intelmq.lib import utils
 from intelmq.lib.bot import Bot
-from intelmq.lib.harmonization import DateTime
 from intelmq.lib.message import Event
 
 
@@ -27,8 +26,8 @@ class Malc0deIPBlacklistParserBot(Bot):
 
             event = Event()
 
-            time_observation = DateTime().generate_datetime_now()
-            event.add('time.observation', time_observation, sanitize=True)
+            event.add('time.observation', report.value(
+                'time.observation'), sanitize=True)
             event.add('classification.type', u'malware')
             event.add('feed.name', report.value("feed.name"))
             event.add('feed.url', report.value("feed.url"))

--- a/intelmq/bots/parsers/malwaredomainlist/parser.py
+++ b/intelmq/bots/parsers/malwaredomainlist/parser.py
@@ -7,7 +7,6 @@ import unicodecsv
 
 from intelmq.lib import utils
 from intelmq.lib.bot import Bot
-from intelmq.lib.harmonization import DateTime
 from intelmq.lib.message import Event
 
 
@@ -46,8 +45,8 @@ class MalwareDomainListParserBot(Bot):
 
                 event.add(key, value, sanitize=True)
 
-            time_observation = DateTime().generate_datetime_now()
-            event.add('time.observation', time_observation, sanitize=True)
+            event.add('time.observation', report.value(
+                'time.observation'), sanitize=True)
             event.add('feed.name', report.value("feed.name"))
             event.add('feed.url', report.value("feed.url"))
             event.add('classification.type', u'malware')

--- a/intelmq/bots/parsers/malwaredomains/parser.py
+++ b/intelmq/bots/parsers/malwaredomains/parser.py
@@ -5,7 +5,6 @@ import sys
 
 from intelmq.lib import utils
 from intelmq.lib.bot import Bot
-from intelmq.lib.harmonization import DateTime
 from intelmq.lib.message import Event
 
 
@@ -47,8 +46,8 @@ class MalwareDomainsParserBot(Bot):
                     event.add('time.source', values[i], sanitize=True)
                     break
 
-            time_observation = DateTime().generate_datetime_now()
-            event.add('time.observation', time_observation, sanitize=True)
+            event.add('time.observation', report.value(
+                'time.observation'), sanitize=True)
             event.add('classification.type', u'malware')
             event.add('feed.name', report.value("feed.name"))
             event.add('feed.url', report.value("feed.url"))

--- a/intelmq/bots/parsers/malwaregroup/parser_domains.py
+++ b/intelmq/bots/parsers/malwaregroup/parser_domains.py
@@ -4,7 +4,6 @@ import sys
 
 from intelmq.lib import utils
 from intelmq.lib.bot import Bot
-from intelmq.lib.harmonization import DateTime
 from intelmq.lib.message import Event
 
 
@@ -39,8 +38,8 @@ class MalwareGroupDomainsParserBot(Bot):
 
             event = Event()
 
-            time_observation = DateTime().generate_datetime_now()
-            event.add('time.observation', time_observation, sanitize=True)
+            event.add('time.observation', report.value(
+                'time.observation'), sanitize=True)
             event.add('time.source', time_source, sanitize=True)
             event.add('classification.type', u'malware')
             event.add('feed.name', report.value("feed.name"))

--- a/intelmq/bots/parsers/malwaregroup/parser_ips.py
+++ b/intelmq/bots/parsers/malwaregroup/parser_ips.py
@@ -4,7 +4,6 @@ import sys
 
 from intelmq.lib import utils
 from intelmq.lib.bot import Bot
-from intelmq.lib.harmonization import DateTime
 from intelmq.lib.message import Event
 
 
@@ -38,8 +37,8 @@ class MalwareGroupIPsParserBot(Bot):
 
             event = Event()
 
-            time_observation = DateTime().generate_datetime_now()
-            event.add('time.observation', time_observation, sanitize=True)
+            event.add('time.observation', report.value(
+                'time.observation'), sanitize=True)
             event.add('time.source', time_source, sanitize=True)
             event.add('classification.type', u'malware')
             event.add('feed.name', report.value("feed.name"))

--- a/intelmq/bots/parsers/malwaregroup/parser_proxies.py
+++ b/intelmq/bots/parsers/malwaregroup/parser_proxies.py
@@ -4,7 +4,6 @@ import sys
 
 from intelmq.lib import utils
 from intelmq.lib.bot import Bot
-from intelmq.lib.harmonization import DateTime
 from intelmq.lib.message import Event
 
 
@@ -40,8 +39,8 @@ class MalwareGroupProxiesParserBot(Bot):
 
             event = Event()
 
-            time_observation = DateTime().generate_datetime_now()
-            event.add('time.observation', time_observation, sanitize=True)
+            event.add('time.observation', report.value(
+                'time.observation'), sanitize=True)
             event.add('time.source', time_source, sanitize=True)
             event.add('classification.type', u'unknown')
             event.add('feed.name', report.value("feed.name"))

--- a/intelmq/bots/parsers/malwarepatrol/parser_dansguardian.py
+++ b/intelmq/bots/parsers/malwarepatrol/parser_dansguardian.py
@@ -4,7 +4,6 @@ import sys
 
 from intelmq.lib import utils
 from intelmq.lib.bot import Bot
-from intelmq.lib.harmonization import DateTime
 from intelmq.lib.message import Event
 
 
@@ -32,8 +31,8 @@ class DansParserBot(Bot):
             for key, value in zip(columns, splitted_row):
                 event.add(key, value, sanitize=True)
 
-            time_observation = DateTime().generate_datetime_now()
-            event.add('time.observation', time_observation, sanitize=True)
+            event.add('time.observation', report.value(
+                'time.observation'), sanitize=True)
             event.add('feed.name', report.value("feed.name"))
             event.add('feed.url', report.value("feed.url"))
             event.add('classification.type', u'malware')

--- a/intelmq/bots/parsers/openbl/parser.py
+++ b/intelmq/bots/parsers/openbl/parser.py
@@ -5,7 +5,6 @@ from datetime import datetime
 
 from intelmq.lib import utils
 from intelmq.lib.bot import Bot
-from intelmq.lib.harmonization import DateTime
 from intelmq.lib.message import Event
 
 
@@ -38,8 +37,8 @@ class OpenBLParserBot(Bot):
 
                 event.add(key, value.strip(), sanitize=True)
 
-            time_observation = DateTime().generate_datetime_now()
-            event.add('time.observation', time_observation, sanitize=True)
+            event.add('time.observation', report.value(
+                'time.observation'), sanitize=True)
             event.add('feed.name', report.value("feed.name"))
             event.add('feed.url', report.value("feed.url"))
             event.add('classification.type', u'blacklist')

--- a/intelmq/bots/parsers/openphish/parser.py
+++ b/intelmq/bots/parsers/openphish/parser.py
@@ -4,7 +4,6 @@ import sys
 
 from intelmq.lib import utils
 from intelmq.lib.bot import Bot
-from intelmq.lib.harmonization import DateTime
 from intelmq.lib.message import Event
 
 
@@ -27,8 +26,8 @@ class OpenPhishParserBot(Bot):
 
             event = Event()
 
-            time_observation = DateTime().generate_datetime_now()
-            event.add('time.observation', time_observation, sanitize=True)
+            event.add('time.observation', report.value(
+                'time.observation'), sanitize=True)
             event.add('classification.type', u'phishing')
             event.add('feed.name', report.value("feed.name"))
             event.add('feed.url', report.value("feed.url"))

--- a/intelmq/bots/parsers/phishtank/parser.py
+++ b/intelmq/bots/parsers/phishtank/parser.py
@@ -7,7 +7,6 @@ import unicodecsv
 
 from intelmq.lib import utils
 from intelmq.lib.bot import Bot
-from intelmq.lib.harmonization import DateTime
 from intelmq.lib.message import Event
 
 
@@ -47,8 +46,8 @@ class PhishTankParserBot(Bot):
 
                 event.add(key, value, sanitize=True)
 
-            time_observation = DateTime().generate_datetime_now()
-            event.add('time.observation', time_observation, sanitize=True)
+            event.add('time.observation', report.value(
+                'time.observation'), sanitize=True)
             event.add('feed.name', report.value("feed.name"))
             event.add('feed.url', report.value("feed.url"))
             event.add('classification.type', u'phishing')

--- a/intelmq/bots/parsers/spamhaus/parser.py
+++ b/intelmq/bots/parsers/spamhaus/parser.py
@@ -5,7 +5,6 @@ from datetime import datetime
 
 from intelmq.lib import utils
 from intelmq.lib.bot import Bot
-from intelmq.lib.harmonization import DateTime
 from intelmq.lib.message import Event
 
 
@@ -42,8 +41,8 @@ class SpamHausParserBot(Bot):
             if self.event_date:
                 event.add('time.source', self.event_date, sanitize=True)
 
-            time_observation = DateTime().generate_datetime_now()
-            event.add('time.observation', time_observation, sanitize=True)
+            event.add('time.observation', report.value(
+                'time.observation'), sanitize=True)
             event.add('classification.type', u'spam')
             event.add('feed.name', report.value("feed.name"))
             event.add('feed.url', report.value("feed.url"))

--- a/intelmq/bots/parsers/taichung/parser.py
+++ b/intelmq/bots/parsers/taichung/parser.py
@@ -6,7 +6,6 @@ import sys
 
 from intelmq.lib import utils
 from intelmq.lib.bot import Bot
-from intelmq.lib.harmonization import DateTime
 from intelmq.lib.message import Event
 
 CLASSIFICATION = {
@@ -56,11 +55,11 @@ class TaichungCityNetflowParserBot(Bot):
             description = info1.group(2)
             description = utils.decode(description)
             event_type = self.get_type(description)
-            time_observation = DateTime().generate_datetime_now()
             time_source = info2.group(1) + " UTC-8"
 
             event.add("time.source", time_source, sanitize=True)
-            event.add('time.observation', time_observation, sanitize=True)
+            event.add('time.observation', report.value(
+                'time.observation'), sanitize=True)
             event.add("source.ip", info1.group(1), sanitize=True)
             event.add('classification.type', event_type, sanitize=True)
             event.add('description.text', description, sanitize=True)

--- a/intelmq/bots/parsers/turris/parser.py
+++ b/intelmq/bots/parsers/turris/parser.py
@@ -7,7 +7,6 @@ import unicodecsv
 
 from intelmq.lib import utils
 from intelmq.lib.bot import Bot
-from intelmq.lib.harmonization import DateTime
 from intelmq.lib.message import Event
 
 
@@ -45,8 +44,8 @@ class TurrisGreylistParserBot(Bot):
 
                 event.add(key, value, sanitize=True)
 
-            time_observation = DateTime().generate_datetime_now()
-            event.add('time.observation', time_observation, sanitize=True)
+            event.add('time.observation', report.value(
+                'time.observation'), sanitize=True)
             event.add('feed.name', report.value("feed.name"))
             event.add('feed.url', report.value("feed.url"))
             event.add('classification.type', u'scanner')

--- a/intelmq/bots/parsers/urlvir/parser_hosts.py
+++ b/intelmq/bots/parsers/urlvir/parser_hosts.py
@@ -4,7 +4,7 @@ import sys
 
 from intelmq.lib import utils
 from intelmq.lib.bot import Bot
-from intelmq.lib.harmonization import DateTime, IPAddress
+from intelmq.lib.harmonization import IPAddress
 from intelmq.lib.message import Event
 
 
@@ -34,8 +34,8 @@ class URLVirHostsParserBot(Bot):
             else:
                 event.add('source.fqdn', row, sanitize=True)
 
-            time_observation = DateTime().generate_datetime_now()
-            event.add('time.observation', time_observation, sanitize=True)
+            event.add('time.observation', report.value(
+                'time.observation'), sanitize=True)
             event.add('classification.type', u'malware')
             event.add('feed.name', report.value("feed.name"))
             event.add('feed.url', report.value("feed.url"))

--- a/intelmq/bots/parsers/urlvir/parser_ips.py
+++ b/intelmq/bots/parsers/urlvir/parser_ips.py
@@ -4,7 +4,6 @@ import sys
 
 from intelmq.lib import utils
 from intelmq.lib.bot import Bot
-from intelmq.lib.harmonization import DateTime
 from intelmq.lib.message import Event
 
 
@@ -31,8 +30,8 @@ class URLVirIPsParserBot(Bot):
 
             event.add('source.ip', row, sanitize=True)
 
-            time_observation = DateTime().generate_datetime_now()
-            event.add('time.observation', time_observation, sanitize=True)
+            event.add('time.observation', report.value(
+                'time.observation'), sanitize=True)
             event.add('classification.type', u'malware')
             event.add('feed.name', report.value("feed.name"))
             event.add('feed.url', report.value("feed.url"))

--- a/intelmq/bots/parsers/vxvault/parser.py
+++ b/intelmq/bots/parsers/vxvault/parser.py
@@ -5,7 +5,7 @@ import urlparse
 
 from intelmq.lib import utils
 from intelmq.lib.bot import Bot
-from intelmq.lib.harmonization import DateTime, IPAddress
+from intelmq.lib.harmonization import IPAddress
 from intelmq.lib.message import Event
 
 
@@ -44,8 +44,8 @@ class VXVaultParserBot(Bot):
             else:
                 event.add("source.fqdn", hostname, sanitize=True)
 
-            time_observation = DateTime().generate_datetime_now()
-            event.add('time.observation', time_observation, sanitize=True)
+            event.add('time.observation', report.value(
+                'time.observation'), sanitize=True)
             event.add('feed.name', report.value("feed.name"))
             event.add('feed.url', report.value("feed.url"))
             event.add('classification.type', u'malware')

--- a/intelmq/conf/harmonization.conf
+++ b/intelmq/conf/harmonization.conf
@@ -11,6 +11,10 @@
     "feed.url": {
       "type": "URL",
       "description": "test ..."
+    },
+    "time.observation": {
+      "type": "DateTime",
+      "description": "test ..."
     }
   },
   "event": {

--- a/intelmq/lib/bot.py
+++ b/intelmq/lib/bot.py
@@ -42,8 +42,8 @@ class Bot(object):
 
             self.load_defaults_configuration()
             self.load_system_configuration()
-            self.logger = utils.log(self.parameters.logging_path, self.bot_id,
-                                    self.parameters.logging_level)
+            self.logger = utils.log(self.bot_id,
+                                    log_level=self.parameters.logging_level)
         except:
             self.log_buffer.append(('critical', traceback.format_exc()))
             self.stop()

--- a/intelmq/lib/bot.py
+++ b/intelmq/lib/bot.py
@@ -7,7 +7,6 @@ from __future__ import print_function, unicode_literals
 import datetime
 import json
 import re
-import sys  # TODO: Replace imports in bots
 import time
 import traceback
 
@@ -35,7 +34,7 @@ class Bot(object):
 
         try:
             self.log_buffer.append(('debug',
-                                    '{} initialized with id {}'
+                                    '{} initialized with id {}.'
                                     ''.format(self.__class__.__name__,
                                               bot_id)))
             self.check_bot_id(bot_id)
@@ -48,9 +47,12 @@ class Bot(object):
         except:
             self.log_buffer.append(('critical', traceback.format_exc()))
             self.stop()
+        else:
+            for line in self.log_buffer:
+                getattr(self.logger, line[0])(line[1])
 
         try:
-            self.logger.info('Bot is starting')
+            self.logger.info('Bot is starting.')
             self.load_runtime_configuration()
             self.load_pipeline_configuration()
             self.load_harmonization_configuration()
@@ -68,48 +70,48 @@ class Bot(object):
               destination_pipeline=None):
         self.source_pipeline = source_pipeline
         self.destination_pipeline = destination_pipeline
-        self.logger.info('Bot start processing')
+        self.logger.info('Bot starts processings.')
 
         while True:
             try:
                 if not starting and (error_on_pipeline or error_on_message):
-                    self.logger.info('Bot will restart in %s seconds' %
+                    self.logger.info('Bot will restart in %s seconds.' %
                                      self.parameters.error_retry_delay)
                     time.sleep(self.parameters.error_retry_delay)
                     self.logger.info('Bot woke up')
-                    self.logger.info('Trying to start processing again')
+                    self.logger.info('Trying to start processing again.')
 
                 if error_on_message:
                     error_on_message = False
 
                 if error_on_pipeline:
-                    self.logger.info("Loading source pipeline")
+                    self.logger.info("Loading source pipeline.")
                     self.source_pipeline = PipelineFactory.create(
                         self.parameters)
-                    self.logger.info("Loading source queue")
+                    self.logger.info("Loading source queue.")
                     self.source_pipeline.set_queues(self.source_queues,
                                                     "source")
-                    self.logger.info("Source queue loaded {}"
+                    self.logger.info("Source queue loaded {}."
                                      "".format(self.source_queues))
                     self.source_pipeline.connect()
-                    self.logger.info("Connected to source queue")
+                    self.logger.info("Connected to source queue.")
 
-                    self.logger.info("Loading destination pipeline")
+                    self.logger.info("Loading destination pipeline.")
                     self.destination_pipeline = PipelineFactory.create(
                         self.parameters)
-                    self.logger.info("Loading destination queues")
+                    self.logger.info("Loading destination queues.")
                     self.destination_pipeline.set_queues(self.destination_queues,
                                                          "destination")
-                    self.logger.info("Destination queues loaded {}"
+                    self.logger.info("Destination queues loaded {}."
                                      "".format(self.destination_queues))
                     self.destination_pipeline.connect()
-                    self.logger.info("Connected to destination queues")
+                    self.logger.info("Connected to destination queues.")
 
-                    self.logger.info("Pipeline ready")
+                    self.logger.info("Pipeline ready.")
                     error_on_pipeline = False
 
                 if starting:
-                    self.logger.info("Start processing")
+                    self.logger.info("Start processing.")
                     starting = False
 
                 self.process()
@@ -118,22 +120,22 @@ class Bot(object):
             except exceptions.PipelineError:
                 error_on_pipeline = True
                 if self.parameters.error_log_exception:
-                    self.logger.exception('Pipeline failed')
+                    self.logger.exception('Pipeline failed.')
                 else:
-                    self.logger.error('Pipeline failed')
+                    self.logger.error('Pipeline failed.')
                 self.source_pipeline = None
                 self.destination_pipeline = None
 
             except Exception as ex:
                 if self.parameters.error_log_exception:
-                    self.logger.exception("Bot has found a problem")
+                    self.logger.exception("Bot has found a problem.")
                 else:
-                    self.logger.error("Bot has found a problem")
+                    self.logger.error("Bot has found a problem.")
 
                 if self.parameters.error_log_message:
-                    self.logger.info("Last Correct Message(event): {!r}"
+                    self.logger.info("Last Correct Message(event): {!r}."
                                      "".format(self.last_message))
-                    self.logger.info("Current Message(event): {!r}"
+                    self.logger.info("Current Message(event): {!r}."
                                      "".format(self.current_message))
 
                 self.error_retries_counter += 1
@@ -203,8 +205,8 @@ class Bot(object):
         res = re.search('[^0-9a-zA-Z\-]+', str)
         if res:
             self.log_buffer.append(('error',
-                                    "Invalid bot id, must match "
-                                    "[^0-9a-zA-Z\-]+"))
+                                    "Invalid bot id, must match '"
+                                    "[^0-9a-zA-Z\-]+'."))
             self.stop()
 
     def send_message(self, message):
@@ -215,7 +217,7 @@ class Bot(object):
         self.logger.debug("Sending message.")
         self.message_counter += 1
         if self.message_counter % 500 == 0:
-            self.logger.info("Processed %s messages" % self.message_counter)
+            self.logger.info("Processed %s messages." % self.message_counter)
 
         raw_message = MessageFactory.serialize(message)
         self.destination_pipeline.send(raw_message)
@@ -224,7 +226,7 @@ class Bot(object):
         self.logger.debug('Receiving Message.')
         message = self.source_pipeline.receive()
 
-        self.logger.debug('Receive message {!r}'.format(message))
+        self.logger.debug('Receive message {!r}.'.format(message))
         if not message:
             self.logger.warning('Empty message received.')
             return None
@@ -261,7 +263,7 @@ class Bot(object):
             json.dump(dump_data, fp, indent=4, sort_keys=True)
 
     def load_defaults_configuration(self):
-        self.log_buffer.append(('debug', "Loading defaults configuration"))
+        self.log_buffer.append(('debug', "Loading defaults configuration."))
         config = utils.load_configuration(DEFAULTS_CONF_FILE)
 
         setattr(self.parameters, 'logging_path', DEFAULT_LOGGING_PATH)
@@ -271,8 +273,8 @@ class Bot(object):
             setattr(self.parameters, option, value)
             self.log_buffer.append(('debug',
                                     "Defaults configuration: parameter '{}' "
-                                    "loaded  with value '{}'".format(option,
-                                                                     value)))
+                                    "loaded  with value '{}'.".format(option,
+                                                                      value)))
 
     def load_system_configuration(self):
         self.log_buffer.append(('debug', "Loading system configuration"))
@@ -282,8 +284,8 @@ class Bot(object):
             setattr(self.parameters, option, value)
             self.log_buffer.append(('debug',
                                     "System configuration: parameter '{}' "
-                                    "loaded  with value '{}'".format(option,
-                                                                     value)))
+                                    "loaded  with value '{}'.".format(option,
+                                                                      value)))
 
     def load_runtime_configuration(self):
         self.logger.debug("Loading runtime configuration")
@@ -308,7 +310,7 @@ class Bot(object):
             if 'source-queue' in config[self.bot_id].keys():
                 self.source_queues = config[self.bot_id]['source-queue']
                 self.logger.debug("Pipeline configuration: parameter "
-                                  "'source-queue' loaded with the value '%s'"
+                                  "'source-queue' loaded with the value '%s'."
                                   % self.source_queues)
 
             if 'destination-queues' in config[self.bot_id].keys():
@@ -316,16 +318,16 @@ class Bot(object):
                 self.destination_queues = config[
                     self.bot_id]['destination-queues']
                 self.logger.debug("Pipeline configuration: parameter"
-                                  "'destination-queues' loaded with the value"
-                                  " '%s'" % ", ".join(self.destination_queues))
+                                  "'destination-queues' loaded with the value "
+                                  "'%s'." % ", ".join(self.destination_queues))
 
         else:
             self.logger.error("Pipeline configuration: no key "
-                              "'{}'".format(self.bot_id))
+                              "'{}'.".format(self.bot_id))
             self.stop()
 
     def load_harmonization_configuration(self):
-        self.logger.debug("Loading Harmonization configuration")
+        self.logger.debug("Loading Harmonization configuration.")
         config = utils.load_configuration(HARMONIZATION_CONF_FILE)
 
         for message_types in config.keys():
@@ -335,7 +337,7 @@ class Bot(object):
                         # FIXME: write in devguide the rules for the keys names
                         raise exceptions.ConfigurationError(
                             'harmonization',
-                            "key %s is not valid" % _key)
+                            "Key %s is not valid." % _key)
 
 
 class Parameters(object):

--- a/intelmq/lib/harmonization.py
+++ b/intelmq/lib/harmonization.py
@@ -32,6 +32,7 @@ try:
 except ImportError:
     from urllib import parse as urlparse
 
+
 class GenericType(object):
 
     @staticmethod

--- a/intelmq/lib/test.py
+++ b/intelmq/lib/test.py
@@ -53,7 +53,7 @@ def mocked_config(bot_id, src_name, dst_names, sysconfig):
 
 
 def mocked_logger(logger):
-    def log(path, name, level):
+    def log(name, log_path=None, log_level=None):
         return logger
     return log
 

--- a/intelmq/lib/test.py
+++ b/intelmq/lib/test.py
@@ -173,10 +173,30 @@ class BotTestCase(object):
             it and have a reasonable output"""
         self.run_bot()
 
+    def test_log_init(self):
+        """ Test if bot logs initialized message. """
+        self.run_bot()
+        self.assertLoglineEqual(0, "{} initialized with id {}."
+                                   "".format(self.bot_name,
+                                             self.bot_id), "DEBUG")
+
     def test_log_starting(self):
         """ Test if bot logs starting message. """
         self.run_bot()
-        self.assertLoglineEqual(0, "Bot is starting", "INFO")
+        self.assertRegexpMatchesLog("INFO - Bot is starting.")
+
+    def test_log_stopped(self):
+        """ Test if bot logs stopped message. """
+        self.run_bot()
+        self.assertLoglineEqual(-1, "Bot stopped.", "INFO")
+
+    def test_log_end_dot(self):
+        """ Test if every log lines ends with a dot. """
+        for logline in self.loglines:
+            fields = utils.parse_logline(logline)
+            self.assertTrue(fields['message'].endswith('.'),
+                            msg='Logline {} does not end with dot.'
+                                ''.format(fields['message']))
 
     def test_log_not_error(self):
         """ Test if bot does not log errors. """
@@ -203,7 +223,7 @@ class BotTestCase(object):
         e.g. if empty. Bots have to handle this situation.
         """
         if self.bot_type == 'collector':
-            raise unittest.SkipTest('Given Bot is Collector.')
+            return
 
         self.input_message = ''
         self.run_bot()
@@ -234,7 +254,7 @@ class BotTestCase(object):
     def test_report(self):
         """ Test if report has required fields. """
         if self.bot_type != 'collector':
-            raise unittest.SkipTest('Given Bot is not a Collector.')
+            return
 
         self.run_bot()
         for report_json in self.get_output_queue():
@@ -243,11 +263,12 @@ class BotTestCase(object):
             self.assertIn('feed.name', report)
             self.assertIn('feed.url', report)
             self.assertIn('raw', report)
+            self.assertIn('time.observation', report)
 
     def test_event(self):
         """ Test if event has required fields. """
         if self.bot_type not in ['parser', 'expert']:
-            raise unittest.SkipTest('Given Bot is not a Parser or Expert.')
+            return
 
         self.run_bot()
         for event_json in self.get_output_queue():
@@ -283,23 +304,26 @@ class BotTestCase(object):
         self.assertRegexpMatches(self.loglines_buffer, pattern)
 
     def assertNotRegexpMatchesLog(self, pattern):
-        """Asserts that pattern doesn't match against log"""
+        """Asserts that pattern doesn't match against log."""
 
         self.assertIsNotNone(self.loglines_buffer)
         self.assertNotRegexpMatches(self.loglines_buffer, pattern)
 
-    def assertEventAlmostEqual(self, queue_pos, expected_event):
-        """Asserts that the given expected_event is
-           contained in the generated event with
-           given queue position"""
+    def assertMessageEqual(self, queue_pos, expected_message):
+        """
+        Asserts that the given expected_message is
+        contained in the generated event with
+        given queue position.
+        """
 
         event = self.get_output_queue()[queue_pos]
-        unicode_event = {}
-
-        for key, value in expected_event.items():
-            unicode_event[unicode(key)] = unicode(value)
-
         self.assertIsInstance(event, unicode)
         event_dict = json.loads(event)
+        del event_dict['time.observation']
 
-        self.assertDictContainsSubset(unicode_event, event_dict)
+        unicode_event = {}
+        del expected_message['time.observation']
+        for key, value in expected_message.items():
+            unicode_event[unicode(key)] = unicode(value)
+
+        self.assertDictEqual(unicode_event, event_dict)

--- a/intelmq/lib/utils.py
+++ b/intelmq/lib/utils.py
@@ -19,6 +19,8 @@ import logging
 import os
 import re
 
+from intelmq import DEFAULT_LOGGING_PATH
+
 # Used loglines format
 LOG_FORMAT = '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
 LOG_FORMAT_STREAM = '%(name)s: %(message)s'
@@ -118,17 +120,17 @@ def load_configuration(configuration_filepath):
     return config
 
 
-def log(logs_path, name, loglevel="DEBUG", stream=None):
+def log(name, log_path=DEFAULT_LOGGING_PATH, log_level="DEBUG", stream=None):
     """
     Returns a logger instance logging to file and sys.stderr or other stream.
 
     Parameters:
     -----------
-        logs_path : string
-            Path to log directory
         name : string
             filename for logfile or string preceding lines in stream
-        loglevel : string
+        log_path : string
+            Path to log directory, defaults to DEFAULT_LOGGING_PATH
+        log_level : string
             default is "DEBUG"
         stream : object
             By default (None), stderr will be used, stream objects can be given
@@ -146,10 +148,10 @@ def log(logs_path, name, loglevel="DEBUG", stream=None):
             Default log format for stream handler
     """
     logger = logging.getLogger(name)
-    logger.setLevel(loglevel)
+    logger.setLevel(log_level)
 
-    handler = logging.FileHandler("%s/%s.log" % (logs_path, name))
-    handler.setLevel(loglevel)
+    handler = logging.FileHandler("%s/%s.log" % (log_path, name))
+    handler.setLevel(log_level)
 
     formatter = logging.Formatter(LOG_FORMAT)
     handler.setFormatter(formatter)
@@ -158,7 +160,7 @@ def log(logs_path, name, loglevel="DEBUG", stream=None):
     console_handler = logging.StreamHandler(stream)
     console_handler.setFormatter(console_formatter)
     logger.addHandler(console_handler)
-    console_handler.setLevel(loglevel)
+    console_handler.setLevel(log_level)
 
     logger.addHandler(handler)
     return logger

--- a/intelmq/tests/bots/experts/abusix/test_expert.py
+++ b/intelmq/tests/bots/experts/abusix/test_expert.py
@@ -10,19 +10,23 @@ from intelmq.bots.experts.abusix.expert import AbusixExpertBot
 EXAMPLE_INPUT = {"__type": "Event",
                  "source.ip": "93.184.216.34",  # example.com
                  "destination.ip": "192.0.43.8",  # iana.org
+                 "time.observation": "2015-01-01T00:00:00+00:00",
                  }
 EXAMPLE_OUTPUT = {"__type": "Event",
                   "source.ip": "93.184.216.34",
                   "destination.ip": "192.0.43.8",
                   "source.abuse_contact": "abuse@edgecast.com",
                   "destination.abuse_contact": "ops@icann.org",
+                  "time.observation": "2015-01-01T00:00:00+00:00",
                   }
 EXAMPLE_INPUT6 = {"__type": "Event",
                   "source.ip": "2001:500:88:200::7",  # iana.org
+                  "time.observation": "2015-01-01T00:00:00+00:00",
                   }
 EXAMPLE_OUTPUT6 = {"__type": "Event",
                    "source.ip": "2001:500:88:200::7",
                    "source.abuse_contact": "ops@icann.org",
+                   "time.observation": "2015-01-01T00:00:00+00:00",
                    }
 
 
@@ -39,13 +43,13 @@ class TestAbusixExpertBot(test.BotTestCase, unittest.TestCase):
     def test_ipv4_lookup(self):
         self.input_message = json.dumps(EXAMPLE_INPUT)
         self.run_bot()
-        self.assertEventAlmostEqual(0, EXAMPLE_OUTPUT)
+        self.assertMessageEqual(0, EXAMPLE_OUTPUT)
 
     @unittest.expectedFailure
     def test_ipv6_lookup(self):
         self.input_message = json.dumps(EXAMPLE_INPUT6)
         self.run_bot()
-        self.assertEventAlmostEqual(0, EXAMPLE_OUTPUT6)
+        self.assertMessageEqual(0, EXAMPLE_OUTPUT6)
 
 if __name__ == '__main__':
     unittest.main()

--- a/intelmq/tests/bots/experts/asn_lookup/test_expert.py
+++ b/intelmq/tests/bots/experts/asn_lookup/test_expert.py
@@ -17,6 +17,7 @@ from intelmq.bots.experts.asn_lookup.expert import ASNLookupExpertBot
 EXAMPLE_INPUT = {"__type": "Event",
                  "source.ip": "93.184.216.34",  # example.com
                  "destination.ip": "192.0.43.8",  # iana.org
+                 "time.observation": "2015-01-01T00:00:00+00:00",
                  }
 EXAMPLE_OUTPUT = {"__type": "Event",
                   "source.ip": "93.184.216.34",
@@ -25,14 +26,17 @@ EXAMPLE_OUTPUT = {"__type": "Event",
                   "destination.ip": "192.0.43.8",
                   "destination.asn": "16876",
                   "destination.bgp_prefix": "192.0.43.0/24",
+                  "time.observation": "2015-01-01T00:00:00+00:00",
                   }
 EXAMPLE_INPUT6 = {"__type": "Event",
                   "source.ip": "2001:500:88:200::7",  # iana.org
+                  "time.observation": "2015-01-01T00:00:00+00:00",
                   }
 EXAMPLE_OUTPUT6 = {"__type": "Event",
                    "source.ip": "2001:500:88:200::7",
                    "source.asn": "16876",
                    "source.bgp_prefix": "2001:500:88::/48",
+                   "time.observation": "2015-01-01T00:00:00+00:00",
                    }
 
 
@@ -51,13 +55,13 @@ class TestASNLookupExpertBot(test.BotTestCase, unittest.TestCase):
     def test_ipv4_lookup(self):
         self.input_message = json.dumps(EXAMPLE_INPUT)
         self.run_bot()
-        self.assertEventAlmostEqual(0, EXAMPLE_OUTPUT)
+        self.assertMessageEqual(0, EXAMPLE_OUTPUT)
 
     @unittest.expectedFailure
     def test_ipv6_lookup(self):
         self.input_message = json.dumps(EXAMPLE_INPUT6)
         self.run_bot()
-        self.assertEventAlmostEqual(0, EXAMPLE_OUTPUT6)
+        self.assertMessageEqual(0, EXAMPLE_OUTPUT6)
 
 
 if __name__ == '__main__':

--- a/intelmq/tests/bots/experts/cymru_whois/test_expert.py
+++ b/intelmq/tests/bots/experts/cymru_whois/test_expert.py
@@ -9,6 +9,7 @@ from intelmq.bots.experts.cymru_whois.expert import CymruExpertBot
 
 EXAMPLE_INPUT = {"__type": "Event",
                  "source.ip": "93.184.216.34",  # example.com
+                 "time.observation": "2015-01-01T00:00:00+00:00",
                  }
 EXAMPLE_OUTPUT = {"__type": "Event",
                   "source.ip": "93.184.216.34",
@@ -18,9 +19,11 @@ EXAMPLE_OUTPUT = {"__type": "Event",
                   "source.allocated": "2008-06-02",
                   "source.asn": "15133",
                   "source.as_name": "EDGECAST - EdgeCast Networks, Inc.,US",
+                  "time.observation": "2015-01-01T00:00:00+00:00",
                   }
 EXAMPLE_INPUT6 = {"__type": "Event",
                   "destination.ip": "2001:500:88:200::8",  # iana.org
+                  "time.observation": "2015-01-01T00:00:00+00:00",
                   }
 EXAMPLE_OUTPUT6 = {"__type": "Event",
                    "destination.ip": "2001:500:88:200::8",  # iana.org
@@ -30,6 +33,7 @@ EXAMPLE_OUTPUT6 = {"__type": "Event",
                    "destination.geolocation.cc": "US",
                    "destination.asn": "16876",
                    "destination.bgp_prefix": "2001:500:88::/48",
+                   "time.observation": "2015-01-01T00:00:00+00:00",
                    }
 
 
@@ -46,12 +50,12 @@ class TestCymruExpertBot(test.BotTestCase, unittest.TestCase):
     def test_ipv4_lookup(self):
         self.input_message = json.dumps(EXAMPLE_INPUT)
         self.run_bot()
-        self.assertEventAlmostEqual(0, EXAMPLE_OUTPUT)
+        self.assertMessageEqual(0, EXAMPLE_OUTPUT)
 
     def test_ipv6_lookup(self):
         self.input_message = json.dumps(EXAMPLE_INPUT6)
         self.run_bot()
-        self.assertEventAlmostEqual(0, EXAMPLE_OUTPUT6)
+        self.assertMessageEqual(0, EXAMPLE_OUTPUT6)
 
 
 if __name__ == '__main__':

--- a/intelmq/tests/bots/experts/reverse_dns/test_expert.py
+++ b/intelmq/tests/bots/experts/reverse_dns/test_expert.py
@@ -11,6 +11,7 @@ from intelmq.bots.experts.reverse_dns.expert import ReverseDnsExpertBot
 EXAMPLE_INPUT = {"__type": "Event",
                  "source.ip": "192.0.43.7",  # icann.org
                  "destination.ip": "192.0.43.8",  # iana.org
+                 "time.observation": "2015-01-01T00:00:00+00:00",
                  }
 EXAMPLE_OUTPUT = {"__type": "Event",
                   "source.ip": "192.0.43.7",
@@ -19,13 +20,16 @@ EXAMPLE_OUTPUT = {"__type": "Event",
                   "destination.reverse_domain_name": "icann.org.",
                   # manual verfication shows another result:
                   # "destination.reverse_domain_name": "43-8.any.icann.org.",
+                  "time.observation": "2015-01-01T00:00:00+00:00",
                   }
 EXAMPLE_INPUT6 = {"__type": "Event",
                   "source.ip": "2001:500:88:200::7",  # iana.org
+                  "time.observation": "2015-01-01T00:00:00+00:00",
                   }
 EXAMPLE_OUTPUT6 = {"__type": "Event",
                    "source.ip": "2001:500:88:200::7",
                    "source.reverse_domain_name": "",
+                   "time.observation": "2015-01-01T00:00:00+00:00",
                    }
 
 
@@ -42,13 +46,13 @@ class TestReverseDnsExpertBot(test.BotTestCase, unittest.TestCase):
     def test_ipv4_lookup(self):
         self.input_message = json.dumps(EXAMPLE_INPUT)
         self.run_bot()
-        self.assertEventAlmostEqual(0, EXAMPLE_OUTPUT)
+        self.assertMessageEqual(0, EXAMPLE_OUTPUT)
 
     @unittest.expectedFailure
     def test_ipv6_lookup(self):
         self.input_message = json.dumps(EXAMPLE_INPUT6)
         self.run_bot()
-        self.assertEventAlmostEqual(0, EXAMPLE_OUTPUT6)
+        self.assertMessageEqual(0, EXAMPLE_OUTPUT6)
 
 
 if __name__ == '__main__':

--- a/intelmq/tests/bots/experts/ripencc_abuse_contact/test_expert.py
+++ b/intelmq/tests/bots/experts/ripencc_abuse_contact/test_expert.py
@@ -11,18 +11,22 @@ from intelmq.bots.experts.ripencc_abuse_contact.expert import RIPENCCExpertBot
 EXAMPLE_INPUT = {"__type": "Event",
                  "source.ip": "93.184.216.34",  # example.com
                  "destination.ip": "192.0.43.8",  # iana.org, not in RIPENCC
+                 "time.observation": "2015-01-01T00:00:00+00:00",
                  }
 EXAMPLE_OUTPUT = {"__type": "Event",
                   "source.ip": "93.184.216.34",
                   "source.abuse_contact": "abuse@edgecast.com",
                   "destination.ip": "192.0.43.8",
+                  "time.observation": "2015-01-01T00:00:00+00:00",
                   }
 EXAMPLE_INPUT6 = {"__type": "Event",  # example.com
                   "source.ip": "2606:2800:220:1:248:1893:25c8:1946",
+                  "time.observation": "2015-01-01T00:00:00+00:00",
                   }
 EXAMPLE_OUTPUT6 = {"__type": "Event",
                    "source.ip": "2001:500:88:200::7",
                    "source.abuse_contact": "abuse@edgecast.com",
+                   "time.observation": "2015-01-01T00:00:00+00:00",
                    }
 
 
@@ -39,13 +43,13 @@ class TestRIPENCCExpertBot(test.BotTestCase, unittest.TestCase):
     def test_ipv4_lookup(self):
         self.input_message = json.dumps(EXAMPLE_INPUT)
         self.run_bot()
-        self.assertEventAlmostEqual(0, EXAMPLE_OUTPUT)
+        self.assertMessageEqual(0, EXAMPLE_OUTPUT)
 
     @unittest.expectedFailure
     def test_ipv6_lookup(self):
         self.input_message = json.dumps(EXAMPLE_INPUT6)
         self.run_bot()
-        self.assertEventAlmostEqual(0, EXAMPLE_OUTPUT6)
+        self.assertMessageEqual(0, EXAMPLE_OUTPUT6)
 
 
 if __name__ == '__main__':

--- a/intelmq/tests/bots/experts/taxonomy/test_expert.py
+++ b/intelmq/tests/bots/experts/taxonomy/test_expert.py
@@ -10,10 +10,12 @@ from intelmq.bots.experts.taxonomy.expert import TaxonomyExpertBot
 
 EXAMPLE_INPUT = {"__type": "Event",
                  "classification.type": "defacement",
+                 "time.observation": "2015-01-01T00:00:00+00:00",
                  }
 EXAMPLE_OUTPUT = {"__type": "Event",
                   "classification.type": "defacement",
                   "classification.taxonomy": "Intrusions",
+                  "time.observation": "2015-01-01T00:00:00+00:00",
                   }
 
 
@@ -30,7 +32,7 @@ class TestTaxonomyExpertBot(test.BotTestCase, unittest.TestCase):
     def test_classification(self):
         self.input_message = json.dumps(EXAMPLE_INPUT)
         self.run_bot()
-        self.assertEventAlmostEqual(0, EXAMPLE_OUTPUT)
+        self.assertMessageEqual(0, EXAMPLE_OUTPUT)
 
 
 if __name__ == '__main__':

--- a/intelmq/tests/bots/experts/tor_nodes/test_expert.py
+++ b/intelmq/tests/bots/experts/tor_nodes/test_expert.py
@@ -16,11 +16,13 @@ from intelmq.bots.experts.tor_nodes.expert import TorExpertBot
 EXAMPLE_INPUT = {"__type": "Event",
                  "source.ip": "37.130.227.133",
                  "destination.ip": "192.0.43.8",  # iana.org
+                 "time.observation": "2015-01-01T00:00:00+00:00",
                  }
 EXAMPLE_OUTPUT = {"__type": "Event",
                   "source.ip": "37.130.227.133",
                   "source.tor_node": "true",
                   "destination.ip": "192.0.43.8",
+                  "time.observation": "2015-01-01T00:00:00+00:00",
                   }
 
 
@@ -39,7 +41,7 @@ class TestTorExpertBot(test.BotTestCase, unittest.TestCase):
     def test_ipv4_lookup(self):
         self.input_message = json.dumps(EXAMPLE_INPUT)
         self.run_bot()
-        self.assertEventAlmostEqual(0, EXAMPLE_OUTPUT)
+        self.assertMessageEqual(0, EXAMPLE_OUTPUT)
 
 if __name__ == '__main__':
     unittest.main()

--- a/intelmq/tests/bots/parsers/malwaredomainlist/test_parser.py
+++ b/intelmq/tests/bots/parsers/malwaredomainlist/test_parser.py
@@ -16,6 +16,7 @@ EXAMPLE_REPORT = {"feed.name": "Malware Domain List",
                          "UmVnaXN0cmFyIEFidXNlIENvbnRhY3QgZG9tYWluYWJ1c2VAZXhh"
                          "bXBsZS5jb20iLCIwMDAwMCI=",
                   "__type": "Report",
+                  "time.observation": "2015-01-01T00:00:00+00:00",
                   }
 EXAMPLE_EVENT = {"feed.name": "Malware Domain List",
                  "feed.url": "http://www.malwaredomainlist.com/updatescsv.php",
@@ -33,6 +34,7 @@ EXAMPLE_EVENT = {"feed.name": "Malware Domain List",
                         "ZXhhbXBsZS5jb20uLFRyb2phbi5FeGFtcGxlLFJlZ2lzdHJhciBB"
                         "YnVzZSBDb250YWN0IGRvbWFpbmFidXNlQGV4YW1wbGUuY29tLDAw"
                         "MDAw",
+                 "time.observation": "2015-01-01T00:00:00+00:00",
                  }
 
 
@@ -49,7 +51,7 @@ class TestMalwareDomainListParserBot(test.BotTestCase, unittest.TestCase):
     def test_event(self):
         """ Test if correct Event has been produced. """
         self.run_bot()
-        self.assertEventAlmostEqual(0, EXAMPLE_EVENT)
+        self.assertMessageEqual(0, EXAMPLE_EVENT)
 
 
 if __name__ == '__main__':

--- a/intelmq/tests/bots/parsers/malwaregroup/test_parser_domains.py
+++ b/intelmq/tests/bots/parsers/malwaregroup/test_parser_domains.py
@@ -17,6 +17,7 @@ EXAMPLE_REPORT = {"feed.name": "MalwareGroup",
                   "feed.url": "http://www.malwaregroup.com/domains",
                   "raw": utils.base64_encode(EXAMPLE_FILE),
                   "__type": "Report",
+                  "time.observation": "2015-01-01T00:00:00+00:00",
                   }
 EXAMPLE_EVENT = {"feed.name": "MalwareGroup",
                  "feed.url": "http://www.malwaregroup.com/domains",
@@ -35,6 +36,7 @@ EXAMPLE_EVENT = {"feed.name": "MalwareGroup",
                         "Ij4xOTIuMC4yLjE8L2E+PC90ZD4gPHRkPlhBPC90ZD4gPHRkPjQ1"
                         "PC90ZD4gPHRkPjIwMTQtMDEtMDE8L3RkPiA8dGQ+MjAxNS0wMS0w"
                         "MTwvdGQ+PC90cj4=",
+                 "time.observation": "2015-01-01T00:00:00+00:00",
                  }
 
 
@@ -51,7 +53,7 @@ class TestMalwareGroupDomainsParserBot(test.BotTestCase, unittest.TestCase):
     def test_event(self):
         """ Test if correct Event has been produced. """
         self.run_bot()
-        self.assertEventAlmostEqual(0, EXAMPLE_EVENT)
+        self.assertMessageEqual(0, EXAMPLE_EVENT)
 
 
 if __name__ == '__main__':

--- a/intelmq/tests/bots/parsers/malwaregroup/test_parser_ips.py
+++ b/intelmq/tests/bots/parsers/malwaregroup/test_parser_ips.py
@@ -18,6 +18,7 @@ EXAMPLE_REPORT = {"feed.name": "MalwareGroup",
                   "feed.url": "http://www.malwaregroup.com/ipaddresses",
                   "raw": utils.base64_encode(EXAMPLE_FILE),
                   "__type": "Report",
+                  "time.observation": "2015-01-01T00:00:00+00:00",
                   }
 EXAMPLE_EVENT = {"feed.name": "MalwareGroup",
                  "feed.url": "http://www.malwaregroup.com/ipaddresses",
@@ -29,6 +30,7 @@ EXAMPLE_EVENT = {"feed.name": "MalwareGroup",
                         "jIuMSI+MTkyLjAuMi4xPC9hPjwvdGQ+IDx0ZD4xPC90ZD4gPHRkPl"
                         "NvbWUgQ291bnRyeTwvdGQ+IDx0ZD4tPC90ZD4gPHRkPjIwMTUtMDg"
                         "tMDE8L3RkPiA8dGQ+MjAxNS0wOC0wMTwvdGQ+PC90cj4=",
+                 "time.observation": "2015-01-01T00:00:00+00:00",
                  }
 
 
@@ -45,7 +47,7 @@ class TestMalwareGroupIPsParserBot(test.BotTestCase, unittest.TestCase):
     def test_event(self):
         """ Test if correct Event has been produced. """
         self.run_bot()
-        self.assertEventAlmostEqual(0, EXAMPLE_EVENT)
+        self.assertMessageEqual(0, EXAMPLE_EVENT)
 
 
 if __name__ == '__main__':

--- a/intelmq/tests/bots/parsers/malwaregroup/test_parser_proxies.py
+++ b/intelmq/tests/bots/parsers/malwaregroup/test_parser_proxies.py
@@ -17,6 +17,7 @@ EXAMPLE_REPORT = {"feed.name": "MalwareGroup",
                   "feed.url": "http://www.malwaregroup.com/proxies",
                   "raw": utils.base64_encode(EXAMPLE_FILE),
                   "__type": "Report",
+                  "time.observation": "2015-01-01T00:00:00+00:00",
                   }
 EXAMPLE_EVENT = {"feed.name": "MalwareGroup",
                  "feed.url": "http://www.malwaregroup.com/proxies",
@@ -30,6 +31,7 @@ EXAMPLE_EVENT = {"feed.name": "MalwareGroup",
                         "LjIuMSI+MTkyLjAuMi4xPC9hPjwvdGQ+IDx0ZD44MTwvdGQ+IDx0"
                         "ZD5YQTwvdGQ+IDx0ZD4tPC90ZD4gPHRkPjIwMTQtMDEtMjcgMDE6"
                         "MzM6MTA8L3RkPjwvdHI+",
+                 "time.observation": "2015-01-01T00:00:00+00:00",
                  }
 
 
@@ -46,7 +48,7 @@ class TestMalwareGroupProxiesParserBot(test.BotTestCase, unittest.TestCase):
     def test_event(self):
         """ Test if correct Event has been produced. """
         self.run_bot()
-        self.assertEventAlmostEqual(0, EXAMPLE_EVENT)
+        self.assertMessageEqual(0, EXAMPLE_EVENT)
 
 
 if __name__ == '__main__':

--- a/intelmq/tests/bots/parsers/urlvir/test_parser_hosts.py
+++ b/intelmq/tests/bots/parsers/urlvir/test_parser_hosts.py
@@ -17,13 +17,16 @@ EXAMPLE_REPORT = {"feed.url": "http://www.urlvir.com/export-hosts/",
                          "IyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIwpleGFt"
                          "cGxlLm5ldA==",
                   "__type": "Report",
-                  "feed.name": "URLVir"}
+                  "feed.name": "URLVir",
+                  "time.observation": "2015-01-01T00:00:00+00:00",
+                  }
 EXAMPLE_EVENT = {"feed.url": "http://www.urlvir.com/export-hosts/",
                  "feed.name": "URLVir",
                  "__type": "Event",
                  "source.fqdn": "example.net",
                  "classification.type": "malware",
                  "raw": "ZXhhbXBsZS5uZXQ=",
+                 "time.observation": "2015-01-01T00:00:00+00:00",
                  }
 
 
@@ -40,7 +43,7 @@ class TestURLVirHostsParserBot(test.BotTestCase, unittest.TestCase):
     def test_event(self):
         """ Test if correct Event has been produced. """
         self.run_bot()
-        self.assertEventAlmostEqual(0, EXAMPLE_EVENT)
+        self.assertMessageEqual(0, EXAMPLE_EVENT)
 
 
 if __name__ == '__main__':

--- a/intelmq/tests/bots/parsers/urlvir/test_parser_ips.py
+++ b/intelmq/tests/bots/parsers/urlvir/test_parser_ips.py
@@ -19,6 +19,7 @@ EXAMPLE_REPORT = {"feed.name": "URLVir",
                          "IyMjIyMjIyMjIyMjIyMjIyMjCjE5Mi4wLjIuMQoxOTIuMC4yLjIK"
                          "MTkyLjAuMi4zCjE5Mi4wLjIuNA==",
                   "__type": "Report",
+                  "time.observation": "2015-01-01T00:00:00+00:00",
                   }
 EXAMPLE_EVENT = {"feed.name": "URLVir",
                  "feed.url": "http://www.urlvir.com/export-ip-addresses/",
@@ -26,6 +27,7 @@ EXAMPLE_EVENT = {"feed.name": "URLVir",
                  "classification.type": "malware",
                  "__type": "Event",
                  "raw": "MTkyLjAuMi4x",
+                 "time.observation": "2015-01-01T00:00:00+00:00",
                  }
 
 
@@ -42,7 +44,7 @@ class TestURLVirIPsParserBot(test.BotTestCase, unittest.TestCase):
     def test_event(self):
         """ Test if correct Event has been produced. """
         self.run_bot()
-        self.assertEventAlmostEqual(0, EXAMPLE_EVENT)
+        self.assertMessageEqual(0, EXAMPLE_EVENT)
 
 
 if __name__ == '__main__':

--- a/intelmq/tests/bots/parsers/vxvault/test_parser.py
+++ b/intelmq/tests/bots/parsers/vxvault/test_parser.py
@@ -13,6 +13,7 @@ EXAMPLE_REPORT = {"feed.name": "VxVault",
                          "NSAxNDozNjoxOSArMDAwMAoKaHR0cDovL2V4YW1wbGUuY29tL2Jh"
                          "ZC9wcm9ncmFtLmV4ZQ==",
                   "__type": "Report",
+                  "time.observation": "2015-01-01T00:00:00+00:00",
                   }
 EXAMPLE_EVENT = {"feed.name": "VxVault",
                  "feed.url": "http://vxvault.siri-urz.net/URL_List.php",
@@ -22,6 +23,7 @@ EXAMPLE_EVENT = {"feed.name": "VxVault",
                  "__type": "Event",
                  "raw": "aHR0cDovL2V4YW1wbGUuY29tL2JhZC9wcm9ncmFtLmV4ZQ==",
                  "source.fqdn": "example.com",
+                 "time.observation": "2015-01-01T00:00:00+00:00",
                  }
 
 
@@ -38,7 +40,7 @@ class TestVXVaultParserBot(test.BotTestCase, unittest.TestCase):
     def test_event(self):
         """ Test if correct Event has been produced. """
         self.run_bot()
-        self.assertEventAlmostEqual(0, EXAMPLE_EVENT)
+        self.assertMessageEqual(0, EXAMPLE_EVENT)
 
 
 if __name__ == '__main__':

--- a/intelmq/tests/bots/test_dummy_bot.py
+++ b/intelmq/tests/bots/test_dummy_bot.py
@@ -32,7 +32,11 @@ class DummyParserBot(bot.Bot):
     """
 
     def process(self):
-        """ Passing through all information from Report to Event. """
+        """
+        Passing through all information from Report to Event.
+
+        Also logs a sample line, which will be tested afterwards.
+        """
         report = self.receive_message()
 
         if not report:
@@ -47,7 +51,6 @@ class DummyParserBot(bot.Bot):
 
         self.send_message(event)
         self.acknowledge_message()
-        self.error_retries_counter = 1
 
 
 class TestDummyParserBot(test.BotTestCase, unittest.TestCase):
@@ -58,18 +61,17 @@ class TestDummyParserBot(test.BotTestCase, unittest.TestCase):
     @classmethod
     def set_bot(cls):
         cls.bot_reference = DummyParserBot
-        cls.default_input_message = json.dumps(EXAMPLE_EVENT)
+        cls.default_input_message = json.dumps(EXAMPLE_REPORT)
 
     def test_log_test_line(self):
         """ Test if bot does log example message. """
         self.run_bot()
-        self.assertRegexpMatches(self.loglines_buffer,
-                                 "INFO - Lorem ipsum dolor sit amet")
+        self.assertRegexpMatchesLog("INFO - Lorem ipsum dolor sit amet")
 
     def test_event(self):
         """ Test if correct Event has been produced. """
         self.run_bot()
-        self.assertEventAlmostEqual(0, EXAMPLE_REPORT)
+        self.assertMessageEqual(0, EXAMPLE_EVENT)
 
 
 if __name__ == '__main__':

--- a/intelmq/tests/lib/test_bot.py
+++ b/intelmq/tests/lib/test_bot.py
@@ -45,7 +45,7 @@ def mocked_config(bot_id, src_name, dst_names, raise_on_connect):
 
 
 def mocked_logger(logger):
-    def log(path, name, level):
+    def log(name, log_path=None, log_level=None):
         return logger
     return log
 

--- a/intelmq/tests/lib/test_utils.py
+++ b/intelmq/tests/lib/test_utils.py
@@ -68,7 +68,8 @@ class TestUtils(unittest.TestCase):
         with tempfile.NamedTemporaryFile() as handle:
             filename = handle.name
             name = os.path.split(filename)[-1]
-            logger = utils.log(tempfile.tempdir, name, stream=io.StringIO())
+            logger = utils.log(name, log_path=tempfile.tempdir,
+                               stream=io.StringIO())
 
             logger.info(LINES['spare'][0])
             logger.error(LINES['spare'][1])
@@ -88,7 +89,7 @@ class TestUtils(unittest.TestCase):
         with tempfile.NamedTemporaryFile() as handle:
             filename = handle.name
             name = os.path.split(filename)[-1]
-            logger = utils.log(tempfile.tempdir, name, stream=stream)
+            logger = utils.log(name, log_path=tempfile.tempdir, stream=stream)
 
             logger.info(LINES['spare'][0])
             logger.error(LINES['spare'][1])


### PR DESCRIPTION
Updated User-Guide.md and Developement-Guide.md

time.observation is generated in collectors, not in parsers. Adjusted the code including the tests accordingly.

Switch parameters of utils.log: first (most important) os now name, log path is second with a default value.
