### PR TITLE
ENH: malware.name - loosen regex

### DIFF
--- a/intelmq/conf/harmonization.conf
+++ b/intelmq/conf/harmonization.conf
@@ -147,7 +147,7 @@
         },
         "malware.name": {
             "description": "A malware family name in lower case.",
-            "regex": "^[-a-z0-9_ ]+$",
+            "regex": "^[-a-z0-9_ :.]+$",
             "type": "MalwareName"
         },
         "malware.version": {


### PR DESCRIPTION
Extended regex for malware name. Changes based on observation of incidents from N6.
More details available here: https://github.com/certtools/intelmq/issues/412