### PR TITLE
several fixes: bugfixes, modify bot config, intelmqdump

### DIFF
--- a/docs/Bots.md
+++ b/docs/Bots.md
@@ -346,6 +346,8 @@ The configuration is called `modify.conf` and looks like this:
 
 The dictionary in the first level holds sections, here called `Spamhaus Cert` to group the rulessets and for easier navigation. It holds another dictionary of rules, consisting of *conditions* and *actions*. The first matching rule is used. Conditions and actions are again dictionaries holding the field names of harmonization and have regex-expressions to existing values (condition) or new values (action). The rule conditions are merged with the default condition and the default action is applied if no rule matches.
 
+The default rule/action list may not exist. If the value is an empty string, the bot checks if the field does not exist. This is useful to apply default values for empty fields.
+
 #### Examples
 
 We have an event with `feed.name = Spamhaus Cert` and `malware.name = confickerab`. The expert loops over all sections in the file and enters section `Spamhaus Cert`. First, the default condition is checked, it matches! Ok, going on. Otherwise the expert would have continued to the next section. Now, iteration through the rules, the first is rule `conficker`. We combine the conditions of this rule with the default conditions, and both rules match! So we can apply the action, here `classification.identifier` is set to `conficker`, the trivial name.

--- a/docs/User-Guide.md
+++ b/docs/User-Guide.md
@@ -224,15 +224,43 @@ usage:
     intelmqdump [botid]
     intelmqdump [-h|--help]
 
+intelmqdump can inspect dumped messages, show, delete or reinject them into
+the pipeline. It's an interactive tool, directly start it to get a list of
+available dumps or call it with a known bot id as parameter.
+
 positional arguments:
   botid       botid to inspect dumps of
 
 optional arguments:
   -h, --help  show this help message and exit
 
-intelmqdump can inspect dumped messages, show, delete or reinject them into
-the pipeline. It's an interactive tool, directly start it to get a list of
-available dumps or call it with a knwon bot id as parameter.
+Interactive actions after a file has been selected:
+- r, Recover by IDs
+  > r id{,id} [queue name]
+  > r 3,4,6
+  > r 3,7,90 modify-expert-queue
+  The messages identified by a consecutive numbering will be stored in the
+  original queue or the given one and removed from the file.
+- a, Recover all
+  > a [queue name]
+  > a
+  > a modify-expert-queue
+  All messages in the opened file will be recovered to the stored or given
+  queue and removed from the file.
+- e, Delete entries by IDs
+  > e id{,id}
+  > e 3,5
+  The entries will be deleted from the dump file.
+- d, Delete file
+  > d
+  Delete the opened file as a whole.
+- s, Show by IDs
+  > s id{,id}
+  > s 0,4,5
+  Show the selected IP in a readable format. It's still a raw format from
+  repr, but with newlines for message and traceback.
+- q, Quit
+  > q
 
 $ intelmqdump
  id: name (bot id)                    content

--- a/intelmq/bin/intelmqdump
+++ b/intelmq/bin/intelmqdump
@@ -12,6 +12,7 @@ import six
 import sys
 import traceback
 
+import intelmq.lib.exceptions as exceptions
 import intelmq.lib.message as message
 import intelmq.lib.pipeline as pipeline
 import intelmq.lib.utils as utils
@@ -163,21 +164,24 @@ if __name__ == '__main__':
             available_opts = [item[0] for item in ACTIONS.values()]
             for count, line in enumerate(meta):
                 print('{:3}: {} {}'.format(count, *line))
-        answer = input(inverted(', '.join(available_opts) + '? ')).strip()
-        if any([answer.startswith(char) for char in AVAILABLE_IDS]):
-            ids = [int(item) for item in answer[1:].split(',')]
-        if answer == 'a':
+        answer = input(inverted(', '.join(available_opts) + '? ')).split()
+        if any([answer[0] == char for char in AVAILABLE_IDS]):
+            ids = [int(item) for item in answer[1].split(',')]
+        queue_name = None
+        if answer[0] == 'a':
             # recover all -> recover all by ids
-            answer = 'r'
+            answer[0] = 'r'
             ids = range(len(meta))
-        if answer == 'q':
+            if len(answer) > 1:
+                queue_name = answer[1]
+        if answer[0] == 'q':
             break
