### PR TITLE
ENH: new error handling

### DIFF
--- a/docs/User-Guide.md
+++ b/docs/User-Guide.md
@@ -323,7 +323,7 @@ error handling, log options and pipeline configuration. Will be removed in
 * `pipeline.conf`: Defines source and destination queues per bot.
 * `BOTS`: Includes configuration hints for all bots. E.g. feed URLs or
 database connection parameters. Use this as a template for `startup.conf`
-and `runtime.conf`. Also read by the intelmq-manager.
+and `runtime.conf`. Also read by the IntelMQ Manager.
 
 To configure a new BOT, you need to define it first in `startup.conf`.
 Then do the configuration in `runtime.conf` using the bot if.
@@ -364,16 +364,16 @@ All bots inherits this configuration parameters and they can overwrite them usin
 #### Error Handling
 
 * **`error_log_message`** - in case of an error, this option will allows bot to write the message (report or event) in log file. Use the following values:
-    * **`true/false`** - write or not write message in log file
+    * **`true/false`** - write or not write current and last message in log file
 
 * **`error_log_exception`** - in case of an error, this option will allows bot to write the error exception in log file. Use the following values:
     * **`true/false`** - write or not write exception in log file
 
 * **`error_procedure`** - in case of an error, this option defines the procedure that bot will adopt. Use the following values:
 
-    * **`stop`** - stop bot after retry X times, defined in `error_max_retries` option with a delay between retries defined at `error_retry_delay` option. If bot reach `error_max_retries` value, bot will remove the message from pipeline and stop. If the option `error_dump_message` is enable, the bot will dump the removed message to the dump log.
+    * **`stop`** - stop bot after retry X times, defined in `error_max_retries` option with a delay between retries defined at `error_retry_delay` option. If bot reach `error_max_retries` value, bot will stop. If the option `error_dump_message` is enable and the error is not a pipeline error, the bot will remove message from pipeline and dump it to the dump log.
     
-    * **`pass`** - will pass to the next message after retry X times, removing from pipeline the current message. If the option `error_dump_message` is enable, the bot will dump the removed message to the dump log.
+    * **`pass`** - will pass to the next message after retry X times. If the error is not a pipeline error, the bot will remove the current message from pipeline and will process the next message. If the option `error_dump_message` is enable and the error is not a pipeline error, the bot will dump the removed message to the dump log. If the error is a pipeline error, bot will keep trying connect infinitely to pipeline.
 
 * **`error_max_retries`** - in case of an error and the value of the `error_procedure` option is `retry`, bot will try to start processing the current message X times defined at `error_max_retries` option. The value must be an `integer value`.
 

