### PR TITLE
intelmqdump: Inspect dumps and reinject messages!

### DIFF
--- a/REQUIREMENTS
+++ b/REQUIREMENTS
@@ -14,5 +14,6 @@ pyzmq>=14.6.0
 redis>=2.10.3
 requests>=2.4.2
 six>=1.7
+python-termstyle>=0.1.10
 unicodecsv>=0.9.4
 xmpppy>=0.5.0rc1

--- a/REQUIREMENTS3
+++ b/REQUIREMENTS3
@@ -13,5 +13,6 @@ pyzmq>=14.6.0
 redis>=2.10.3
 requests>=2.4.2
 six>=1.7
+python-termstyle>=0.1.10
 unicodecsv>=0.9.4
 xmpppy>=0.5.0rc1

--- a/intelmq/bin/intelmqdump
+++ b/intelmq/bin/intelmqdump
@@ -1,17 +1,21 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from __future__ import print_function, unicode_literals
+
 import argparse
 import glob
 import io
 import json
+import os.path
 import pprint
 import six
 import sys
-import os.path
 
-from intelmq import DEFAULT_LOGGING_PATH
-
+import intelmq.lib.message as message
+import intelmq.lib.pipeline as pipeline
+import intelmq.lib.utils as utils
+from intelmq import DEFAULT_LOGGING_PATH, DEFAULTS_CONF_FILE, RUNTIME_CONF_FILE
+from termstyle import bold, inverted
 
 if sys.version_info[0] == 2:
     input = raw_input
@@ -87,11 +91,16 @@ if __name__ == '__main__':
                      for fname in filenames]
 
         length = max([len(value[1]) for value in filenames])
+        print(bold("{c:>3}: {s:{l}} {i}".format(c='id', s='name (bot id)',
+                                                i='content', l=length)))
         for count, (fname, shortname) in enumerate(filenames):
             info = dump_info(fname)
             print("{c:3}: {s:{l}} {i}".format(c=count, s=shortname, i=info,
                                               l=length))
-        botid = input('Which dump file to process (number or name)? ')
+        botid = input(inverted('Which dump file to process (id or name)? '))
+        botid = botid.strip()
+        if botid == 'q':
+            exit(0)
         try:
             fname, botid = filenames[int(botid)]
         except ValueError:
@@ -99,29 +108,30 @@ if __name__ == '__main__':
     else:
         botid = args.botid
         fname = os.path.join(DEFAULT_LOGGING_PATH, botid) + '.dump'
-        info = dump_info(fname)
 
     if not os.path.isfile(fname):
-        print('Given file does not exist: {}'.format(fname))
+        print(bold('Given file does not exist: {}'.format(fname)))
         exit(1)
     while True:
-        print ('Processing {}: {}'.format(botid, dump_info(fname)))
+        info = dump_info(fname)
+        print('Processing {}: {}'.format(bold(botid), info))
         try:
             with io.open(fname, 'rt') as handle:
                 content = json.load(handle)
             meta = load_meta(content)
         except ValueError as exc:
             available_opts = [item[0] for item in ACTIONS.values() if item[2]]
-            print('Could not load file: {}\nRestricted actions.'.format(exc))
+            print(bold('Could not load file: {}\nRestricted actions.'
+                       ''.format(exc)))
         else:
             available_opts = [item[0] for item in ACTIONS.values()]
             for count, line in enumerate(meta):
                 print('{:3}: {} {}'.format(count, *line))
-        answer = input(', '.join(available_opts) + '? ').strip()
+        answer = input(inverted(', '.join(available_opts) + '? ')).strip()
         if any([answer.startswith(char) for char in AVAILABLE_IDS]):
-            ids = [int(id) for id in answer[1:].split(',')]
-            print(ids)
+            ids = [int(item) for item in answer[1:].split(',')]
         if answer == 'a':
+            # recover all -> recover all by ids
             answer = 'r'
             ids = range(len(meta))
         if answer == 'q':
@@ -132,13 +142,53 @@ if __name__ == '__main__':
                 del content[meta[entry][0]]
             save_file(fname, content)
         elif answer.startswith('r'):
