### PR TITLE
Deb package: Remove redundant modify bot example configs

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -25,9 +25,12 @@ override_dh_auto_install: $(BOTDOCS)
 	mkdir -p debian/intelmq/opt/intelmq/var/log
 	mkdir -p debian/intelmq/opt/intelmq/var/lib/bots/file-output
 	mkdir -p debian/intelmq/etc/logrotate.d
-	# install a modifier bot conf file besides the example file
+	# Install a modifier bot config file based on an example
 	cp -a debian/intelmq/opt/intelmq/var/lib/bots/modify/example/default.conf \
 		debian/intelmq/opt/intelmq/var/lib/bots/modify/modify.conf
+	# Remove modify bot example configs from their original location because
+	# intelmq.install copies them to the /usr/share/doc/intelmq/bots hierarchy
+	rm -vr debian/intelmq/opt/intelmq/var/lib/bots/modify/example
 	## BOTS
 	# Include all bot READMEs
 	for readme in $(foreach bot,$(BOTDOCS),$(subst intelmq/bots/,,$(bot))); \


### PR DESCRIPTION
A regular Python installation places the modify expert bot example
configs in /opt/intelmq/var/lib/bots/modify/example.  The deb package
copies them to the bot's documentation directory in
/usr/share/doc/intelmq.

This patch removes the files from their original location to avoid
duplication.