### PR TITLE
Simplify the use of an alternative ROOT_DIR

### DIFF
--- a/intelmq/__init__.py
+++ b/intelmq/__init__.py
@@ -1,14 +1,14 @@
 from .version import __version__
-
+import os
 
 ROOT_DIR = "/opt/intelmq/"
-CONFIG_DIR = ROOT_DIR + "etc/"
+CONFIG_DIR = os.path.join(ROOT_DIR, "etc/")
 DEFAULT_LOGGING_LEVEL = "INFO"
-DEFAULT_LOGGING_PATH = "/opt/intelmq/var/log/"
-DEFAULTS_CONF_FILE = CONFIG_DIR + "defaults.conf"
-HARMONIZATION_CONF_FILE = CONFIG_DIR + "harmonization.conf"
-PIPELINE_CONF_FILE = CONFIG_DIR + "pipeline.conf"
-RUNTIME_CONF_FILE = CONFIG_DIR + "runtime.conf"
-STARTUP_CONF_FILE = CONFIG_DIR + "startup.conf"
-SYSTEM_CONF_FILE = CONFIG_DIR + "system.conf"
-VAR_RUN_PATH = "/opt/intelmq/var/run/"
+DEFAULT_LOGGING_PATH = os.path.join(ROOT_DIR, "var/log/")
+DEFAULTS_CONF_FILE = os.path.join(CONFIG_DIR, "defaults.conf")
+HARMONIZATION_CONF_FILE = os.path.join(CONFIG_DIR, "harmonization.conf")
+PIPELINE_CONF_FILE = os.path.join(CONFIG_DIR, "pipeline.conf")
+RUNTIME_CONF_FILE = os.path.join(CONFIG_DIR, "runtime.conf")
+STARTUP_CONF_FILE = os.path.join(CONFIG_DIR, "startup.conf")
+SYSTEM_CONF_FILE = os.path.join(CONFIG_DIR, "system.conf")
+VAR_RUN_PATH = os.path.join(ROOT_DIR, "var/run/")

--- a/intelmq/bin/intelmqctl.py
+++ b/intelmq/bin/intelmqctl.py
@@ -12,7 +12,7 @@ import pkg_resources
 import psutil
 
 from intelmq import (DEFAULTS_CONF_FILE, PIPELINE_CONF_FILE, RUNTIME_CONF_FILE,
-                     STARTUP_CONF_FILE, SYSTEM_CONF_FILE)
+                     STARTUP_CONF_FILE, SYSTEM_CONF_FILE, VAR_RUN_PATH)
 from intelmq.lib import utils
 from intelmq.lib.pipeline import PipelineFactory
 
@@ -20,8 +20,8 @@ from intelmq.lib.pipeline import PipelineFactory
 class Parameters(object):
     pass
 
-PIDDIR = "/opt/intelmq/var/run/"
-PIDFILE = "/opt/intelmq/var/run/{}.pid"
+PIDDIR = VAR_RUN_PATH
+PIDFILE = os.path.join(PIDDIR, "{}.pid")
 
 STATUSES = {
     'starting': 0,

--- a/intelmq/lib/test.py
+++ b/intelmq/lib/test.py
@@ -15,7 +15,8 @@ import pkg_resources
 
 import intelmq.lib.pipeline as pipeline
 import intelmq.lib.utils as utils
-from intelmq import PIPELINE_CONF_FILE, RUNTIME_CONF_FILE, SYSTEM_CONF_FILE
+from intelmq import (PIPELINE_CONF_FILE, RUNTIME_CONF_FILE, SYSTEM_CONF_FILE,
+                     CONFIG_DIR)
 
 __all__ = ['BotTestCase']
 
@@ -49,7 +50,7 @@ def mocked_config(bot_id='test-bot', src_name='', dst_names=(), sysconfig={}):
             conf = BOT_CONFIG.copy()
             conf.update(sysconfig)
             return conf
-        elif conf_file.startswith('/opt/intelmq/etc/'):
+        elif conf_file.startswith(CONFIG_DIR):
             confname = os.path.join('etc/', os.path.split(conf_file)[-1])
             fname = pkg_resources.resource_filename('intelmq',
                                                     confname)

--- a/intelmq/tests/lib/test_bot.py
+++ b/intelmq/tests/lib/test_bot.py
@@ -14,7 +14,8 @@ import pkg_resources
 
 import intelmq.lib.pipeline as pipeline
 import intelmq.lib.utils as utils
-from intelmq import PIPELINE_CONF_FILE, RUNTIME_CONF_FILE, SYSTEM_CONF_FILE
+from intelmq import (PIPELINE_CONF_FILE, RUNTIME_CONF_FILE, SYSTEM_CONF_FILE,
+                     CONFIG_DIR)
 from intelmq.lib.test import mocked_logger
 
 
@@ -40,7 +41,7 @@ def mocked_config(bot_id='', src_name='', dst_names=(),
                     "error_max_retries": 0,
                     "testing": True,
                     }
-        elif conf_file.startswith('/opt/intelmq/etc/'):
+        elif conf_file.startswith(CONFIG_DIR):
             confname = os.path.join('etc/', os.path.split(conf_file)[-1])
             fname = pkg_resources.resource_filename('intelmq',
                                                     confname)


### PR DESCRIPTION
* Avoid most of the references to `/opt/intelmq/`
* Use `os.path.join()` to avoid issues with missing `/`