### PR TITLE
New parser's architecture, dumping of individual messages

### DIFF
--- a/docs/Developers-Guide.md
+++ b/docs/Developers-Guide.md
@@ -336,7 +336,68 @@ Parsers can use a different, specialized Bot-class. It allows to work on individ
 
 For common cases, like CSV, exisiting function can be used, reducing the amount of code to implement. In the best case, only `parse_line` needs to be coded, as only this part interprets the data.
 
-You can have a look at the implementation `intelmq/lib/bot.py` or at examples, e.g. the DummyBot in `intelmq/tests/bots/test_dummy_bot.py`
+You can have a look at the implementation `intelmq/lib/bot.py` or at examples, e.g. the DummyBot in `intelmq/tests/bots/test_dummy_bot.py`. This is a stub for creating a new Parser, showing the parameters and possible code:
+
+```python
+class MyParserBot(ParserBot):
+
+    def parse(self, report):
+        """
+        A generator yielding the single elements of the data.
+
+        Comments, headers etc. can be processed here. Data needed by
+        `self.parse_line` can be saved in `self.tempdata` (list).
+
+        Default parser yields stripped lines.
+        Override for your use or use an exisiting parser, e.g.:
+            parse = ParserBot.parse_csv
+        """
+        for line in utils.base64_decode(report.get("raw")).splitlines():
+            yield line.strip()
+
+    def parse_line(self, line, report):
+        """
+        A generator which can yield one or more messages contained in line.
+
+        Report has the full message, thus you can access some metadata.
+        Override for your use.
+        """
+        raise NotImplementedError
+
+    def process(self):
+        self.tempdata = []  # temporary data for parse, parse_line and recover_line
+        self.__failed = []
+        report = self.receive_message()
+
+        for line in self.parse(report):
+            if not line:
+                continue
+            try:
+                # filter out None
+                events = list(filter(bool, self.parse_line(line, report)))
+            except Exception as exc:
+                self.logger.exception('Failed to parse line.')
+                self.__failed.append((exc, line))
+            else:
+                self.send_message(*events)
+
+        for exc, line in self.__failed:
+            self._dump_message(exc, self.recover_line(line))
+
+        self.acknowledge_message()
+
+    def recover_line(self, line):
+        """
+        Reverse of parse for single lines.
+
+        Recovers a fully functional report with only the problematic line.
+        """
+        return '\n'.join(self.tempdata + [line])
+
+```
+
+#### parse_line
+One line can lead to multiple events, thus `parse_line` can't just return one Event. Thus, this function is a generator, which allows to easily return multple values. Use `yield event` for valid Events and `return` in case of a void result (not parseable line, invalid data etc.).
 
 ### Tests
 

--- a/docs/Developers-Guide.md
+++ b/docs/Developers-Guide.md
@@ -325,6 +325,19 @@ class ExampleParserBot(Bot):
 * Check [Expert Bots](../intelmq/bots/experts/)
 * Check [Parser Bots](../intelmq/bots/parsers/)
 
+### Parsers
+
+Parsers can use a different, specialized Bot-class. It allows to work on individual elements of a report, splitting the functionality of the parser into multiple functions:
+
+ * `process`: getting and sending data, handling of failures etc.
+ * `parse`: Parses the report and splits it into single elements (e.g. lines). Can be overridden.
+ * `parse_line`: Parses elements, returns an Event. Can be overridden.
+ * `recover_line`: In case of failures and for the field `raw`, this function recovers a fully functional report containing only one element. Can be overridden.
+
+For common cases, like CSV, exisiting function can be used, reducing the amount of code to implement. In the best case, only `parse_line` needs to be coded, as only this part interprets the data.
+
+You can have a look at the implementation `intelmq/lib/bot.py` or at examples, e.g. the DummyBot in `intelmq/tests/bots/test_dummy_bot.py`
+
 ### Tests
 
 In order to do automated tests on the bot, it is necessary to write tests including sample data. Have a look at some existing tests:

--- a/intelmq/bots/parsers/abusech/parser_domain.py
+++ b/intelmq/bots/parsers/abusech/parser_domain.py
@@ -23,7 +23,7 @@ SOURCE_FEEDS = {'https://feodotracker.abuse.ch/blocklist/?download=domainblockli
 class AbusechDomainParserBot(ParserBot):
     lastgenerated = None
 
-    def parseline(self, line, report):
+    def parse_line(self, line, report):
         if line.startswith('#'):
             self.tempdata.append(line)
             if 'Generated on' in line:
@@ -38,7 +38,7 @@ class AbusechDomainParserBot(ParserBot):
             event.add("malware.name", SOURCE_FEEDS[report["feed.url"]])
             yield event
 
-    def recoverline(self, line):
+    def recover_line(self, line):
         return '\n'.join(self.tempdata + [line])
 
 

--- a/intelmq/bots/parsers/abusech/parser_domain.py
+++ b/intelmq/bots/parsers/abusech/parser_domain.py
@@ -12,7 +12,7 @@ import sys
 
 import dateutil.parser
 
-from intelmq.lib.bot import Bot
+from intelmq.lib.bot import ParserBot
 from intelmq.lib.message import Event
 
 SOURCE_FEEDS = {'https://feodotracker.abuse.ch/blocklist/?download=domainblocklist': 'Cridex',
@@ -20,7 +20,7 @@ SOURCE_FEEDS = {'https://feodotracker.abuse.ch/blocklist/?download=domainblockli
                 'https://zeustracker.abuse.ch/blocklist.php?download=baddomains': 'Zeus'}
 
 
-class AbusechDomainParserBot(Bot):
+class AbusechDomainParserBot(ParserBot):
     lastgenerated = None
 
     def parseline(self, line, report):

--- a/intelmq/bots/parsers/abusech/parser_ip.py
+++ b/intelmq/bots/parsers/abusech/parser_ip.py
@@ -23,7 +23,7 @@ SOURCE_FEEDS = {'https://feodotracker.abuse.ch/blocklist/?download=ipblocklist':
 class AbusechIPParserBot(ParserBot):
     lastgenerated = None
 
-    def parseline(self, line, report):
+    def parse_line(self, line, report):
         if line.startswith('#'):
             self.tempdata.append(line)
             if 'Generated on' in line:
@@ -38,7 +38,7 @@ class AbusechIPParserBot(ParserBot):
             event.add("malware.name", SOURCE_FEEDS[report["feed.url"]])
             yield event
 
-    def recoverline(self, line):
+    def recover_line(self, line):
         return '\n'.join(self.tempdata + [line])
 
 

--- a/intelmq/bots/parsers/abusech/parser_ip.py
+++ b/intelmq/bots/parsers/abusech/parser_ip.py
@@ -12,7 +12,7 @@ import sys
 
 import dateutil
 
-from intelmq.lib.bot import Bot
+from intelmq.lib.bot import ParserBot
 from intelmq.lib.message import Event
 
 SOURCE_FEEDS = {'https://feodotracker.abuse.ch/blocklist/?download=ipblocklist': 'Cridex',
@@ -20,7 +20,7 @@ SOURCE_FEEDS = {'https://feodotracker.abuse.ch/blocklist/?download=ipblocklist':
                 'https://zeustracker.abuse.ch/blocklist.php?download=badips': 'Zeus'}
 
 
-class AbusechIPParserBot(Bot):
+class AbusechIPParserBot(ParserBot):
     lastgenerated = None
 
     def parseline(self, line, report):

--- a/intelmq/bots/parsers/abusech/parser_ip.py
+++ b/intelmq/bots/parsers/abusech/parser_ip.py
@@ -12,7 +12,6 @@ import sys
 
 import dateutil
 
-from intelmq.lib import utils
 from intelmq.lib.bot import Bot
 from intelmq.lib.message import Event
 
@@ -22,34 +21,25 @@ SOURCE_FEEDS = {'https://feodotracker.abuse.ch/blocklist/?download=ipblocklist':
 
 
 class AbusechIPParserBot(Bot):
+    lastgenerated = None
 
-    def process(self):
-        report = self.receive_message()
-
-        raw_report = utils.base64_decode(report.get("raw"))
-        lastgenerated = None
-
-        for row in raw_report.splitlines():
+    def parseline(self, line, report):
+        if line.startswith('#'):
+            self.tempdata.append(line)
+            if 'Generated on' in line:
+                row = line.strip('# ')[13:]
+                self.lastgenerated = dateutil.parser.parse(row).isoformat()
+        else:
             event = Event(report)
-
-            row = row.strip()
-            if len(row) == 0:
-                continue
-            elif row.startswith("#"):
-                if 'Generated on' in row:
-                    row = row.strip('# ')[13:]
-                    lastgenerated = dateutil.parser.parse(row).isoformat()
-                continue
-
-            event.add('time.source', lastgenerated)
-
-            event.add('source.ip', row)
+            event.add('time.source', self.lastgenerated)
             event.add('classification.type', 'c&c')
-            event.add("raw", row)
-            event.add("malware.name", SOURCE_FEEDS[report.get("feed.url")])
+            event.add('source.ip', line)
+            event.add("raw", line)
+            event.add("malware.name", SOURCE_FEEDS[report["feed.url"]])
+            yield event
 
-            self.send_message(event)
-        self.acknowledge_message()
+    def recoverline(self, line):
+        return '\n'.join(self.tempdata + [line])
 
 
 if __name__ == "__main__":

--- a/intelmq/bots/parsers/alienvault/parser.py
+++ b/intelmq/bots/parsers/alienvault/parser.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 import sys
 
-from intelmq.lib import utils
 from intelmq.lib.bot import Bot
 from intelmq.lib.message import Event
 
@@ -18,60 +17,46 @@ CLASSIFICATION = {
 
 class AlienVaultParserBot(Bot):
 
-    def process(self):
-        report = self.receive_message()
-        if (report is None or not report.contains("raw") or
-                len(report.get("raw").strip()) == 0):
-            self.acknowledge_message()
-            return
+    def parseline(self, row, report):
+        values = row.split("#")
 
-        raw_report = utils.base64_decode(report.get("raw"))
+        # Send one event per classification
+        classification_types = list()
+        if values[3].strip().find(";") > 0:
+            classification_types.extend(values[3].split(";"))
+        else:
+            classification_types.append(values[3])
 
-        for row in raw_report.splitlines():
+        for ctype in classification_types:
 
-            row = row.strip()
-            if len(row) == 0:
-                continue
+            event = Event(report)
 
-            values = row.split("#")
-
-            # Send one event per classification
-            classification_types = list()
-            if values[3].strip().find(";") > 0:
-                classification_types.extend(values[3].split(";"))
+            if ctype.lower() in CLASSIFICATION:
+                event.add('classification.type',
+                          CLASSIFICATION[ctype.lower()])
             else:
-                classification_types.append(values[3])
+                event.add('classification.type', "unknown")
 
-            for ctype in classification_types:
+            if len(values[6].strip()) > 0:
+                geo_coordinates = values[6].strip().split(",")
+                if len(geo_coordinates) == 2:
+                    geo_latitude = geo_coordinates[0]
+                    geo_longitude = geo_coordinates[1]
 
-                event = Event(report)
+            event.add('source.ip', values[0].strip())
+            event.add('source.geolocation.cc',
+                      values[4].strip())
+            event.add('source.geolocation.city',
+                      values[5].strip())
+            event.add('source.geolocation.latitude',
+                      geo_latitude.strip())
+            event.add('source.geolocation.longitude',
+                      geo_longitude.strip())
 
-                if ctype.lower() in CLASSIFICATION:
-                    event.add('classification.type',
-                              CLASSIFICATION[ctype.lower()])
-                else:
-                    event.add('classification.type', "unknown")
+            event.add("raw", row)
 
-                if len(values[6].strip()) > 0:
-                    geo_coordinates = values[6].strip().split(",")
-                    if len(geo_coordinates) == 2:
-                        geo_latitude = geo_coordinates[0]
-                        geo_longitude = geo_coordinates[1]
+            yield event
 
-                event.add('source.ip', values[0].strip())
-                event.add('source.geolocation.cc',
-                          values[4].strip())
-                event.add('source.geolocation.city',
-                          values[5].strip())
-                event.add('source.geolocation.latitude',
-                          geo_latitude.strip())
-                event.add('source.geolocation.longitude',
-                          geo_longitude.strip())
-
-                event.add("raw", row)
-
-                self.send_message(event)
-        self.acknowledge_message()
 
 if __name__ == "__main__":
     bot = AlienVaultParserBot(sys.argv[1])

--- a/intelmq/bots/parsers/alienvault/parser.py
+++ b/intelmq/bots/parsers/alienvault/parser.py
@@ -17,7 +17,7 @@ CLASSIFICATION = {
 
 class AlienVaultParserBot(Bot):
 
-    def parseline(self, row, report):
+    def parse_line(self, row, report):
         values = row.split("#")
 
         # Send one event per classification

--- a/intelmq/bots/parsers/arbor/parser.py
+++ b/intelmq/bots/parsers/arbor/parser.py
@@ -5,28 +5,28 @@ Completely untested. If you have example data, please contact us!
 
 import sys
 
-from intelmq.lib.bot import Bot
+from intelmq.lib.bot import ParserBot
 from intelmq.lib.message import Event
 
 
-class ArborParserBot(Bot):
+class ArborParserBot(ParserBot):
 
     def parseline(self, row, report):
         if row.startswith('other'):
             yield
+        else:
+            event = Event(report)
 
-        event = Event(report)
+            event.add('classification.type', 'brute-force')
+            event.add("raw", row)
 
-        event.add('classification.type', 'brute-force')
-        event.add("raw", row)
+            columns = ["source.ip"]
+            row = row.split()
 
-        columns = ["source.ip"]
-        row = row.split()
+            for key, value in zip(columns, row):
+                event.add(key, value)
 
-        for key, value in zip(columns, row):
-            event.add(key, value)
-
-        yield event
+            yield event
 
 
 if __name__ == "__main__":

--- a/intelmq/bots/parsers/arbor/parser.py
+++ b/intelmq/bots/parsers/arbor/parser.py
@@ -11,7 +11,7 @@ from intelmq.lib.message import Event
 
 class ArborParserBot(ParserBot):
 
-    def parseline(self, row, report):
+    def parse_line(self, row, report):
         if row.startswith('other'):
             yield
         else:

--- a/intelmq/bots/parsers/arbor/parser.py
+++ b/intelmq/bots/parsers/arbor/parser.py
@@ -13,20 +13,20 @@ class ArborParserBot(ParserBot):
 
     def parse_line(self, row, report):
         if row.startswith('other'):
-            yield
-        else:
-            event = Event(report)
+            return
 
-            event.add('classification.type', 'brute-force')
-            event.add("raw", row)
+        event = Event(report)
 
-            columns = ["source.ip"]
-            row = row.split()
+        event.add('classification.type', 'brute-force')
+        event.add("raw", row)
 
-            for key, value in zip(columns, row):
-                event.add(key, value)
+        columns = ["source.ip"]
+        row = row.split()
 
-            yield event
+        for key, value in zip(columns, row):
+            event.add(key, value)
+
+        yield event
 
 
 if __name__ == "__main__":

--- a/intelmq/bots/parsers/arbor/parser.py
+++ b/intelmq/bots/parsers/arbor/parser.py
@@ -1,36 +1,32 @@
 # -*- coding: utf-8 -*-
+"""
+Completely untested. If you have example data, please contact us!
+"""
+
 import sys
 
-from intelmq.lib import utils
 from intelmq.lib.bot import Bot
 from intelmq.lib.message import Event
 
 
 class ArborParserBot(Bot):
 
-    def process(self):
-        report = self.receive_message()
+    def parseline(self, row, report):
+        if row.startswith('other'):
+            yield
 
-        raw_report = utils.base64_decode(report.get("raw"))
-        for row in raw_report.splitlines():
-            row = row.strip()
+        event = Event(report)
 
-            if len(row) == 0 or row.startswith('other'):
-                continue
+        event.add('classification.type', 'brute-force')
+        event.add("raw", row)
 
-            event = Event(report)
+        columns = ["source.ip"]
+        row = row.split()
 
-            event.add('classification.type', 'brute-force')
-            event.add("raw", row)
+        for key, value in zip(columns, row):
+            event.add(key, value)
 
-            columns = ["source.ip"]
-            row = row.split()
-
-            for key, value in zip(columns, row):
-                event.add(key, value)
-
-            self.send_message(event)
-        self.acknowledge_message()
+        yield event
 
 
 if __name__ == "__main__":

--- a/intelmq/bots/parsers/autoshun/parser.py
+++ b/intelmq/bots/parsers/autoshun/parser.py
@@ -28,7 +28,7 @@ class AutoshunParserBot(ParserBot):
         for line in splitted[2:]:
             yield line.strip()
 
-    def parseline(self, line, report):
+    def parse_line(self, line, report):
         event = Event(report)
 
         info = line.split("<td>")

--- a/intelmq/bots/parsers/blocklistde/parser.py
+++ b/intelmq/bots/parsers/blocklistde/parser.py
@@ -3,8 +3,7 @@ import posixpath
 import sys
 from urllib.parse import urlparse
 
-from intelmq.lib import utils
-from intelmq.lib.bot import Bot
+from intelmq.lib.bot import ParserBot
 from intelmq.lib.message import Event
 
 MAPPING = {
@@ -70,32 +69,22 @@ MAPPING = {
 }
 
 
-class BlockListDEParserBot(Bot):
+class BlockListDEParserBot(ParserBot):
 
-    def process(self):
-        report = self.receive_message()
-
-        raw_report = utils.base64_decode(report.get("raw"))
-        raw_report = raw_report.strip()
-
-        url = report.get('feed.url')
-        path = urlparse(url).path
+    def parseline(self, line, report):
+        path = urlparse(report['feed.url']).path
         filename = posixpath.basename(path)
 
-        for row in raw_report.splitlines():
-            event = Event(report)
+        event = Event(report)
+        event.add('source.ip', line)
+        if filename in MAPPING:
+            for key, value in MAPPING[filename].items():
+                event.add(key, value)
+        else:
+            event.add('classification.type', 'blacklist')
 
-            event.add('source.ip', row.strip())
-            if filename in MAPPING:
-                for key, value in MAPPING[filename].items():
-                    event.add(key, value)
-            else:
-                event.add('classification.type', 'blacklist')
-
-            event.add("raw", row)
-
-            self.send_message(event)
-        self.acknowledge_message()
+        event.add("raw", line)
+        yield event
 
 
 if __name__ == "__main__":

--- a/intelmq/bots/parsers/blocklistde/parser.py
+++ b/intelmq/bots/parsers/blocklistde/parser.py
@@ -71,7 +71,7 @@ MAPPING = {
 
 class BlockListDEParserBot(ParserBot):
 
-    def parseline(self, line, report):
+    def parse_line(self, line, report):
         path = urlparse(report['feed.url']).path
         filename = posixpath.basename(path)
 

--- a/intelmq/bots/parsers/dragonresearchgroup/parser_ssh.py
+++ b/intelmq/bots/parsers/dragonresearchgroup/parser_ssh.py
@@ -7,7 +7,7 @@ from intelmq.lib.message import Event
 
 class DragonResearchGroupSSHParserBot(ParserBot):
 
-    def parseline(self, line, report):
+    def parse_line(self, line, report):
         if line.startswith('#'):
             self.tempdata.append(line)
         else:

--- a/intelmq/bots/parsers/dragonresearchgroup/parser_ssh.py
+++ b/intelmq/bots/parsers/dragonresearchgroup/parser_ssh.py
@@ -1,25 +1,17 @@
 # -*- coding: utf-8 -*-
 import sys
 
-from intelmq.lib import utils
-from intelmq.lib.bot import Bot
+from intelmq.lib.bot import ParserBot
 from intelmq.lib.message import Event
 
 
-class DragonResearchGroupSSHParserBot(Bot):
+class DragonResearchGroupSSHParserBot(ParserBot):
 
-    def process(self):
-        report = self.receive_message()
-
-        raw_report = utils.base64_decode(report.get("raw"))
-        for row in raw_report.splitlines():
-
-            row = row.strip()
-
-            if len(row) == 0 or row.startswith('#'):
-                continue
-
-            splitted_row = row.split('|')
+    def parseline(self, line, report):
+        if line.startswith('#'):
+            self.tempdata.append(line)
+        else:
+            splitted_row = line.split('|')
             event = Event(report)
 
             columns = ["source.asn", "source.as_name",
@@ -40,10 +32,9 @@ class DragonResearchGroupSSHParserBot(Bot):
             event.add("protocol.application", "ssh")
             event.add("protocol.transport", "tcp")
             event.add("destination.port", 22)
-            event.add("raw", row)
+            event.add("raw", line)
 
-            self.send_message(event)
-        self.acknowledge_message()
+            yield event
 
 
 if __name__ == "__main__":

--- a/intelmq/bots/parsers/dragonresearchgroup/parser_vnc.py
+++ b/intelmq/bots/parsers/dragonresearchgroup/parser_vnc.py
@@ -1,25 +1,17 @@
 # -*- coding: utf-8 -*-
 import sys
 
-from intelmq.lib import utils
-from intelmq.lib.bot import Bot
+from intelmq.lib.bot import ParserBot
 from intelmq.lib.message import Event
 
 
-class DragonResearchGroupVNCParserBot(Bot):
+class DragonResearchGroupVNCParserBot(ParserBot):
 
-    def process(self):
-        report = self.receive_message()
-
-        raw_report = utils.base64_decode(report.get("raw"))
-        for row in raw_report.splitlines():
-
-            row = row.strip()
-
-            if len(row) == 0 or row.startswith('#'):
-                continue
-
-            splitted_row = row.split('|')
+    def parseline(self, line, report):
+        if line.startswith('#'):
+            self.tempdata.append(line)
+        else:
+            splitted_row = line.split('|')
             event = Event(report)
 
             columns = ["source.asn", "source.as_name",
@@ -39,10 +31,9 @@ class DragonResearchGroupVNCParserBot(Bot):
             event.add("classification.type", "brute-force")
             event.add("protocol.application", "vnc")
             event.add("protocol.transport", "tcp")
-            event.add("raw", row)
+            event.add("raw", line)
 
-            self.send_message(event)
-        self.acknowledge_message()
+            yield event
 
 
 if __name__ == "__main__":

--- a/intelmq/bots/parsers/dragonresearchgroup/parser_vnc.py
+++ b/intelmq/bots/parsers/dragonresearchgroup/parser_vnc.py
@@ -7,7 +7,7 @@ from intelmq.lib.message import Event
 
 class DragonResearchGroupVNCParserBot(ParserBot):
 
-    def parseline(self, line, report):
+    def parse_line(self, line, report):
         if line.startswith('#'):
             self.tempdata.append(line)
         else:

--- a/intelmq/bots/parsers/generic/parser_csv.py
+++ b/intelmq/bots/parsers/generic/parser_csv.py
@@ -19,19 +19,16 @@ import sys
 from dateutil.parser import parse
 
 from intelmq.lib import utils
-from intelmq.lib.bot import Bot
+from intelmq.lib.bot import ParserBot
 from intelmq.lib.message import Event
 
 
-class GenericCsvParserBot(Bot):
+class GenericCsvParserBot(ParserBot):
 
-    def process(self):
-        report = self.receive_message()
-
-        columns = self.parameters.columns
-        type_translation = None
+    def parse(self, report):
+        self.type_translation = None
         if hasattr(self.parameters, 'type_translation'):
-            type_translation = json.loads(self.parameters.type_translation)
+            self.type_translation = json.loads(self.parameters.type_translation)
 
         raw_report = utils.base64_decode(report.get("raw"))
         # ignore lines starting with #
@@ -40,69 +37,64 @@ class GenericCsvParserBot(Bot):
         raw_report = re.sub(r'(?m)\0', '', raw_report)
         for row in csv.reader(io.StringIO(raw_report),
                               delimiter=str(self.parameters.delimiter)):
-            event = Event(report)
+            yield row
 
-            for key, value in zip(columns, row):
+    def parse_line(self, row, report):
+        event = Event(report)
 
-                if key in ["__IGNORE__", ""]:
+        for key, value in zip(self.parameters.columns, row):
+
+            if key in ["__IGNORE__", ""]:
+                continue
+            if key in ["time.source", "time.destination"]:
+                value = parse(value, fuzzy=True).isoformat()
+                value += " UTC"
+            # regex from http://stackoverflow.com/a/23483979
+            # matching ipv4/ipv6 IP within string
+            elif key in ["source.ip", "destination.ip"]:
+                value = re.compile(
+                    '(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])'
+                    '\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0'
+                    '-5])|(([a-zA-Z]|[a-zA-Z][a-zA-Z0-9\-]*[a-zA-Z0-9])'
+                    '\.)*([A-Za-z]|[A-Za-z][A-Za-z0-9\-]*[A-Za-z0-9])|'
+                    '\s*((([0-9A-Fa-f]{1,4}:){7}([0-9A-Fa-f]{1,4}|:))|('
+                    '([0-9A-Fa-f]{1,4}:){6}(:[0-9A-Fa-f]{1,4}|((25[0-5]'
+                    '|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d'
+                    '\d|[1-9]?\d)){3})|:))|(([0-9A-Fa-f]{1,4}:){5}(((:['
+                    '0-9A-Fa-f]{1,4}){1,2})|:((25[0-5]|2[0-4]\d|1\d\d|['
+                    '1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3})|'
+                    ':))|(([0-9A-Fa-f]{1,4}:){4}(((:[0-9A-Fa-f]{1,4}){1'
+                    ',3})|((:[0-9A-Fa-f]{1,4})?:((25[0-5]|2[0-4]\d|1\d'
+                    '\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){'
+                    '3}))|:))|(([0-9A-Fa-f]{1,4}:){3}(((:[0-9A-Fa-f]{1,'
+                    '4}){1,4})|((:[0-9A-Fa-f]{1,4}){0,2}:((25[0-5]|2[0-'
+                    '4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-'
+                    '9]?\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){2}(((:[0-9A-'
+                    'Fa-f]{1,4}){1,5})|((:[0-9A-Fa-f]{1,4}){0,3}:((25[0'
+                    '-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1'
+                    '\d\d|[1-9]?\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){1}(('
+                    '(:[0-9A-Fa-f]{1,4}){1,6})|((:[0-9A-Fa-f]{1,4}){0,4'
+                    '}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2['
+                    '0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(:(((:[0-9A-Fa-f]'
+                    '{1,4}){1,7})|((:[0-9A-Fa-f]{1,4}){0,5}:((25[0-5]|2'
+                    '[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|'
+                    '[1-9]?\d)){3}))|:)))(%.+)?').match(value).group()
+            elif key.endswith('.url') and '://' not in value:
+                value = self.parameters.default_url_protocol + value
+            elif key in ["classification.type"] and self.type_translation:
+                if value in self.type_translation:
+                    value = self.type_translation[value]
+                elif not hasattr(self.parameters, 'type'):
                     continue
-                try:
-                    if key in ["time.source", "time.destination"]:
-                        value = parse(value, fuzzy=True).isoformat()
-                        value += " UTC"
-                    # regex from http://stackoverflow.com/a/23483979
-                    # matching ipv4/ipv6 IP within string
-                    elif key in ["source.ip", "destination.ip"]:
-                        value = re.compile(
-                            '(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])'
-                            '\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0'
-                            '-5])|(([a-zA-Z]|[a-zA-Z][a-zA-Z0-9\-]*[a-zA-Z0-9])'
-                            '\.)*([A-Za-z]|[A-Za-z][A-Za-z0-9\-]*[A-Za-z0-9])|'
-                            '\s*((([0-9A-Fa-f]{1,4}:){7}([0-9A-Fa-f]{1,4}|:))|('
-                            '([0-9A-Fa-f]{1,4}:){6}(:[0-9A-Fa-f]{1,4}|((25[0-5]'
-                            '|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d'
-                            '\d|[1-9]?\d)){3})|:))|(([0-9A-Fa-f]{1,4}:){5}(((:['
-                            '0-9A-Fa-f]{1,4}){1,2})|:((25[0-5]|2[0-4]\d|1\d\d|['
-                            '1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3})|'
-                            ':))|(([0-9A-Fa-f]{1,4}:){4}(((:[0-9A-Fa-f]{1,4}){1'
-                            ',3})|((:[0-9A-Fa-f]{1,4})?:((25[0-5]|2[0-4]\d|1\d'
-                            '\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){'
-                            '3}))|:))|(([0-9A-Fa-f]{1,4}:){3}(((:[0-9A-Fa-f]{1,'
-                            '4}){1,4})|((:[0-9A-Fa-f]{1,4}){0,2}:((25[0-5]|2[0-'
-                            '4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-'
-                            '9]?\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){2}(((:[0-9A-'
-                            'Fa-f]{1,4}){1,5})|((:[0-9A-Fa-f]{1,4}){0,3}:((25[0'
-                            '-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1'
-                            '\d\d|[1-9]?\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){1}(('
-                            '(:[0-9A-Fa-f]{1,4}){1,6})|((:[0-9A-Fa-f]{1,4}){0,4'
-                            '}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2['
-                            '0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(:(((:[0-9A-Fa-f]'
-                            '{1,4}){1,7})|((:[0-9A-Fa-f]{1,4}){0,5}:((25[0-5]|2'
-                            '[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|'
-                            '[1-9]?\d)){3}))|:)))(%.+)?').match(value).group()
-                    elif key.endswith('.url') and '://' not in value:
-                        value = self.parameters.default_url_protocol + value
-                    elif key in ["classification.type"] and type_translation:
-                        if value in type_translation:
-                            value = type_translation[value]
-                        elif not hasattr(self.parameters, 'type'):
-                            continue
+            event.add(key, value)
 
-                except:
-                    self.logger.warning('Encountered error while parsing line'
-                                        ' in csv file, ignoring this row: ' +
-                                        repr(row))
-                    continue
-                event.add(key, value)
+        if hasattr(self.parameters, 'type')\
+                and not event.contains("classification.type"):
+            event.add('classification.type', self.parameters.type)
+        event.add("raw", ",".join(row))
+        yield event
 
-            if hasattr(self.parameters, 'type')\
-                    and not event.contains("classification.type"):
-                event.add('classification.type', self.parameters.type)
-            event.add("raw", ",".join(row))
-
-            self.send_message(event)
-        self.acknowledge_message()
-
+    recover_line = ParserBot.recover_line_csv
 
 if __name__ == "__main__":
     bot = GenericCsvParserBot(sys.argv[1])

--- a/intelmq/bots/parsers/malwaredomainlist/parser.py
+++ b/intelmq/bots/parsers/malwaredomainlist/parser.py
@@ -35,7 +35,7 @@ class MalwareDomainListParserBot(ParserBot):
         event.add("source.asn", int(row[6]))
 
         event.add('classification.type', 'malware')
-        event.add("raw", ",".join(row))
+        event.add("raw", self.recoverline(row))
         yield event
 
 if __name__ == "__main__":

--- a/intelmq/bots/parsers/malwaredomainlist/parser.py
+++ b/intelmq/bots/parsers/malwaredomainlist/parser.py
@@ -16,9 +16,9 @@ class MalwareDomainListParserBot(ParserBot):
             return 'http://' + url
 
     parse = ParserBot.parse_csv
-    recoverline = ParserBot.recoverline_csv
+    recover_line = ParserBot.recover_line_csv
 
-    def parseline(self, row, report):
+    def parse_line(self, row, report):
         event = Event(report)
 
         event.add("time.source", row[0].replace('_', ' ') + " UTC")
@@ -35,7 +35,7 @@ class MalwareDomainListParserBot(ParserBot):
         event.add("source.asn", int(row[6]))
 
         event.add('classification.type', 'malware')
-        event.add("raw", self.recoverline(row))
+        event.add("raw", self.recover_line(row))
         yield event
 
 if __name__ == "__main__":

--- a/intelmq/bots/parsers/malwaredomainlist/parser.py
+++ b/intelmq/bots/parsers/malwaredomainlist/parser.py
@@ -1,16 +1,13 @@
 # -*- coding: utf-8 -*-
-import csv
-import io
 import sys
 from urllib.parse import urlparse
 
-from intelmq.lib import utils
-from intelmq.lib.bot import Bot
+from intelmq.lib.bot import ParserBot
 from intelmq.lib.exceptions import InvalidValue
 from intelmq.lib.message import Event
 
 
-class MalwareDomainListParserBot(Bot):
+class MalwareDomainListParserBot(ParserBot):
     def add_http(self, url):
         """
         We can assume here, that everything is http by default if not given.
@@ -18,33 +15,28 @@ class MalwareDomainListParserBot(Bot):
         if '://' not in url:
             return 'http://' + url
 
-    def process(self):
-        report = self.receive_message()
+    parse = ParserBot.parse_csv
+    recoverline = ParserBot.recoverline_csv
 
-        raw_report = utils.base64_decode(report.get("raw"))
-        for row in csv.reader(io.StringIO(raw_report)):
-            event = Event(report)
-            self.logger.debug(repr(row))
+    def parseline(self, row, report):
+        event = Event(report)
 
-            event.add("time.source", row[0].replace('_', ' ') + " UTC")
-            if row[1] != '-':
-                event.add("source.url", self.add_http(row[1]))
-            try:
-                event.add("source.ip", row[2])
-            except InvalidValue:
-                event.add("source.url", self.add_http(row[2]))
-                event.add('source.ip', urlparse(row[2]).netloc)
-            event.add("source.reverse_dns", row[3])
-            event.add("event_description.text", row[4])
-            # TODO: ignore abuse contact for now
-            event.add("source.asn", int(row[6]))
+        event.add("time.source", row[0].replace('_', ' ') + " UTC")
+        if row[1] != '-':
+            event.add("source.url", self.add_http(row[1]))
+        try:
+            event.add("source.ip", row[2])
+        except InvalidValue:
+            event.add("source.url", self.add_http(row[2]))
+            event.add('source.ip', urlparse(row[2]).netloc)
+        event.add("source.reverse_dns", row[3])
+        event.add("event_description.text", row[4])
+        # TODO: ignore abuse contact for now
+        event.add("source.asn", int(row[6]))
 
-            event.add('classification.type', 'malware')
-            event.add("raw", ",".join(row))
-
-            self.send_message(event)
-        self.acknowledge_message()
-
+        event.add('classification.type', 'malware')
+        event.add("raw", ",".join(row))
+        yield event
 
 if __name__ == "__main__":
     bot = MalwareDomainListParserBot(sys.argv[1])

--- a/intelmq/lib/test.py
+++ b/intelmq/lib/test.py
@@ -100,6 +100,7 @@ class BotTestCase(object):
         cls.maxDiff = None  # For unittest module, prints long diffs
         cls.pipe = None
         cls.sysconfig = {}
+        cls.allowed_error_count = 0  # allows dumping of some lines
 
         cls.set_bot()
 
@@ -239,7 +240,8 @@ class BotTestCase(object):
     def test_log_not_error(self):
         """ Test if bot does not log errors. """
         self.run_bot()
-        self.assertNotRegexpMatchesLog("ERROR")
+        self.assertNotRegexpMatchesLog("(ERROR.*?){}"
+                                       "".format(self.allowed_error_count))
 
     def test_log_not_critical(self):
         """ Test if bot does not log critical errors. """

--- a/intelmq/tests/bots/parsers/autoshun/shunlist.html
+++ b/intelmq/tests/bots/parsers/autoshun/shunlist.html
@@ -1,0 +1,11 @@
+<html><head>
+<meta http-equiv="content-type" content="text/html; charset=windows-1252"></head><body><table border="1">
+<tbody><tr>
+<td colspan="3"><center>Currently Shunning 500 attackers as of Tue, 31 May 2016 06:30:01 -0500</center></td>
+</tr>
+<tr>
+<td>Attacker</td><td>Time of Shun CDT</td><td>Description of Event</td>
+</tr>
+<tr><td>198.51.100.45</td><td>2016-05-17 10:59:27</td><td>RA SCAN Unusually fast Terminal Server Traffic Inbound</td></tr>
+<tr><td>198.51.100.86</td><td>2016-05-18 14:01:06</td><td>MS Terminal Server Single Character Login, possible Morto inbound</td></tr>
+</tbody></table></body></html>

--- a/intelmq/tests/bots/parsers/autoshun/test_parser.py
+++ b/intelmq/tests/bots/parsers/autoshun/test_parser.py
@@ -1,9 +1,44 @@
 # -*- coding: utf-8 -*-
-
+import os
 import unittest
 
 import intelmq.lib.test as test
+import intelmq.lib.utils as utils
 from intelmq.bots.parsers.autoshun.parser import AutoshunParserBot
+
+
+with open(os.path.join(os.path.dirname(__file__),
+                       'shunlist.html')) as handle:
+    EXAMPLE_FILE = handle.read()
+
+EXAMPLE_REPORT = {"feed.name": "Autoshun",
+                  "feed.url": "https://www.autoshun.org/files/shunlist.html",
+                  "raw": utils.base64_encode(EXAMPLE_FILE),
+                  "__type": "Report",
+                  "time.observation": "2015-09-02T14:17:58+00:00"
+                  }
+EXAMPLE_EVENT0 = {
+    "__type": "Event",
+    "feed.name": "Autoshun",
+    "classification.type": "scanner",
+    "feed.url": "https://www.autoshun.org/files/shunlist.html",
+    "raw": "PHRyPjx0ZD4xOTguNTEuMTAwLjQ1PC90ZD48dGQ+MjAxNi0wNS0xNyAxMDo1OToyNzwvdGQ+PHRkPlJBIFNDQU4gVW51c3VhbGx5IGZhc3QgVGVybWluYWwgU2VydmVyIFRyYWZmaWMgSW5ib3VuZDwvdGQ+PC90cj4=",
+    "event_description.text": "RA SCAN Unusually fast Terminal Server Traffic Inbound",
+    "time.source": "2016-05-17T15:59:27+00:00",
+    "time.observation": "2015-05-17T14:17:5810:59:27+00:00",
+    "source.ip": "198.51.100.45"
+}
+EXAMPLE_EVENT1 = {
+    "__type": "Event",
+    "feed.name": "Autoshun",
+    "classification.type": "unknown",
+    "feed.url": "https://www.autoshun.org/files/shunlist.html",
+    "raw": "PHRyPjx0ZD4xOTguNTEuMTAwLjg2PC90ZD48dGQ+MjAxNi0wNS0xOCAxNDowMTowNjwvdGQ+PHRkPk1TIFRlcm1pbmFsIFNlcnZlciBTaW5nbGUgQ2hhcmFjdGVyIExvZ2luLCBwb3NzaWJsZSBNb3J0byBpbmJvdW5kPC90ZD48L3RyPg==",
+    "event_description.text": "MS Terminal Server Single Character Login, possible Morto inbound",
+    "time.source": "2016-05-18T19:01:06+00:00",
+    "time.observation": "2015-05-17T14:17:5810:59:27+00:00",
+    "source.ip": "198.51.100.86"
+}
 
 
 class TestAutoshunParserBot(test.BotTestCase, unittest.TestCase):
@@ -14,7 +49,14 @@ class TestAutoshunParserBot(test.BotTestCase, unittest.TestCase):
     @classmethod
     def set_bot(cls):
         cls.bot_reference = AutoshunParserBot
-        cls.default_input_message = {'__type': 'Report', 'raw': 'Cg=='}
+        cls.default_input_message = EXAMPLE_REPORT
+
+    def test_event(self):
+        """ Test if correct Event has been produced. """
+        self.run_bot()
+        self.assertMessageEqual(0, EXAMPLE_EVENT0)
+        self.assertMessageEqual(1, EXAMPLE_EVENT1)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/intelmq/tests/bots/parsers/malwaredomainlist/test_parser.py
+++ b/intelmq/tests/bots/parsers/malwaredomainlist/test_parser.py
@@ -31,7 +31,7 @@ EXAMPLE_EVENT = {"feed.name": "Malware Domain List",
                         "dGVudC9wbHVnaW5zL2JhZC9wcm9ncmFtLmV4ZSwxOTIuMC4yLjEs"
                         "ZXhhbXBsZS5jb20uLFRyb2phbi5FeGFtcGxlLFJlZ2lzdHJhciBB"
                         "YnVzZSBDb250YWN0IGRvbWFpbmFidXNlQGV4YW1wbGUuY29tLDAw"
-                        "MDAw",
+                        "MDAwDQo=",
                  "time.observation": "2015-01-01T00:00:00+00:00",
                  }
 EXAMPLE_REPORT2 = EXAMPLE_REPORT.copy()
@@ -47,7 +47,7 @@ EXAMPLE_EVENT2['source.reverse_dns'] = "ptr-155.133.18.117.vmline.pl"
 EXAMPLE_EVENT2['event_description.text'] = "Trojan.Andromeda"
 EXAMPLE_EVENT2['raw'] = ('MjAxNS8xMC8yNF8wMzo1MCwtLDE1NS4xMzMuMTguMTE3LzM4eWVz'
                          'My5leGUscHRyLTE1NS4xMzMuMTguMTE3LnZtbGluZS5wbC4sVHJv'
-                         'amFuLkFuZHJvbWVkYSwtLDE5NzIyNg==')
+                         'amFuLkFuZHJvbWVkYSwtLDE5NzIyNg0K')
 
 REPORT_HACJEK = EXAMPLE_REPORT.copy()
 REPORT_HACJEK['raw'] = "IjIwMTUvMTIvMjNfMTg6NTIiLCJ3d3cuYWdyaW1vbnQuY3ovIiwiOTUuMTY4LjIwNC4yMjUiLCJtYXNha3JhdG9yLnppa3VtLmN6LiIsImNvbXByb21pc2VkIHNpdGUgbGVhZHMgdG8gQW5nbGVyIEVLIiwiTGlib3IgS3LDoWwgLyBpbmZvQHppa3VtLmN6IiwiMzkzOTIi"  # nopep8
@@ -58,7 +58,7 @@ EVENT_HACJEK['source.ip'] = "95.168.204.225"
 EVENT_HACJEK['source.asn'] = 39392
 EVENT_HACJEK['source.reverse_dns'] = "masakrator.zikum.cz"
 EVENT_HACJEK['event_description.text'] = "compromised site leads to Angler EK"
-EVENT_HACJEK['raw'] = "MjAxNS8xMi8yM18xODo1Mix3d3cuYWdyaW1vbnQuY3ovLDk1LjE2OC4yMDQuMjI1LG1hc2FrcmF0b3IuemlrdW0uY3ouLGNvbXByb21pc2VkIHNpdGUgbGVhZHMgdG8gQW5nbGVyIEVLLExpYm9yIEtyw6FsIC8gaW5mb0B6aWt1bS5jeiwzOTM5Mg=="  # nopep8
+EVENT_HACJEK['raw'] = "MjAxNS8xMi8yM18xODo1Mix3d3cuYWdyaW1vbnQuY3ovLDk1LjE2OC4yMDQuMjI1LG1hc2FrcmF0b3IuemlrdW0uY3ouLGNvbXByb21pc2VkIHNpdGUgbGVhZHMgdG8gQW5nbGVyIEVLLExpYm9yIEtyw6FsIC8gaW5mb0B6aWt1bS5jeiwzOTM5Mg0K"  # nopep8
 
 
 class TestMalwareDomainListParserBot(test.BotTestCase, unittest.TestCase):

--- a/intelmq/tests/bots/test_dummy_bot.py
+++ b/intelmq/tests/bots/test_dummy_bot.py
@@ -43,7 +43,7 @@ class DummyParserBot(bot.ParserBot):
     A dummy bot only for testing purpose.
     """
 
-    def parseline(self, line, report):
+    def parse_line(self, line, report):
         if line.startswith('#'):
             self.logger.info('Lorem ipsum dolor sit amet')
             self.tempdata.append(line)
@@ -60,7 +60,7 @@ class DummyParserBot(bot.ParserBot):
             event['classification.type'] = 'malware'
             yield event
 
-    def recoverline(self, line):
+    def recover_line(self, line):
         return '\n'.join([self.tempdata[0], line, self.tempdata[1]])
 
 

--- a/intelmq/tests/bots/test_dummy_bot.py
+++ b/intelmq/tests/bots/test_dummy_bot.py
@@ -1,54 +1,67 @@
 # -*- coding: utf-8 -*-
 
 import unittest
+import dateutil.parser
+import mock
 
+import intelmq.lib.bot
 import intelmq.lib.bot as bot
 import intelmq.lib.test as test
 from intelmq.lib.message import Event
 
-EXAMPLE_REPORT = {"source.ip": "192.0.2.3",
-                  "time.source": "2015-06-04T13:37:00+00:00",
-                  "feed.url": "http://www.example.com/",
-                  "source.reverse_dns": "reverse.example.net",
-                  "source.url": "http://example.org",
+EXAMPLE_REPORT = {"feed.url": "http://www.example.com/",
                   "time.observation": "2015-08-11T13:03:40+00:00",
-                  "raw": "MjAxNS8wNi8wNF8xMzozNyxleGFtcGxlLm9yZywxOTIuMC4yLjMs"
-                         "cmV2ZXJzZS5leGFtcGxlLm5ldCxleGFtcGxlIGRlc2NyaXB0aW9u"
-                         "LHJlcG9ydEBleGFtcGxlLm9yZywwMDAwMAo=",
+                  "raw": """
+IyBpZ25vcmUgdGhpcwoyMDE1LzA2LzA0IDEzOjM3ICswMCxleGFtcGxlLm9yZywxOTIuMC4yLjMs
+cmV2ZXJzZS5leGFtcGxlLm5ldCxleGFtcGxlIGRlc2NyaXB0aW9uLHJlcG9ydEBleGFtcGxlLm9y
+ZywwCgoyMDE1LzA2LzA0XzEzOjM3ICswMCxleGFtcGxlLm9yZywxOTIuMC4yLjMscmV2ZXJzZS5l
+eGFtcGxlLm5ldCxleGFtcGxlIGRlc2NyaXB0aW9uLHJlcG9ydEBleGFtcGxlLm9yZywwCiNlbmRp
+bmcgbGluZQ==
+""",
                   "__type": "Report",
-                  "classification.type": "malware",
-                  "event_description.text": "example description",
-                  "source.asn": 00000,
                   "feed.name": "Example"}
-EXAMPLE_EVENT = EXAMPLE_REPORT
-EXAMPLE_EVENT['__type'] = 'Event'
+EXAMPLE_EVENT = {"feed.url": "http://www.example.com/",
+                 "source.ip": "192.0.2.3",
+                 "time.source": "2015-06-04T13:37:00+00:00",
+                 "source.reverse_dns": "reverse.example.net",
+                 "source.fqdn": "example.org",
+                 "source.account": "report@example.org",
+                 "time.observation": "2015-08-11T13:03:40+00:00",
+                 "__type": "Event",
+                 "classification.type": "malware",
+                 "event_description.text": "example description",
+                 "source.asn": 0,
+                 "feed.name": "Example"}
+
+EXPECTED_DUMP = '''# ignore this
+2015/06/04_13:37 +00,example.org,192.0.2.3,reverse.example.net,example description,report@example.org,0
+#ending line'''
 
 
-class DummyParserBot(bot.Bot):
+class DummyParserBot(bot.ParserBot):
     """
     A dummy bot only for testing purpose.
     """
 
-    def process(self):
-        """
-        Passing through all information from Report to Event.
+    def parseline(self, line, report):
+        if line.startswith('#'):
+            self.logger.info('Lorem ipsum dolor sit amet')
+            self.tempdata.append(line)
+        else:
+            event = Event(report)
+            line = line.split(',')
+            event['time.source'] = str(dateutil.parser.parse(line[0]))
+            event['source.fqdn'] = line[1]
+            event['source.ip'] = line[2]
+            event['source.reverse_dns'] = line[3]
+            event['event_description.text'] = line[4]
+            event['source.account'] = line[5]
+            event['source.asn'] = line[6]
+            event['classification.type'] = 'malware'
+            yield event
 
-        Also logs a sample line, which will be tested afterwards.
-        """
-        report = self.receive_message()
-
-        if not report:
-            self.acknowledge_message()
-            return
-
-        event = Event()
-        self.logger.info('Lorem ipsum dolor sit amet')
-
-        for key in report.keys():
-            event.add(key, report[key], sanitize=False)
-
-        self.send_message(event)
-        self.acknowledge_message()
+    def recoverline(self, line):
+        return '\n'.join([self.tempdata[0], line, self.tempdata[1]])
 
 
 class TestDummyParserBot(test.BotTestCase, unittest.TestCase):
@@ -60,6 +73,15 @@ class TestDummyParserBot(test.BotTestCase, unittest.TestCase):
     def set_bot(cls):
         cls.bot_reference = DummyParserBot
         cls.default_input_message = EXAMPLE_REPORT
+        cls.allowed_error_count = 1
+
+    def dump_message(self, error_traceback, message=None):
+        self.assertEqual(EXPECTED_DUMP, message)
+
+    def run_bot(self):
+        with mock.patch.object(intelmq.lib.bot.Bot, "_dump_message",
+                               self.dump_message):
+            super(TestDummyParserBot, self).run_bot()
 
     def test_log_test_line(self):
         """ Test if bot does log example message. """


### PR DESCRIPTION
An additional possibility for parsers.

The parsing of the text itself (splitlines in the simplest case) has been separated from the parsing of individual lines. Now, single lines can be dumped.
As small drawback, we need now mechanisms to reconstruct the original messages, but this is usually a one-liner (see examples).

This also lowers the complexity.

All changes are backwards-compatible, parsers using `process()` work fine, nothing changed for them.

This is a proof-of-concept, ready for reviews.

Still missing: docs for devs, tests, more conversions

refers to #374, #513 and #405
ping at @robcza @SYNchroACK @aaronkaplan @ondj @mauroasilva (everybody how participated in linked discussions)