### PR TITLE
Added Classification.Type other to TAXONOMY Expert bot.

### DIFF
--- a/intelmq/bots/experts/taxonomy/expert.py
+++ b/intelmq/bots/experts/taxonomy/expert.py
@@ -26,6 +26,7 @@ TAXONOMY = {
     "blacklist": "Other",
     "unknown": "Other",
     "test": "Test",
+    "other": "Other"
 }
 
 


### PR DESCRIPTION
This Fixes https://github.com/certtools/intelmq/issues/525
I also checked if all other classification.types are available:
Result: Yes they are.