-            raise NotImplementedError
+            # recover entries
+            for key, entry in [item for (count, item)
+                               in enumerate(content.items()) if count in ids]:
+                if type(entry['message']) is dict:
+                    if '__type' in entry['message']:
+                        msg = json.dumps(entry['message'])
+                    # backwards compat: dumps had no type info
+                    elif '-parser' in entry['bot_id']:
+                        msg = message.Report(entry['message']).serialize()
+                    else:
+                        msg = message.Event(entry['message']).serialize()
+                elif issubclass(type(entry['message']), (six.binary_type,
+                                                         six.text_type)):
+                    msg = entry['message']
+                elif entry['message'] is None:
+                    print(bold('No message here, deleting directly.'))
+                    del content[key]
+                    save_file(fname, content)
+                    continue
+                else:
+                    print(bold('Unhandable type of message: {!r}'
+                               ''.format(type(entry['message']))))
+                    continue
+                print(entry['source_queue'])
+
+                default = utils.load_configuration(DEFAULTS_CONF_FILE)
+                runtime = utils.load_configuration(RUNTIME_CONF_FILE)
+                params = utils.load_parameters(default, runtime)
+                pipe = pipeline.PipelineFactory.create(params)
+                pipe.set_queues(entry['source_queue'], 'destination')
+                pipe.connect()
+                pipe.send(msg)
+                del content[key]
+                save_file(fname, content)
         elif answer.startswith('d'):
+            # delete dumpfile
             os.remove(fname)
+            print('Deleted file {}'.format(fname))
             break
         elif answer.startswith('s'):
-            for count, (key, value) in enumerate(content.iteritems()):
+            # Show entries by id
+            for count, (key, value) in enumerate(content.items()):
                 if count in ids:
                     print('='*100, '\nShowing id {} {}\n'.format(count, key),
                           '-'*50)
+                    if isinstance(type(value['message']), (six.binary_type,
+                                                           six.text_type)):
+                        value['message'] = json.loads(value['message'])
+                    value['traceback'] = value['traceback'].splitlines()
                     pprint.pprint(value)

--- a/intelmq/bin/intelmqdump
+++ b/intelmq/bin/intelmqdump
@@ -10,20 +10,26 @@ import os.path
 import pprint
 import six
 import sys
+import traceback
 
 import intelmq.lib.message as message
 import intelmq.lib.pipeline as pipeline
 import intelmq.lib.utils as utils
 from intelmq import DEFAULT_LOGGING_PATH, DEFAULTS_CONF_FILE, RUNTIME_CONF_FILE
