### PR TITLE
intelmq_psql_initdb.py JSON instead of String

### DIFF
--- a/intelmq/bin/intelmq_psql_initdb.py
+++ b/intelmq/bin/intelmq_psql_initdb.py
@@ -30,7 +30,7 @@ def main():
     for field in DATA.keys():
         value = DATA[field]
 
-        if value['type'] in ('String', 'Base64', 'URL', 'FQDN', 'JSON',
+        if value['type'] in ('String', 'Base64', 'URL', 'FQDN',
                              'MalwareName', 'ClassificationType'):
             dbtype = 'varchar({})'.format(value.get('length', 2000))
         elif value['type'] in ('IPAddress', 'IPNetwork'):
@@ -45,6 +45,8 @@ def main():
             dbtype = 'real'
         elif value['type'] == 'UUID':
             dbtype = 'UUID'
+        elif value['type'] == 'JSON':
+            dbtype = 'json'
         else:
             print('Unknow type {!r}, assuming varchar(2000) by default'
                   ''.format(value['type']))


### PR DESCRIPTION
Hey folks,

as already discussed in one of our phone calls, we suggest to move change from String to JSON for the data in the "Extra" field.

To do so, we modified the file in order to create database columns of type
json instead of string.

This should enhance the processing speed of data which is stored in the
extras column.

ATTENTION: This is a schema-alteration of the EventDB.
If data already exists in the EventDB it might be required, that data is
converted from string to json.
Refer to: http://www.postgresql.org/docs/9.2/static/datatype-json.html

This change requires a PostgreSQL 9.2 or higher.