-        elif answer.startswith('e'):
+        elif answer[0] == 'e':
             # Delete entries
             for entry in ids:
                 del content[meta[entry][0]]
             save_file(fname, content)
-        elif answer.startswith('r'):
+        elif answer[0] == 'r':
             # recover entries
             for key, entry in [item for (count, item)
                                in enumerate(content.items()) if count in ids]:
@@ -207,24 +211,39 @@ if __name__ == '__main__':
                 runtime = utils.load_configuration(RUNTIME_CONF_FILE)
                 params = utils.load_parameters(default, runtime)
                 pipe = pipeline.PipelineFactory.create(params)
-                pipe.set_queues(entry['source_queue'], 'destination')
-                pipe.connect()
-                pipe.send(msg)
-                del content[key]
-                save_file(fname, content)
-        elif answer.startswith('d'):
+                if queue_name is None:
+                    if len(answer) == 2:
+                        queue_name = answer[2]
+                    else:
+                        queue_name = entry['source_queue']
+                try:
+                    pipe.set_queues(queue_name, 'destination')
+                    pipe.connect()
+                    pipe.send(msg)
+                except exceptions.PipelineError:
+                    print(red('Could not reinject into queue {}: {}'
+                              ''.format(queue_name, traceback.format_exc())))
+                else:
+                    del content[key]
+                    save_file(fname, content)
+        elif answer[0] == 'd':
             # delete dumpfile
             os.remove(fname)
             print('Deleted file {}'.format(fname))
             break
-        elif answer.startswith('s'):
+        elif answer[0] == 's':
             # Show entries by id
             for count, (key, value) in enumerate(content.items()):
-                if count in ids:
-                    print('='*100, '\nShowing id {} {}\n'.format(count, key),
-                          '-'*50)
-                    if isinstance(value['message'], (six.binary_type,
-                                                     six.text_type)):
-                        value['message'] = json.loads(value['message'])
-                    value['traceback'] = value['traceback'].splitlines()
-                    pprint.pprint(value)
+                if count not in ids:
+                    continue
+                print('=' * 100, '\nShowing id {} {}\n'.format(count, key),
+                      '-' * 50)
+                if isinstance(value['message'], (six.binary_type,
+                                                 six.text_type)):
+                    value['message'] = json.loads(value['message'])
+                    if ('raw' in value['message'] and
+                            len(value['message']['raw']) > 1000):
+                        value['message']['raw'] = value['message'][
+                            'raw'][:1000] + '...[truncated]'
+                value['traceback'] = value['traceback'].splitlines()
+                pprint.pprint(value)