-from termstyle import bold, inverted
+from termstyle import bold, inverted, red
 
 if sys.version_info[0] == 2:
     input = raw_input
 
 APPNAME = "intelmqdump"
 DESCRIPTION = """
-description: intelmqctl is the tool to control intelmq system."""
-USAGE = '''intelmqdump [botid]'''
+intelmqdump can inspect dumped messages, show, delete or reinject them into
+the pipeline. It's an interactive tool, directly start it to get a list
+of available dumps or call it with a knwon bot id as parameter.
+"""
+USAGE = '''
+    intelmqdump [botid]
+    intelmqdump [-h|--help]'''
 # shortcut: description, takes ids, available for corrupted files
 ACTIONS = {'r': ('(r)ecover by ids', True, False),
            'a': ('recover (a)ll', False, False),
@@ -36,21 +42,21 @@ AVAILABLE_IDS = [key for key, value in ACTIONS.items() if value[1]]
 
 
 def dump_info(fname):
-    info = 'defect'
+    info = red('unknwon error')
     try:
         handle = io.open(fname, 'rt')
     except OSError as exc:
-        info = 'unable to open file: {!s}'.format(exc)
+        info = red('unable to open file: {!s}'.format(exc))
     else:
         try:
             content = json.load(handle)
         except ValueError as exc:
-            info = 'unable to load JSON: {!s}'.format(exc)
+            info = red('unable to load JSON: {!s}'.format(exc))
         else:
             try:
                 info = "{!s} dumps".format(len(content.keys()))
             except AttributeError as exc:
-                info = "unable to count dumps: {!s}".format(exc)
+                info = red("unable to count dumps: {!s}".format(exc))
     finally:
         try:
             handle.close()
@@ -88,7 +94,7 @@ if __name__ == '__main__':
     if args.botid is None:
         filenames = glob.glob(os.path.join(DEFAULT_LOGGING_PATH, '*.dump'))
         filenames = [(fname, fname[len(DEFAULT_LOGGING_PATH):-5])
-                     for fname in filenames]
+                     for fname in sorted(filenames)]
 
         length = max([len(value[1]) for value in filenames])
         print(bold("{c:>3}: {s:{l}} {i}".format(c='id', s='name (bot id)',
@@ -121,8 +127,8 @@ if __name__ == '__main__':
             meta = load_meta(content)
         except ValueError as exc:
             available_opts = [item[0] for item in ACTIONS.values() if item[2]]
-            print(bold('Could not load file: {}\nRestricted actions.'
-                       ''.format(exc)))
+            print(bold('Could not load file:') + '\n{}\nRestricted actions.'
+                  ''.format(traceback.format_exc()))
         else:
             available_opts = [item[0] for item in ACTIONS.values()]
             for count, line in enumerate(meta):
@@ -187,8 +193,8 @@ if __name__ == '__main__':
                 if count in ids:
                     print('='*100, '\nShowing id {} {}\n'.format(count, key),
                           '-'*50)
-                    if isinstance(type(value['message']), (six.binary_type,
-                                                           six.text_type)):
+                    if isinstance(value['message'], (six.binary_type,
+                                                     six.text_type)):
                         value['message'] = json.loads(value['message'])
                     value['traceback'] = value['traceback'].splitlines()
                     pprint.pprint(value)

--- a/intelmq/bin/intelmqdump
+++ b/intelmq/bin/intelmqdump
@@ -1,9 +1,12 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from __future__ import print_function, unicode_literals
 import argparse
 import glob
 import io
 import json
+import pprint
+import six
 import sys
 import os.path
 
@@ -17,6 +20,15 @@ APPNAME = "intelmqdump"
 DESCRIPTION = """
 description: intelmqctl is the tool to control intelmq system."""
 USAGE = '''intelmqdump [botid]'''
+# shortcut: description, takes ids, available for corrupted files
+ACTIONS = {'r': ('(r)ecover by ids', True, False),
+           'a': ('recover (a)ll', False, False),
+           'e': ('delete (e)ntries', True, False),
+           'd': ('(d)elete file', False, True),
+           's': ('(s)how by ids', True, False),
+           'q': ('(q)uit', False, True),
+           }
+AVAILABLE_IDS = [key for key, value in ACTIONS.items() if value[1]]
 
 
 def dump_info(fname):
@@ -43,11 +55,18 @@ def dump_info(fname):
     return info
 
 
+def save_file(fname, content):
+    with open(fname, 'wt') as handle:
+        json.dump(content, handle)
+
+
 def load_meta(dump):
     retval = []
     for key, value in dump.items():
-        retval.append((key, value['traceback'].splitlines()[-1][:500]))
-        # TOOO: show end of traceback
+        error = value['traceback'].splitlines()[-1]
+        if len(error) > 200:
+            error = error[:100] + '...' + error[-100:]
+        retval.append((key, error))
     return retval
 
 
@@ -67,9 +86,11 @@ if __name__ == '__main__':
         filenames = [(fname, fname[len(DEFAULT_LOGGING_PATH):-5])
                      for fname in filenames]
 
+        length = max([len(value[1]) for value in filenames])
         for count, (fname, shortname) in enumerate(filenames):
             info = dump_info(fname)
-            print("{:3}: {} {}".format(count, shortname, info))
+            print("{c:3}: {s:{l}} {i}".format(c=count, s=shortname, i=info,
+                                              l=length))
         botid = input('Which dump file to process (number or name)? ')
         try:
             fname, botid = filenames[int(botid)]
@@ -80,14 +101,44 @@ if __name__ == '__main__':
         fname = os.path.join(DEFAULT_LOGGING_PATH, botid) + '.dump'
         info = dump_info(fname)
 
+    if not os.path.isfile(fname):
+        print('Given file does not exist: {}'.format(fname))
+        exit(1)
     while True:
-        print ('Processing {}: {}'.format(botid, info))
-        with io.open(fname, 'rt') as handle:
-            content = json.load(handle)
-        for count, line in enumerate(load_meta(content)):
-            print('{:3}: {} {}'.format(count, *line))
-        answer = input('(r)ecover by ids, recover (a)ll, delete (e)ntries, (d)elete file, (s)how by ids? ')
-        if any([answer.startswith(char) for char in ('r', 'd', 's')]):
+        print ('Processing {}: {}'.format(botid, dump_info(fname)))
+        try:
+            with io.open(fname, 'rt') as handle:
+                content = json.load(handle)
+            meta = load_meta(content)
+        except ValueError as exc:
+            available_opts = [item[0] for item in ACTIONS.values() if item[2]]
+            print('Could not load file: {}\nRestricted actions.'.format(exc))
+        else:
+            available_opts = [item[0] for item in ACTIONS.values()]
+            for count, line in enumerate(meta):
+                print('{:3}: {} {}'.format(count, *line))
+        answer = input(', '.join(available_opts) + '? ').strip()
+        if any([answer.startswith(char) for char in AVAILABLE_IDS]):
             ids = [int(id) for id in answer[1:].split(',')]
             print(ids)
-
+        if answer == 'a':
+            answer = 'r'
+            ids = range(len(meta))
+        if answer == 'q':
+            break
+        elif answer.startswith('e'):
+            # Delete entries
+            for entry in ids:
+                del content[meta[entry][0]]
+            save_file(fname, content)
+        elif answer.startswith('r'):
+            raise NotImplementedError
+        elif answer.startswith('d'):
+            os.remove(fname)
+            break
+        elif answer.startswith('s'):
+            for count, (key, value) in enumerate(content.iteritems()):
+                if count in ids:
+                    print('='*100, '\nShowing id {} {}\n'.format(count, key),
+                          '-'*50)
+                    pprint.pprint(value)

--- a/intelmq/bin/intelmqdump
+++ b/intelmq/bin/intelmqdump
@@ -1,0 +1,93 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+import argparse
+import glob
+import io
+import json
+import sys
+import os.path
+
+from intelmq import DEFAULT_LOGGING_PATH
+
+
+if sys.version_info[0] == 2:
+    input = raw_input
+
+APPNAME = "intelmqdump"
+DESCRIPTION = """
+description: intelmqctl is the tool to control intelmq system."""
+USAGE = '''intelmqdump [botid]'''
+
+
+def dump_info(fname):
+    info = 'defect'
+    try:
+        handle = io.open(fname, 'rt')
+    except OSError as exc:
+        info = 'unable to open file: {!s}'.format(exc)
+    else:
+        try:
+            content = json.load(handle)
+        except ValueError as exc:
+            info = 'unable to load JSON: {!s}'.format(exc)
+        else:
+            try:
+                info = "{!s} dumps".format(len(content.keys()))
+            except AttributeError as exc:
+                info = "unable to count dumps: {!s}".format(exc)
+    finally:
+        try:
+            handle.close()
+        except NameError:
+            pass
+    return info
+
+
+def load_meta(dump):
+    retval = []
+    for key, value in dump.items():
+        retval.append((key, value['traceback'].splitlines()[-1][:500]))
+        # TOOO: show end of traceback
+    return retval
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        prog=APPNAME,
+        usage=USAGE,
+        epilog=DESCRIPTION
+    )
+
+    parser.add_argument('botid', metavar='botid', nargs='?',
+                        default=None, help='botid to inspect dumps of')
+    args = parser.parse_args()
+
+    if args.botid is None:
+        filenames = glob.glob(os.path.join(DEFAULT_LOGGING_PATH, '*.dump'))
+        filenames = [(fname, fname[len(DEFAULT_LOGGING_PATH):-5])
+                     for fname in filenames]
+
+        for count, (fname, shortname) in enumerate(filenames):
+            info = dump_info(fname)
+            print("{:3}: {} {}".format(count, shortname, info))
+        botid = input('Which dump file to process (number or name)? ')
+        try:
+            fname, botid = filenames[int(botid)]
+        except ValueError:
+            fname = os.path.join(DEFAULT_LOGGING_PATH, botid) + '.dump'
+    else:
+        botid = args.botid
+        fname = os.path.join(DEFAULT_LOGGING_PATH, botid) + '.dump'
+        info = dump_info(fname)
+
+    while True:
+        print ('Processing {}: {}'.format(botid, info))
+        with io.open(fname, 'rt') as handle:
+            content = json.load(handle)
+        for count, line in enumerate(load_meta(content)):
+            print('{:3}: {} {}'.format(count, *line))
+        answer = input('(r)ecover by ids, recover (a)ll, delete (e)ntries, (d)elete file, (s)how by ids? ')
+        if any([answer.startswith(char) for char in ('r', 'd', 's')]):
+            ids = [int(id) for id in answer[1:].split(',')]
+            print(ids)
+

--- a/intelmq/lib/bot.py
+++ b/intelmq/lib/bot.py
@@ -238,7 +238,6 @@ class Bot(object):
         self.last_message = self.current_message
         self.source_pipeline.acknowledge()
 
-    # FIXME: create load_message to re-insert events into pipeline
     def dump_message(self, ex):
         timestamp = datetime.datetime.utcnow()
         timestamp = timestamp.isoformat()
@@ -250,7 +249,11 @@ class Bot(object):
         new_dump_data[timestamp]["bot_id"] = self.bot_id
         new_dump_data[timestamp]["source_queue"] = self.source_queues
         new_dump_data[timestamp]["traceback"] = traceback.format_exc(ex)
-        new_dump_data[timestamp]["message"] = self.current_message
+        if self.current_message is not None:
+            message = self.current_message.serialize()
+        else:
+            message = None
+        new_dump_data[timestamp]["message"] = message
 
         try:
             with open(dump_file, 'r') as fp:

--- a/intelmq/lib/utils.py
+++ b/intelmq/lib/utils.py
@@ -24,7 +24,8 @@ from intelmq import DEFAULT_LOGGING_PATH
 
 
 __all__ = ['decode', 'encode', 'base64_encode', 'base64_decode',
-           'load_configuration', 'log', 'reverse_readline', 'parse_logline']
+           'load_configuration', 'load_parameters', 'log', 'reverse_readline',
+           'parse_logline']
 
 # Used loglines format
 LOG_FORMAT = '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
@@ -35,6 +36,10 @@ LOG_REGEX = (r'^(?P<asctime>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d+) -'
              r' (?P<name>[-\w]+) - '
              r'(?P<levelname>[A-Z]+) - '
              r'(?P<message>.+)$')
+
+
+class Parameters(object):
+    pass
 
 
 def decode(text, encodings=("utf-8", ), force=False):
@@ -154,6 +159,27 @@ def load_configuration(configuration_filepath):
     with open(configuration_filepath, 'r') as fpconfig:
         config = json.loads(fpconfig.read())
     return config
+
+
+def load_parameters(*configs):
+    """
+    Load dictionaries into new Parameters() instance.
+
+    Parameters:
+    -----------
+    *configs : dict
+        Arbitrary number of dictionaries to load.
+
+    Returns:
+    --------
+    parameters : Parameters
+        class instance with items of configs as attributes
+    """
+    parameters = Parameters()
+    for config in configs:
+        for option, value in config.items():
+            setattr(parameters, option, value)
+    return parameters
 
 
 def log(name, log_path=DEFAULT_LOGGING_PATH, log_level="DEBUG", stream=None):

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,7 @@ setup(
                  ),
                 ('/opt/intelmq/bin/', [
                                    'intelmq/bin/intelmqctl',
+                                   'intelmq/bin/intelmqdump',
                                    'intelmq/bin/intelmq_gen_harm_docs.py',
                                    'intelmq/bin/intelmq_psql_initdb.py',
                                   ],


### PR DESCRIPTION
New interactive tool to read and analyze dumped messages. Recover all or some of the dumped messages.

It lists all dumps, showing the counted messages in it, or corrupt files. Select the dump to process and have the choice to show a formatted version of the message, recover it, delete single messages from a dump file, etc.

Visual enhancements to the terminal (bold, inverted or red fonts) indicate important messages, inputs and errors!