### PR TITLE
shadowserver's Open-Mongo DB feed does not have a username field

### DIFF
--- a/intelmq/bots/parsers/shadowserver/config.py
+++ b/intelmq/bots/parsers/shadowserver/config.py
@@ -568,7 +568,6 @@ open_mongo_db = {
         ('source.geolocation.cc', 'geo'),
         ('source.geolocation.region', 'region'),
         ('source.geolocation.city', 'city'),
-        ('source.account', 'username'),
         # Other known fields which will go into "extra"
         ('extra.', 'naics', invalidate_zero),
         ('extra.', 'sic', invalidate_zero),


### PR DESCRIPTION
Remove the rule for the field "username" from the shadowserver parser's
configuration for the Open-Mongo DB feed because it does not actually
exist in the feed. In the new parser fails to parse the feed as a
consequence (which is a good thing!).