--- a/intelmq/conf/defaults.conf
+++ b/intelmq/conf/defaults.conf
@@ -1,12 +1,11 @@
 {
     "broker": "redis",
-    "error_procedure": "retry",
+    "error_procedure": "pass",
     "error_max_retries": 3,
     "error_log_message": true,
     "error_log_exception": true,
     "error_dump_message": true,
     "error_retry_delay": 15,
-    "exit_on_stop": true,
     "rate_limit": 0,
     "load_balance": false,
     "source_pipeline_host": "127.0.0.1",

--- a/intelmq/conf/runtime.conf
+++ b/intelmq/conf/runtime.conf
@@ -1,24 +1,12 @@
 {
     "malware-domain-list-collector": {
-        "error_procedure": "retry",
-        "error_retry_delay": 30,
-        "error_log_message": true,
-        "error_dump_message": true,
         "http_url": "http://www.malwaredomainlist.com/updatescsv.php",
         "feed": "Malware Domain List",
         "rate_limit": 3600
     },
     "malware-domain-list-parser": {
-        "error_procedure": "pass",
-        "error_retry_delay": 30,
-        "error_log_message": true,
-        "error_dump_message": true
     },
     "file-output": {
-        "error_procedure": "retry",
-        "error_retry_delay": 30,
-        "error_log_message": true,
-        "error_dump_message": true,
         "file": "/opt/intelmq/var/lib/bots/file-output/events.txt"
     }
 }

--- a/intelmq/lib/bot.py
+++ b/intelmq/lib/bot.py
@@ -95,10 +95,14 @@ class Bot(object):
                     starting = False
 
                 self.process()
+                self.error_retries_counter = 0  # reset counter
+
                 self.source_pipeline.sleep(self.parameters.rate_limit)
 
             except exceptions.PipelineError:
                 error_on_pipeline = True
+                error_traceback = traceback.format_exc()
+
                 if self.parameters.error_log_exception:
                     self.logger.exception('Pipeline failed.')
                 else:
@@ -106,6 +110,9 @@ class Bot(object):
                 self.disconnect_pipelines()
 
             except Exception:
+                error_on_message = True
+                error_traceback = traceback.format_exc()
+
                 if self.parameters.error_log_exception:
                     self.logger.exception("Bot has found a problem.")
                 else:
@@ -117,33 +124,45 @@ class Bot(object):
                     self.logger.info("Current Message(event): {!r}."
                                      "".format(self.current_message)[:500])
 
-                self.error_retries_counter += 1
-                if self.parameters.error_procedure == "retry":
-                    if (self.error_retries_counter >=
-                            self.parameters.error_max_retries):
-                        if self.parameters.error_dump_message:
-                            self.dump_message()
-                        self.acknowledge_message()
-                        self.stop()
-
-                    # when bot acknowledge the message, dont need to wait again
-                    error_on_message = True
-                else:
-                    if self.parameters.error_dump_message:
-                        self.dump_message()
-                    self.acknowledge_message()
-
             except KeyboardInterrupt:
                 self.logger.error("Received KeyboardInterrupt.")
                 self.stop()
                 break
 
             finally:
-                if (self.error_retries_counter >=
-                        self.parameters.error_max_retries and
-                        self.parameters.error_max_retries >= 0):
+                if self.parameters.testing:
                     self.stop()
                     break
+
+                if error_on_message or error_on_pipeline:
+                    self.error_retries_counter += 1
+
+                    # reached the maximum number of retries
+                    if (self.error_retries_counter >
+                            self.parameters.error_max_retries):
+
+                        if error_on_message:
+
+                            if self.parameters.error_dump_message:
+                                self.dump_message(error_traceback)
+
+                            # FIXME: if broker fails in this instant
+                            #        it will crash the bot
+                            #
+                            # remove message from pipeline
+                            self.acknowledge_message()
+
+                            # when bot acknowledge the message,
+                            # dont need to wait again
+                            error_on_message = False
+
+                        # error_procedure: stop
+                        if self.parameters.error_procedure == "stop":
+                            self.stop()
+
+                        # error_procedure: pass
+                        else:
+                            self.error_retries_counter = 0  # reset counter
 
     def stop(self):
         self.disconnect_pipelines()
@@ -153,7 +172,8 @@ class Bot(object):
         else:
             self.log_buffer.append(('info', 'Bot stopped.'))
             self.print_log_buffer()
-        if self.parameters.exit_on_stop:
+
+        if not self.parameters.testing:
             self.terminate()
 
     def terminate(self):
@@ -245,7 +265,11 @@ class Bot(object):
         self.last_message = self.current_message
         self.source_pipeline.acknowledge()
 
-    def dump_message(self):
+    def dump_message(self, error_traceback):
+        if self.current_message is None:
+            return
+
+        self.logger.info('Dumping message from pipeline to dump file.')
         timestamp = datetime.datetime.utcnow()
         timestamp = timestamp.isoformat()
 
@@ -255,12 +279,9 @@ class Bot(object):
         new_dump_data[timestamp] = dict()
         new_dump_data[timestamp]["bot_id"] = self.bot_id
         new_dump_data[timestamp]["source_queue"] = self.source_queues
-        new_dump_data[timestamp]["traceback"] = traceback.format_exc()
-        if self.current_message is not None:
-            message = self.current_message.serialize()
-        else:
-            message = None
-        new_dump_data[timestamp]["message"] = message
+        new_dump_data[timestamp]["traceback"] = error_traceback
+
+        new_dump_data[timestamp]["message"] = self.current_message.serialize()
 
         try:
             with open(dump_file, 'r') as fp:
@@ -272,10 +293,15 @@ class Bot(object):
         with open(dump_file, 'w') as fp:
             json.dump(dump_data, fp, indent=4, sort_keys=True)
 
+        self.logger.info('Message dumped.')
+        self.current_message = None
+
+
     def load_defaults_configuration(self):
         self.log_buffer.append(('debug', "Loading defaults configuration."))
         config = utils.load_configuration(DEFAULTS_CONF_FILE)
 
+        setattr(self.parameters, 'testing', False)
         setattr(self.parameters, 'logging_path', DEFAULT_LOGGING_PATH)
         setattr(self.parameters, 'logging_level', DEFAULT_LOGGING_LEVEL)
 

--- a/intelmq/lib/test.py
+++ b/intelmq/lib/test.py
@@ -30,7 +30,7 @@ BOT_CONFIG = {
     "retry_delay": 0,
     "error_retry_delay": 0,
     "error_max_retries": 0,
-    "exit_on_stop": False,
+    "testing": True,
     "redis_cache_host": "localhost",
     "redis_cache_port": 6379,
     "redis_cache_db": 10,

--- a/intelmq/tests/lib/test_bot.py
+++ b/intelmq/tests/lib/test_bot.py
@@ -38,7 +38,7 @@ def mocked_config(bot_id='', src_name='', dst_names=(),
                     "retry_delay": 0,
                     "error_retry_delay": 0,
                     "error_max_retries": 0,
-                    "exit_on_stop": False,
+                    "testing": True,
                     }
         elif conf_file.startswith('/opt/intelmq/etc/'):
             confname = os.path.join('conf/', os.path.split(conf_file)[-1])


### PR DESCRIPTION
**Notes:**
1. `error_traceback` variable is because in `finally:` section of the `try:except` is not possible to get the exception message through `traceback.format_exc()`. New approaches are welcome! :)
2. In case of pipeline error, the message will not be dumped because it stills saved on pipeline. I think the dumped message will not add extra value to the system in this specific situation.
3. This pull req keeps a bug which already exists (https://github.com/SYNchroACK/intelmq/blob/error_handling/intelmq/lib/bot.py#L149)
4. The new behavior of error handling is described in documentation. Feedback is welcome!

@sebix , your feedback on this is a must! :p Thank you.

fix #326 
fix #316 