### PR TITLE
Use an unlimited type for the raw field in the events table

### DIFF
--- a/intelmq/bin/intelmq_psql_initdb.py
+++ b/intelmq/bin/intelmq_psql_initdb.py
@@ -29,9 +29,11 @@ def main():
     for field in DATA.keys():
         value = DATA[field]
 
-        if value['type'] in ('String', 'Base64', 'URL', 'FQDN',
+        if value['type'] in ('String', 'URL', 'FQDN',
                              'MalwareName', 'ClassificationType'):
             dbtype = 'varchar({})'.format(value.get('length', 2000))
+        elif value['type'] == 'Base64':
+            dbtype = 'text'
         elif value['type'] in ('IPAddress', 'IPNetwork'):
             dbtype = 'inet'
         elif value['type'] == 'DateTime':


### PR DESCRIPTION
This is a somewhat ad-hoc fix for the problem that the raw field can be
quite large and may not fit into the 2000 characters that are assumed if
no length is specified for a `Base64` field in `harmonization.conf`. There's
probably a better solution but for now we only need it for the raw field
and that's the only field that uses the Base64 type.

See issue #547

A better solution would probably be

```python
        if value['type'] in ('String', 'Base64', 'URL', 'FQDN',
                             'MalwareName', 'ClassificationType'):
            length = value.get('length')
            if length is not None:
                dbtype = 'varchar({})'.format(length)
            else:
                dbtype = 'text'
```

But that would change the SQL types of all fields that do not explicitly have a length in `harmonization.conf`. OTOH, that would actually be correct, since they could be of any length in the event. As long as `intelmq_psql_initdb.py` puts an arbitrary length limit on fields that are actually unbounded it can happen that an event can not be stored in the event database.