--- a/intelmq/bin/intelmqdump
+++ b/intelmq/bin/intelmqdump
@@ -24,8 +24,36 @@ if sys.version_info[0] == 2:
 APPNAME = "intelmqdump"
 DESCRIPTION = """
 intelmqdump can inspect dumped messages, show, delete or reinject them into
-the pipeline. It's an interactive tool, directly start it to get a list
-of available dumps or call it with a knwon bot id as parameter.
+the pipeline. It's an interactive tool, directly start it to get a list of
+available dumps or call it with a known bot id as parameter."""
+EPILOG = """
+Interactive actions after a file has been selected:
+- r, Recover by IDs
+  > r id{,id} [queue name]
+  > r 3,4,6
+  > r 3,7,90 modify-expert-queue
+  The messages identified by a consecutive numbering will be stored in the
+  original queue or the given one and removed from the file.
+- a, Recover all
+  > a [queue name]
+  > a
+  > a modify-expert-queue
+  All messages in the opened file will be recovered to the stored or given
+  queue and removed from the file.
+- e, Delete entries by IDs
+  > e id{,id}
+  > e 3,5
+  The entries will be deleted from the dump file.
+- d, Delete file
+  > d
+  Delete the opened file as a whole.
+- s, Show by IDs
+  > s id{,id}
+  > s 0,4,5
+  Show the selected IP in a readable format. It's still a raw format from
+  repr, but with newlines for message and traceback.
+- q, Quit
+  > q
 """
 USAGE = '''
     intelmqdump [botid]
@@ -83,8 +111,10 @@ def load_meta(dump):
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(
         prog=APPNAME,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
         usage=USAGE,
-        epilog=DESCRIPTION
+        description=DESCRIPTION,
+        epilog=EPILOG,
     )
 
     parser.add_argument('botid', metavar='botid', nargs='?',

--- a/intelmq/bots/BOTS
+++ b/intelmq/bots/BOTS
@@ -82,7 +82,7 @@
             }
         },
         "BlockList.DE Apache": {
-            "description": "BlockList.DE Apache Collector is the bot responsible to get the report from source of information.",
+            "description": "BlockList.DE Apache Collector is the bot responsible to get the report from source of information. All IP addresses which have been reported within the last 48 hours as having run attacks on the service Apache, Apache-DDOS, RFI-Attacks. ",
             "module": "intelmq.bots.collectors.http.collector_http",
             "parameters": {
                 "feed": "BlockList.de",
@@ -91,7 +91,7 @@
             }
         },
         "BlockList.DE Bots": {
-            "description": "BlockList.DE Bots Collector is the bot responsible to get the report from source of information.",
+            "description": "BlockList.DE Bots Collector is the bot responsible to get the report from source of information. All IP addresses which have been reported within the last 48 hours as having run attacks attacks on the RFI-Attacks, REG-Bots, IRC-Bots or BadBots (BadBots = he has posted a Spam-Comment on a open Forum or Wiki).",
             "module": "intelmq.bots.collectors.http.collector_http",
             "parameters": {
                 "feed": "BlockList.de",
@@ -100,7 +100,7 @@
             }
         },
         "BlockList.DE Brute-force Login": {
-            "description": "BlockList.DE Brute-force Login Collector is the bot responsible to get the report from source of information.",
+            "description": "BlockList.DE Brute-force Login Collector is the bot responsible to get the report from source of information. All IPs which attacks Joomlas, Wordpress and other Web-Logins with Brute-Force Logins.",
             "module": "intelmq.bots.collectors.http.collector_http",
             "parameters": {
                 "feed": "BlockList.de",
@@ -109,7 +109,7 @@
             }
         },
         "BlockList.DE FTP": {
-            "description": "BlockList.DE FTP Collector is the bot responsible to get the report from source of information.",
+            "description": "BlockList.DE FTP Collector is the bot responsible to get the report from source of information. All IP addresses which have been reported within the last 48 hours for attacks on the Service FTP.",
             "module": "intelmq.bots.collectors.http.collector_http",
             "parameters": {
                 "feed": "BlockList.de",
@@ -118,7 +118,7 @@
             }
         },
         "BlockList.DE IMAP": {
-            "description": "BlockList.DE IMAP Collector is the bot responsible to get the report from source of information.",
+            "description": "BlockList.DE IMAP Collector is the bot responsible to get the report from source of information. All IP addresses which have been reported within the last 48 hours for attacks on the Service imap, sasl, pop3.....",
             "module": "intelmq.bots.collectors.http.collector_http",
             "parameters": {
                 "feed": "BlockList.de",
@@ -136,7 +136,7 @@
             }
         },
         "BlockList.DE Mail": {
-            "description": "BlockList.DE Mail Collector is the bot responsible to get the report from source of information.",
+            "description": "BlockList.DE Mail Collector is the bot responsible to get the report from source of information. All IP addresses which have been reported within the last 48 hours as having run attacks on the service Mail, Postfix.",
             "module": "intelmq.bots.collectors.http.collector_http",
             "parameters": {
                 "feed": "BlockList.de",
@@ -145,7 +145,7 @@
             }
         },
         "BlockList.DE SIP": {
-            "description": "BlockList.DE SIP Collector is the bot responsible to get the report from source of information.",
+            "description": "BlockList.DE SIP Collector is the bot responsible to get the report from source of information. All IP addresses that tried to login in a SIP-, VOIP- or Asterisk-Server and are inclueded in the IPs-List from http://www.infiltrated.net/ (Twitter).",
             "module": "intelmq.bots.collectors.http.collector_http",
             "parameters": {
                 "feed": "BlockList.de",
@@ -154,7 +154,7 @@
             }
         },
         "BlockList.DE SSH": {
-            "description": "BlockList.DE SSH Collector is the bot responsible to get the report from source of information.",
+            "description": "BlockList.DE SSH Collector is the bot responsible to get the report from source of information. All IP addresses which have been reported within the last 48 hours as having run attacks on the service SSH. ",
             "module": "intelmq.bots.collectors.http.collector_http",
             "parameters": {
                 "feed": "BlockList.de",
@@ -163,7 +163,7 @@
             }
         },
         "BlockList.DE Strong IPs": {
-            "description": "BlockList.DE Strong IPs Collector is the bot responsible to get the report from source of information.",
+            "description": "BlockList.DE Strong IPs Collector is the bot responsible to get the report from source of information. All IPs which are older then 2 month and have more then 5.000 attacks.",
             "module": "intelmq.bots.collectors.http.collector_http",
             "parameters": {
                 "feed": "BlockList.de",

--- a/intelmq/bots/BOTS
+++ b/intelmq/bots/BOTS
@@ -534,11 +534,11 @@
             }
         },
         "RFC 1918": {
-            "description": "RFC 1918 removes fields or discards events if an ip is invalid (local, reserved, documentation).",
+            "description": "RFC 1918 removes fields or discards events if an ip or domain is invalid (invalid, local, reserved, documentation). IP, FQDN and URL field names are supported.",
             "module": "intelmq.bots.experts.rfc1918.expert",
             "parameters": {
-                "fields": "destination.ip,source.ip",
-                "policy": "del,drop"
+                "fields": "destination.ip,source.ip,source.url",
+                "policy": "del,drop,drop"
             }
         },
         "RIPENCC": {

--- a/intelmq/bots/experts/modify/expert.py
+++ b/intelmq/bots/experts/modify/expert.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 """
 Modify Expert bot let's you manipulate all fields with a config file.
-
-
 """
 from __future__ import unicode_literals
 import re
@@ -18,6 +16,12 @@ def matches(event, *rules):
         condition.update(rule)
 
     for name, rule in condition.items():
+        # empty string means non-existant field
+        if rule == '':
+            if name in event:
+                return False
+            else:
+                continue
         if name not in event:
             return False
         if not re.search(rule, event[name]):
@@ -44,8 +48,8 @@ class ModifyExpertBot(Bot):
             return
 
         for section_id, section in self.config.items():
-            default_cond = section['__default'][0]
-            default_action = section['__default'][1]
+            default_cond = section.get('__default', [{}, {}])[0]
+            default_action = section.get('__default', [{}, {}])[1]
             if not matches(event, default_cond):
                 continue
 

--- a/intelmq/bots/experts/modify/modify.conf
+++ b/intelmq/bots/experts/modify/modify.conf
@@ -41,6 +41,63 @@
             "classification.identifier": "sality"
         }]
     },
+"Blocklist.de": {
+    "__default": [{
+            "feed.name": "^BlockList\\.de$",
+            "classification.identifier": ""
+        }, {
+        }],
+    "bots" : [{
+            "feed.url": "bots.txt$"
+        }, {
+            "classification.identifier": "spam"
+        }],
+    "bruteforcelogin" : [{
+            "feed.url": "bruteforcelogin.txt$"
+        }, {
+            "classification.identifier": "http"
+        }],
+    "ftp" : [{
+            "feed.url": "dtp.txt$"
+        }, {
+            "classification.identifier": "ftp"
+        }],
+    "imap" : [{
+            "feed.url": "imap.txt$"
+        }, {
+            "classification.identifier": "imap"
+        }],
+    "irc" : [{
+            "feed.url": "irc.txt$"
+        }, {
+            "classification.identifier": "irc"
+        }],
+    "sip" : [{
+            "feed.url": "sip.txt$"
+        }, {
+            "classification.identifier": "sip"
+        }],
+    "strongip" : [{
+            "feed.url": "strongips.txt$"
+        }, {
+            "classification.identifier": "blacklist"
+        }],
+    "smtp" : [{
+            "feed.url": "mail.txt$"
+        }, {
+            "classification.identifier": "smtp"
+        }],
+    "http" : [{
+            "feed.url": "apache.txt$"
+        }, {
+            "classification.identifier": "http"
+        }],
+    "ssh" : [{
+            "feed.url": "ssh.txt$"
+        }, {
+            "classification.identifier": "ssh"
+        }]
+    },
 "Spamhaus Cert": {
     "__default": [{
             "feed.name": "^Spamhaus Cert$",

--- a/intelmq/bots/experts/modify/modify.conf
+++ b/intelmq/bots/experts/modify/modify.conf
@@ -1,10 +1,5 @@
 {
-"Spamhaus Cert": {
-    "__default": [{
-            "feed.name": "^Spamhaus Cert$"
-        }, {
-            "classification.identifier": "{msg[malware.name]}"
-        }],
+"default": {
     "conficker": [{
             "malware.name": "^conficker(ab)?$"
         }, {
@@ -19,6 +14,39 @@
             "malware.name": "^gozi2?$"
         }, {
             "classification.identifier": "gozi"
+        }],
+    "zeus": [{
+            "malware.name": "^((p2p)?[Zz]eus(_p2p|_[Gg]ameover(_(us|US))?|VM)?|botnet_certtw)$"
+        }, {
+            "classification.identifier": "zeus"
+        }],
+    "brobot": [{
+            "malware.name": "^[Bb]robot(bsi|fbi|us)?$"
+        }, {
+            "classification.identifier": "brobot"
+        }],
+    "pushdo": [{
+            "malware.name": "^(all4family_|manual)?[Pp]ushdo$"
+        }, {
+            "classification.identifier": "pushdo"
+        }],
+    "citadel": [{
+            "malware.name": "^[Cc]itadel( certpl| MS|ch)?$"
+        }, {
+            "classification.identifier": "citadel"
+        }],
+    "sality": [{
+            "malware.name": "^[Ss]ality(_p2p)?$"
+        }, {
+            "classification.identifier": "sality"
+        }]
+    },
+"Spamhaus Cert": {
+    "__default": [{
+            "feed.name": "^Spamhaus Cert$",
+            "classification.identifier": ""
+        }, {
+            "classification.identifier": "{msg[malware.name]}"
         }]
     }
 }

--- a/intelmq/bots/parsers/blocklistde/parser.py
+++ b/intelmq/bots/parsers/blocklistde/parser.py
@@ -52,7 +52,9 @@ MAPPING = {
                                   "service SIP, VOIP, Asterisk",
     },
     "bots.txt": {
-        "classification.type": "botnet drone"  # TODO: description
+        "classification.type": "spam",
+        "event_description.text": "IP reported as having spammed on IRC, open "
+                                  "forums, wikis or registration forms.",
     },
     "strongips.txt": {
         "classification.type": "blacklist",

--- a/intelmq/bots/parsers/dragonresearchgroup/parser_ssh.py
+++ b/intelmq/bots/parsers/dragonresearchgroup/parser_ssh.py
@@ -44,7 +44,7 @@ class DragonResearchGroupSSHParserBot(Bot):
             event.add("classification.type", "brute-force")
             event.add("protocol.application", "ssh")
             event.add("protocol.transport", "tcp")
-            event.add("destination.port", "22")
+            event.add("destination.port", 22)
             event.add("raw", row, sanitize=True)
 
             self.send_message(event)

--- a/intelmq/lib/cache.py
+++ b/intelmq/lib/cache.py
@@ -39,3 +39,9 @@ class Cache():
         # backward compatibility (Redis v2.2)
         self.redis.setnx(key, value)
         self.redis.expire(key, self.ttl)
+
+    def flush(self):
+        """
+        Flushes the currently opened database by calling FLUSHDB.
+        """
+        self.redis.flushdb()

--- a/intelmq/lib/test.py
+++ b/intelmq/lib/test.py
@@ -21,6 +21,23 @@ import six
 from intelmq import PIPELINE_CONF_FILE, RUNTIME_CONF_FILE, SYSTEM_CONF_FILE
 
 
+BOT_CONFIG = {
+    "logging_level": "DEBUG",
+    "http_proxy":  None,
+    "https_proxy": None,
+    "broker": "pythonlist",
+    "rate_limit": 0,
+    "retry_delay": 0,
+    "error_retry_delay": 0,
+    "error_max_retries": 0,
+    "exit_on_stop": False,
+    "redis_cache_host": "localhost",
+    "redis_cache_port": 6379,
+    "redis_cache_db": 10,
+    "redis_cache_ttl": 10,
+}
+
+
 def mocked_config(bot_id='test-bot', src_name='', dst_names=(), sysconfig={}):
     def mock(conf_file):
         if conf_file == PIPELINE_CONF_FILE:
@@ -30,20 +47,7 @@ def mocked_config(bot_id='test-bot', src_name='', dst_names=(), sysconfig={}):
         elif conf_file == RUNTIME_CONF_FILE:
             return {bot_id: {}}
         elif conf_file == SYSTEM_CONF_FILE:
-            conf = {"logging_level": "DEBUG",
-                    "http_proxy":  None,
-                    "https_proxy": None,
-                    "broker": "pythonlist",
-                    "rate_limit": 0,
-                    "retry_delay": 0,
-                    "error_retry_delay": 0,
-                    "error_max_retries": 0,
-                    "exit_on_stop": False,
-                    "redis_cache_host": "localhost",
-                    "redis_cache_port": 6379,
-                    "redis_cache_db": "10",
-                    "redis_cache_ttl": 10,
-                    }
+            conf = BOT_CONFIG
             conf.update(sysconfig)
             return conf
         elif conf_file.startswith('/opt/intelmq/etc/'):

--- a/intelmq/tests/bots/experts/cymru_whois/test_expert.py
+++ b/intelmq/tests/bots/experts/cymru_whois/test_expert.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-import json
 import unittest
 
 import intelmq.lib.test as test
+from intelmq.lib.cache import Cache
 from intelmq.bots.experts.cymru_whois.expert import CymruExpertBot
 
 EXAMPLE_INPUT = {"__type": "Event",
@@ -76,6 +76,15 @@ class TestCymruExpertBot(test.BotTestCase, unittest.TestCase):
         self.input_message = UNICODE_INPUT
         self.run_bot()
         self.assertMessageEqual(0, UNICODE_OUTPUT)
+
+    @classmethod
+    def tearDownClass(cls):
+        cache = Cache(test.BOT_CONFIG['redis_cache_host'],
+                      test.BOT_CONFIG['redis_cache_port'],
+                      test.BOT_CONFIG['redis_cache_db'],
+                      test.BOT_CONFIG['redis_cache_ttl'],
+                      )
+        cache.flush()
 
 
 if __name__ == '__main__':

--- a/intelmq/tests/bots/experts/modify/test_expert.py
+++ b/intelmq/tests/bots/experts/modify/test_expert.py
@@ -21,15 +21,23 @@ EVENT_TEMPL = {"__type": "Event",
 INPUT = [{'malware.name': 'confickerab'},
          {'malware.name': 'gozi2'},
          {'malware.name': 'feodo'},
+         {'malware.name': 'zeus_gameover_us'},
+         {'malware.name': 'foobar', 'feed.name': 'Other Feed'},
          ]
 OUTPUT = [{'classification.identifier': 'conficker'},
           {'classification.identifier': 'gozi'},
           {'classification.identifier': 'feodo'},
+          {'classification.identifier': 'zeus'},
+          {'feed.name': 'Other Feed'}
           ]
-for event_in, event_out in zip(INPUT, OUTPUT):
-    event_in.update(EVENT_TEMPL)
-    event_out.update(event_in)
-    event_out.update(EVENT_TEMPL)
+for index in range(len(INPUT)):
+    copy1 = EVENT_TEMPL.copy()
+    copy2 = EVENT_TEMPL.copy()
+    copy1.update(INPUT[index])
+    copy2.update(INPUT[index])
+    copy2.update(OUTPUT[index])
+    INPUT[index] = copy1
+    OUTPUT[index] = copy2
 
 
 class TestModifyExpertBot(test.BotTestCase, unittest.TestCase):

--- a/intelmq/tests/bots/experts/reverse_dns/test_expert.py
+++ b/intelmq/tests/bots/experts/reverse_dns/test_expert.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 import unittest
 
 import intelmq.lib.test as test
+from intelmq.lib.cache import Cache
 from intelmq.bots.experts.reverse_dns.expert import ReverseDnsExpertBot
 
 EXAMPLE_INPUT = {"__type": "Event",
@@ -51,6 +52,14 @@ class TestReverseDnsExpertBot(test.BotTestCase, unittest.TestCase):
         self.run_bot()
         self.assertMessageEqual(0, EXAMPLE_OUTPUT6)
 
+    @classmethod
+    def tearDownClass(cls):
+        cache = Cache(test.BOT_CONFIG['redis_cache_host'],
+                      test.BOT_CONFIG['redis_cache_port'],
+                      test.BOT_CONFIG['redis_cache_db'],
+                      test.BOT_CONFIG['redis_cache_ttl'],
+                      )
+        cache.flush()
 
 if __name__ == '__main__':
     unittest.main()

--- a/intelmq/tests/bots/experts/reverse_dns/test_expert.py
+++ b/intelmq/tests/bots/experts/reverse_dns/test_expert.py
@@ -21,14 +21,13 @@ EXAMPLE_OUTPUT = {"__type": "Event",
                   "time.observation": "2015-01-01T00:00:00+00:00",
                   }
 EXAMPLE_INPUT6 = {"__type": "Event",
-                  "source.ip": "2001:500:88:200::7",  # iana.org
+                  "source.ip": "2001:500:88:200::8",  # iana.org
                   "time.observation": "2015-01-01T00:00:00+00:00",
                   }
 EXAMPLE_OUTPUT6 = {"__type": "Event",
-                   "source.ip": "2001:500:88:200::7",
-                   "source.reverse_dns": "",
+                   "source.ip": "2001:500:88:200::8",
+                   "source.reverse_dns": "iana.org.",
                    "time.observation": "2015-01-01T00:00:00+00:00",
-                   "source.reverse_dns": "",
                    }
 
 
@@ -47,7 +46,6 @@ class TestReverseDnsExpertBot(test.BotTestCase, unittest.TestCase):
         self.run_bot()
         self.assertMessageEqual(0, EXAMPLE_OUTPUT)
 
-    @unittest.expectedFailure
     def test_ipv6_lookup(self):
         self.input_message = EXAMPLE_INPUT6
         self.run_bot()

--- a/intelmq/tests/bots/experts/rfc1918/test_expert.py
+++ b/intelmq/tests/bots/experts/rfc1918/test_expert.py
@@ -19,9 +19,24 @@ OUTPUT1 = {"__type": "Event",
            "time.observation": "2015-01-01T00:00:00+00:00",
            }
 INPUT2 = {"__type": "Event",
-          "source.ip": "192.168.0.1",  #
+          "source.ip": "192.168.0.1",  # internal
           "time.observation": "2015-01-01T00:00:00+00:00",
           }
+INPUT_TLD = {"__type": "Event",
+             "source.fqdn": "sub.example.com",
+             "time.observation": "2015-01-01T00:00:00+00:00",
+             }
+INPUT_DOMAIN = {"__type": "Event",
+                "destination.fqdn": "sub.example.invalid",
+                "time.observation": "2015-01-01T00:00:00+00:00",
+                }
+OUTPUT_DOMAIN = {"__type": "Event",
+                 "time.observation": "2015-01-01T00:00:00+00:00",
+                 }
+INPUT_URL = {"__type": "Event",
+             "source.url": "http://sub.example.com/foo/bar",
+             "time.observation": "2015-01-01T00:00:00+00:00",
+             }
 
 
 class TestRFC1918ExpertBot(test.BotTestCase, unittest.TestCase):
@@ -32,8 +47,9 @@ class TestRFC1918ExpertBot(test.BotTestCase, unittest.TestCase):
     @classmethod
     def set_bot(self):
         self.bot_reference = RFC1918ExpertBot
-        self.sysconfig = {'fields': 'destination.ip,source.ip',
-                          'policy': 'del,drop',
+        self.sysconfig = {'fields': 'destination.ip,source.ip,source.fqdn,'
+                                    'destination.fqdn,source.url',
+                          'policy': 'del,drop,drop,del,drop',
                           }
         self.default_input_message = {'__type': 'Event'}
 
@@ -44,6 +60,21 @@ class TestRFC1918ExpertBot(test.BotTestCase, unittest.TestCase):
 
     def test_drop(self):
         self.input_message = INPUT2
+        self.run_bot()
+        self.assertOutputQueueLen(0)
+
+    def test_drop_tld(self):
+        self.input_message = INPUT_TLD
+        self.run_bot()
+        self.assertOutputQueueLen(0)
+
+    def test_del_domain(self):
+        self.input_message = INPUT_DOMAIN
+        self.run_bot()
+        self.assertMessageEqual(0, OUTPUT_DOMAIN)
+
+    def test_drop_url(self):
+        self.input_message = INPUT_URL
         self.run_bot()
         self.assertOutputQueueLen(0)
 


### PR DESCRIPTION
The fixes from the last week:

- intelmqdump truncates long raw fields
- intelmqdump can inject into arbitrary queues  by given name
- modify bot has more extensive default config (it's not special for any cert)
-  the RFC1918 bot can clean FQDNs and URLs
- the tests for cymru and reversedns clean the cache after finishing (caused problems because of identical keys)
- IPv6 test for reverse dns
- bugfix for #346