### PR TITLE
Deb package: Change fewer intelmq home dir permissions

### DIFF
--- a/debian/intelmq.postinst
+++ b/debian/intelmq.postinst
@@ -5,7 +5,7 @@ if [ "$1" = "configure" ] ; then
     if ! getent passwd intelmq >/dev/null 2>&1; then
         useradd -d /opt/intelmq -U -s /bin/bash intelmq
     fi
-    chmod -R g+w /opt/intelmq
+    chmod -R g+w /opt/intelmq/*
     chown -R intelmq:intelmq /opt/intelmq
 fi
 


### PR DESCRIPTION
Only change permissions of its contents, i.e., `var` and `etc`.

This should resolve #559.