### PR TITLE
Revised intelmqctl parameter sytnax

### DIFF
--- a/docs/User-Guide.md
+++ b/docs/User-Guide.md
@@ -374,31 +374,53 @@ See [IntelMQ Manager repository](https://github.com/certtools/intelmq-manager).
 ```bash
 # su - intelmq
 
-$ intelmqctl --h
+$ intelmqctl -h
 usage: 
-        intelmqctl --bot [start|stop|restart|status] --id=cymru-expert
-        intelmqctl --botnet [start|stop|restart|status]
-        intelmqctl --list [bots|queues]
+        intelmqctl [start|stop|restart|status] bot-id
+        intelmqctl [start|stop|restart|status]
+        intelmqctl list [bots|queues]
+        intelmqctl log bot-id [number-of-lines [log-level]]
+        intelmqctl clear queue-id
+
+Starting a bot:
+    intelmqctl start bot-id
+Stopping a bot:
+    intelmqctl stop bot-id
+Restarting a bot:
+    intelmqctl restart bot-id
+Get status of a bot:
+    intelmqctl status bot-id
+
+Starting the botnet (all bots):
+    intelmqctl start
+    etc.
+
+Get a list of all configured bots:
+    intelmqctl list bots
+
+Get a list of all queues:
+    intelmqctl list queues
+
+Clear a queue:
+    intelmqctl clear queue-id
+
+Get logs of a bot:
+    intelmqctl log bot-id [number-of-lines [log-level]]
+    Reads the last lines from bot log, or from system log if no bot ID was
+    given. Log level should be one of DEBUG, INFO, ERROR or CRITICAL.
+    Default is INFO. Number of lines defaults to 10, -1 gives all. Result
+    can be longer due to our logging format!
+
+positional arguments:
+  [start|stop|restart|status|list|clear|log]
+  parameter
 
 optional arguments:
   -h, --help            show this help message and exit
   -v, --version         show program's version number and exit
-  --id BOT_ID, -i BOT_ID
-                        bot ID
   --type {text,json}, -t {text,json}
-                        choose if it should return regular text or other forms
-                        of output
-  --log [log-level]:[number-of-lines], -l [log-level]:[number-of-lines]
-                        Reads the last lines from bot log, or from system log
-                        if no bot ID was given. Log level should be one of
-                        DEBUG, INFO, ERROR or CRTICAL. Default is INFO. Number
-                        of lines defaults to 10, -1 gives all. Reading from
-                        system log is not implemented yet.
-  --bot [start|stop|restart|status], -b [start|stop|restart|status]
-  --botnet [start|stop|restart|status], -n [start|stop|restart|status]
-  --list [bots|queues], -s [bots|queues]
-  --clear queue, -c queue
-                        Clears the given queue in broker
+                        choose if it should return regular text or other
+                        machine-readable
 
 description: intelmqctl is the tool to control intelmq system. Outputs are
 logged to /opt/intelmq/var/log/intelmqctl
@@ -406,7 +428,7 @@ logged to /opt/intelmq/var/log/intelmqctl
 
 #### Botnet Concept
 
-The botnet represents all currently configured bots. To get an overview which bots are running, use `intelmqctl -n status`or use IntelMQ Manager.
+The botnet represents all currently configured bots. To get an overview which bots are running, use `intelmqctl status`or use IntelMQ Manager.
 
 #### Forcing reset pipeline and cache (be careful)
 

--- a/docs/User-Guide.md
+++ b/docs/User-Guide.md
@@ -376,7 +376,7 @@ See [IntelMQ Manager repository](https://github.com/certtools/intelmq-manager).
 
 $ intelmqctl -h
 usage: 
-        intelmqctl [start|stop|restart|status] bot-id
+        intelmqctl [start|stop|restart|status|run] bot-id
         intelmqctl [start|stop|restart|status]
         intelmqctl list [bots|queues]
         intelmqctl log bot-id [number-of-lines [log-level]]
@@ -390,6 +390,9 @@ Restarting a bot:
     intelmqctl restart bot-id
 Get status of a bot:
     intelmqctl status bot-id
+
+Run a bot directly (blocking) for debugging purpose:
+    intelmqctl run bot-id
 
 Starting the botnet (all bots):
     intelmqctl start
@@ -412,7 +415,7 @@ Get logs of a bot:
     can be longer due to our logging format!
 
 positional arguments:
-  [start|stop|restart|status|list|clear|log]
+  [start|stop|restart|status|run|list|clear|log]
   parameter
 
 optional arguments:

--- a/intelmq/bin/intelmqctl.py
+++ b/intelmq/bin/intelmqctl.py
@@ -165,9 +165,40 @@ class IntelMQContoller():
 
         Outputs are logged to /opt/intelmq/var/log/intelmqctl"""
         USAGE = '''
-        intelmqctl --bot [start|stop|restart|status] --id=cymru-expert
-        intelmqctl --botnet [start|stop|restart|status]
-        intelmqctl --list [bots|queues]'''
+        intelmqctl [start|stop|restart|status] bot-id
+        intelmqctl [start|stop|restart|status]
+        intelmqctl list [bots|queues]
+        intelmqctl log bot-id [number-of-lines [log-level]]
+        intelmqctl clear queue-id
+
+Starting a bot:
+    intelmqctl start bot-id
+Stopping a bot:
+    intelmqctl stop bot-id
+Restarting a bot:
+    intelmqctl restart bot-id
+Get status of a bot:
+    intelmqctl status bot-id
+
+Starting the botnet (all bots):
+    intelmqctl start
+    etc.
+
+Get a list of all configured bots:
+    intelmqctl list bots
+
+Get a list of all queues:
+    intelmqctl list queues
+
+Clear a queue:
+    intelmqctl clear queue-id
+
+Get logs of a bot:
+    intelmqctl log bot-id [number-of-lines [log-level]]
+    Reads the last lines from bot log, or from system log if no bot ID was
+    given. Log level should be one of DEBUG, INFO, ERROR or CRITICAL.
+    Default is INFO. Number of lines defaults to 10, -1 gives all. Result
+    can be longer due to our logging format!'''
 
         parser = argparse.ArgumentParser(
             prog=APPNAME,
@@ -175,48 +206,23 @@ class IntelMQContoller():
             epilog=DESCRIPTION
         )
 
-        group = parser.add_mutually_exclusive_group()
-        group_list = group.add_mutually_exclusive_group()
-
         parser.add_argument('-v', '--version',
                             action='version', version=VERSION)
-        parser.add_argument('--id', '-i',
-                            dest='bot_id', default=None, help='bot ID')
         parser.add_argument('--type', '-t', choices=RETURN_TYPES,
                             default=RETURN_TYPES[0],
                             help='choose if it should return regular text or '
-                                 'other forms of output')
+                                 'other machine-readable')
 
-        group_list.add_argument('--log', '-l',
-                                metavar='[log-level]:[number-of-lines]',
-                                default=None,
-                                help='''Reads the last lines from bot log, or
-                                from system log if no bot ID was given.
-                                Log level should be one of DEBUG, INFO, ERROR
-                                or CRTICAL. Default is INFO.
-                                Number of lines defaults to 10, -1 gives all.
-
-                                Reading from system log is not implemented yet.
-                                ''')
-        group_list.add_argument('--bot', '-b',
-                                choices=['start', 'stop', 'restart', 'status'],
-                                metavar='[start|stop|restart|status]',
-                                default=None)
-        group_list.add_argument('--botnet', '-n',
-                                choices=['start', 'stop', 'restart', 'status'],
-                                metavar='[start|stop|restart|status]',
-                                default=None)
-        group_list.add_argument('--list', '-s',
-                                choices=['bots', 'queues'],
-                                metavar='[bots|queues]',
-                                default=None)
-        group_list.add_argument('--clear', '-c', metavar='queue', default=None,
-                                help='''Clears the given queue in broker''')
-
+        parser.add_argument('action',
+                            choices=['start', 'stop', 'restart', 'status',
+                                     'list', 'clear', 'help', 'log'],
+                            metavar='[start|stop|restart|status|list|clear|'
+                                    'log]')
+        parser.add_argument('parameter', nargs='*')
         self.args = parser.parse_args()
-
-        if len(sys.argv) == 1:
+        if self.args.action == 'help':
             parser.print_help()
+            exit(0)
 
         RETURN_TYPE = self.args.type
 
@@ -252,34 +258,34 @@ class IntelMQContoller():
         for option, value in config.items():
             setattr(self.parameters, option, value)
 
-    def auto_method_call(self, method):
-        inspect_members = inspect.getmembers(self)
-        for name, func in inspect_members:
-            if name.startswith(method):
-                return func
-
     def run(self):
         results = None
-        if self.args.bot:
-            method_name = "bot_" + self.args.bot
-            call_method = self.auto_method_call(method_name)
-            results = call_method(self.args.bot_id)
-
-        elif self.args.botnet:
-            method_name = "botnet_" + self.args.botnet
-            call_method = self.auto_method_call(method_name)
+        if self.args.action in ['start', 'restart', 'stop', 'status']:
+            if self.args.parameter:
+                method_name = "bot_" + self.args.action
+                call_method = getattr(self, method_name)
+                results = call_method(self.args.parameter)
+            else:
+                method_name = "botnet_" + self.args.action
+                call_method = getattr(self, method_name)
+                results = call_method()
+        elif self.args.action == 'list':
+            if self.args.parameter not in ['bots', 'queues']:
+                print("Second argument must be 'bots' or 'queues'.")
+                exit(2)
+            method_name = "list_" + self.args.parameter
+            call_method = getattr(self, method_name)
             results = call_method()
-
-        elif self.args.list:
-            method_name = "list_" + self.args.list
-            call_method = self.auto_method_call(method_name)
-            results = call_method()
-
-        elif self.args.log:
-            results = self.read_log(self.args.log, self.args.bot_id)
-
-        elif self.args.clear:
-            results = self.clear_queue(self.args.clear,)
+        elif self.args.action == 'log':
+            if not self.args.parameter:
+                print("You must give parameters for 'log'.")
+                exit(2)
+            results = self.read_log(*self.args.parameter)
+        elif self.args.action == 'clear':
+            if not self.args.parameter:
+                print("Queue name not given.")
+                exit(2)
+            results = self.clear_queue(self.args.parameter)
 
         if self.args.type == 'json':
             print(json.dumps(results))
@@ -458,36 +464,23 @@ class IntelMQContoller():
                          "".format(queue, traceback.format_exc()))
             return 'error'
 
-    def read_log(self, log_level, bot_id):
+    def read_log(self, bot_id, number_of_lines=10, log_level='INFO'):
         # TODO: Parse number of lines
-        split_log_level = log_level.split(':')
-
-        if len(split_log_level) != 2:
-            logger.error("Invalid parameter for log, defaulting to 'INFO:10'")
+        try:
+            number_of_lines = int(number_of_lines)
+        except ValueError:
             number_of_lines = 10
+        if not log_level:
             log_level = LOG_LEVEL['INFO']
         else:
             try:
-                number_of_lines = int(split_log_level[1])
-            except ValueError:
-                number_of_lines = 10
-            if not len(split_log_level[0]):
-                log_level = LOG_LEVEL['INFO']
-            else:
-                try:
-                    log_level = LOG_LEVEL[split_log_level[0].upper()]
-                except KeyError:
-                    logger.error("Invalid log_level. Must be one of {}"
-                                 "".format(', '.join(LOG_LEVEL.keys())))
-                    return[]
+                log_level = LOG_LEVEL[log_level.upper()]
+            except KeyError:
+                logger.error("Invalid log_level. Must be one of {}"
+                             "".format(', '.join(LOG_LEVEL.keys())))
+                return[]
 
-        if bot_id is None:
-            return self.read_system_log(log_level, number_of_lines)
-        else:
-            return self.read_bot_log(bot_id, log_level, number_of_lines)
-
-    def read_system_log(self, log_level, number_of_lines):
-        logger.error("Reading from system log is not implemented yet")
+        return self.read_bot_log(bot_id, log_level, number_of_lines)
 
     def read_bot_log(self, bot_id, log_level, number_of_lines):
         bot_log_path = os.path.join(self.system['logging_path'],


### PR DESCRIPTION
As proposed in certtools/intelmq#474, this changes the syntax for intelmqctl.

Will provide fixes for intelmq-manager if there are no objections here.

```
$ intelmqctl -h
usage: 
        intelmqctl [start|stop|restart|status|run] bot-id
        intelmqctl [start|stop|restart|status]
        intelmqctl list [bots|queues]
        intelmqctl log bot-id [number-of-lines [log-level]]
        intelmqctl clear queue-id

Starting a bot:
    intelmqctl start bot-id
Stopping a bot:
    intelmqctl stop bot-id
Restarting a bot:
    intelmqctl restart bot-id
Get status of a bot:
    intelmqctl status bot-id

Run a bot directly (blocking) for debugging purpose:
    intelmqctl run bot-id

Starting the botnet (all bots):
    intelmqctl start
    etc.

Get a list of all configured bots:
    intelmqctl list bots

Get a list of all queues:
    intelmqctl list queues

Clear a queue:
    intelmqctl clear queue-id

Get logs of a bot:
    intelmqctl log bot-id [number-of-lines [log-level]]
    Reads the last lines from bot log, or from system log if no bot ID was
    given. Log level should be one of DEBUG, INFO, ERROR or CRITICAL.
    Default is INFO. Number of lines defaults to 10, -1 gives all. Result
    can be longer due to our logging format!

positional arguments:
  [start|stop|restart|status|run|list|clear|log]
  parameter

optional arguments:
  -h, --help            show this help message and exit
  -v, --version         show program's version number and exit
  --type {text,json}, -t {text,json}
                        choose if it should return regular text or other
                        machine-readable

description: intelmqctl is the tool to control intelmq system. Outputs are
logged to /opt/intelmq/var/log/intelmqctl
```