### PR TITLE
other is a valid eCSIRT II classification

### DIFF
--- a/intelmq/lib/harmonization.py
+++ b/intelmq/lib/harmonization.py
@@ -162,6 +162,7 @@ class ClassificationType(GenericType):
                       'phishing',
                       'vulnerable service',
                       'blacklist',
+                      'other',
                       'unknown'
                       ]
 


### PR DESCRIPTION
 according to 
https://www.enisa.europa.eu/activities/cert/support/incident-management/browsable/incident-handling-process/incident-taxonomy/existing-taxonomies

"other" is a valid classification. Add it.
