### PR TITLE
TST: Reduce number of bot tests and fix log errors

### DIFF
--- a/intelmq/bots/BOTS
+++ b/intelmq/bots/BOTS
@@ -633,7 +633,7 @@
             "module": "intelmq.bots.collectors.http.collector_http",
             "parameters": {
                 "feed": "VxVault",
-                "http_url": "http://vxvault.siri-urz.net/URL_List.php",
+                "http_url": "http://vxvault.net/URL_List.php",
                 "rate_limit": 3600
             }
         },

--- a/intelmq/bots/collectors/file/collector_file.py
+++ b/intelmq/bots/collectors/file/collector_file.py
@@ -35,7 +35,7 @@ class FileCollectorBot(Bot):
 
         if not self.parameters.postfix:
             self.logger.warn("No file extension was set. The collector will"
-                             " read all files in %s", self.parameters.path)
+                             " read all files in %s.", self.parameters.path)
             if self.parameters.delete_file:
                 self.logger.error("This configuration would delete all files"
                                   " in %s. I'm stopping now....",
@@ -43,7 +43,7 @@ class FileCollectorBot(Bot):
                 self.stop()
 
     def process(self):
-        self.logger.debug("Started looking for Files")
+        self.logger.debug("Started looking for files.")
 
         if os.path.isdir(self.parameters.path):
             p = os.path.abspath(self.parameters.path)
@@ -67,9 +67,9 @@ class FileCollectorBot(Bot):
                         if self.parameters.delete_file:
                             try:
                                 os.remove(filename)
-                                self.logger.debug("Deleted file: %s" % filename)
+                                self.logger.debug("Deleted file: %r." % filename)
                             except PermissionError:
-                                self.logger.error("Could not delete file %s" % filename)
+                                self.logger.error("Could not delete file %r." % filename)
                                 self.logger.info("Maybe I don't have sufficient rights on that file?")
                                 self.logger.error("Stopping now, to prevent reading this file again.")
                                 self.stop()

--- a/intelmq/bots/experts/filter/expert.py
+++ b/intelmq/bots/experts/filter/expert.py
@@ -22,7 +22,7 @@ class FilterExpertBot(Bot):
         try:
             result = re.findall(r'^(\d+)\s+(\w+[^s])s?$', relative_time, re.UNICODE)
         except ValueError as e:
-            raise ValueError("Could not apply regex to attribute \"%s\" with exception %s",
+            raise ValueError("Could not apply regex to attribute \"%s\" with exception %s.",
                              repr(relative_time), repr(e.args))
         if len(result) == 1 and len(result[0]) == 2 and result[0][1] in FilterExpertBot.timespans:
             return int(result[0][0]) * FilterExpertBot.timespans[result[0][1]]
@@ -35,10 +35,10 @@ class FilterExpertBot(Bot):
             absolute = parser.parse(time_attr)
         except ValueError:
             relative = timedelta(minutes=self.parse_relative(time_attr))
-            self.logger.info("Filtering out events to (relative time) " + repr(relative))
+            self.logger.info("Filtering out events to (relative time) {!r}.".format(relative))
             return relative
         else:
-            self.logger.info("Filtering out events to (absolute time) " + repr(absolute))
+            self.logger.info("Filtering out events to (absolute time) {!r}.".format(absolute))
             return absolute
         return None
 
@@ -79,25 +79,25 @@ class FilterExpertBot(Bot):
             try:
                 event_time = parser.parse(str(event.get('time.source'))).replace(tzinfo=pytz.timezone('UTC'))
             except ValueError:
-                self.logger.error("Could not parse time.source " + str(event.get('time.source')))
+                self.logger.error("Could not parse time.source {!s}.".format(event.get('time.source')))
             else:
                 if type(self.not_after) is datetime and event_time > self.not_after:
                     self.acknowledge_message()
-                    self.logger.debug("Filtered out event with time.source " + repr(event.get('time.source')))
+                    self.logger.debug("Filtered out event with time.source {!s}.".format(event.get('time.source')))
                     return
                 if type(self.not_before) is datetime and event_time < self.not_before:
                     self.acknowledge_message()
-                    self.logger.debug("Filtered out event with time.source " + repr(event.get('time.source')))
+                    self.logger.debug("Filtered out event with time.source {!r}.".format(event.get('time.source')))
                     return
 
                 now = datetime.now(tz=pytz.timezone('UTC'))
                 if type(self.not_after) is timedelta and event_time > (now - self.not_after):
                     self.acknowledge_message()
-                    self.logger.debug("Filtered out event with time.source " + repr(event.get('time.source')))
+                    self.logger.debug("Filtered out event with time.source {!r}.".format(event.get('time.source')))
                     return
                 if type(self.not_before) is timedelta and event_time < (now - self.not_before):
                     self.acknowledge_message()
-                    self.logger.debug("Filtered out event with time.source " + repr(event.get('time.source')))
+                    self.logger.debug("Filtered out event with time.source {!r}.".format(event.get('time.source')))
                     return
 
         # key/value based filtering

--- a/intelmq/bots/parsers/alienvault/parser.py
+++ b/intelmq/bots/parsers/alienvault/parser.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import sys
 
-from intelmq.lib.bot import Bot
+from intelmq.lib.bot import ParserBot
 from intelmq.lib.message import Event
 
 CLASSIFICATION = {
@@ -15,7 +15,7 @@ CLASSIFICATION = {
 }
 
 
-class AlienVaultParserBot(Bot):
+class AlienVaultParserBot(ParserBot):
 
     def parse_line(self, row, report):
         values = row.split("#")

--- a/intelmq/bots/parsers/shadowserver/parser.py
+++ b/intelmq/bots/parsers/shadowserver/parser.py
@@ -126,8 +126,8 @@ class ShadowserverParserBot(ParserBot):
                     try:
                         value = conv_func(raw_value)
                     except:
-                        self.logger.error('could not convert shadowkey: "{}", ' +
-                                          'value: "{}" via conversion function {}'.format(shadowkey, raw_value, repr(conv_func)))
+                        self.logger.error('Could not convert shadowkey: "{}", ' +
+                                          'value: "{}" via conversion function {}.'.format(shadowkey, raw_value, repr(conv_func)))
                         value = None
                         # """ fail early and often in this case. We want to be able to convert everything """
                         # self.stop()
@@ -142,10 +142,10 @@ class ShadowserverParserBot(ParserBot):
                     fields.remove(shadowkey)
                 except InvalidValue:
                     self.logger.info(
-                        'Could not add key "{}";'
+                        'Could not add key {!r};'
                         ' adding it to extras...'.format(shadowkey)
                     )
-                    self.logger.debug('The value of the event is %s', value)
+                    self.logger.debug('The value of the event is {!r}.'.format(value))
                 except InvalidKey:
                     extra[intelmqkey] = value
                     fields.remove(shadowkey)
@@ -156,7 +156,7 @@ class ShadowserverParserBot(ParserBot):
         for key, value in conf.get('constant_fields', {}).items():
             event.add(key, value)
 
-        self.logger.debug("raw_line: {!r}".format(row))
+        self.logger.debug("Raw_line: {!r}.".format(row))
         event.add('raw', self.recover_line(row))
 
         # Add everything which could not be resolved to extra.

--- a/intelmq/bots/parsers/vxvault/parser.py
+++ b/intelmq/bots/parsers/vxvault/parser.py
@@ -2,6 +2,7 @@
 import sys
 from urllib.parse import urlparse
 
+from intelmq.lib import utils
 from intelmq.lib.bot import ParserBot
 from intelmq.lib.harmonization import IPAddress
 from intelmq.lib.message import Event
@@ -9,14 +10,20 @@ from intelmq.lib.message import Event
 
 class VXVaultParserBot(ParserBot):
 
+    def parse(self, report):
+        report_split = utils.base64_decode(report["raw"]).strip().splitlines()
+        self.tempdata = report_split[:2]
+        for line in report_split[3:]:
+            yield line.strip()
+
     def parse_line(self, row, report):
         if not row.startswith('http'):
-            return
+            return []
 
         url_object = urlparse(row)
 
         if not url_object:
-            return
+            return []
 
         url = url_object.geturl()
         hostname = url_object.hostname
@@ -34,8 +41,12 @@ class VXVaultParserBot(ParserBot):
         if port:
             event.add("source.port", port)
         event.add("raw", row)
+        event.add("time.source", self.tempdata[1])
 
-        self.send_message(event)
+        yield event
+
+    def recover_line(self, line):
+        return '\n'.join(self.tempdata + [line])
 
 
 if __name__ == "__main__":

--- a/intelmq/lib/bot.py
+++ b/intelmq/lib/bot.py
@@ -342,7 +342,7 @@ class Bot(object):
                                                                         value)))
 
     def __load_system_configuration(self):
-        self.__log_buffer.append(('debug', "Loading system configuration"))
+        self.__log_buffer.append(('debug', "Loading system configuration."))
         config = utils.load_configuration(SYSTEM_CONF_FILE)
 
         for option, value in config.items():
@@ -353,7 +353,7 @@ class Bot(object):
                                                                         value)))
 
     def __load_runtime_configuration(self):
-        self.logger.debug("Loading runtime configuration")
+        self.logger.debug("Loading runtime configuration.")
         config = utils.load_configuration(RUNTIME_CONF_FILE)
 
         if self.__bot_id in list(config.keys()):
@@ -363,7 +363,7 @@ class Bot(object):
                                   "loaded with value {!r}.".format(option, value))
 
     def __load_pipeline_configuration(self):
-        self.logger.debug("Loading pipeline configuration")
+        self.logger.debug("Loading pipeline configuration.")
         config = utils.load_configuration(PIPELINE_CONF_FILE)
 
         self.__source_queues = None

--- a/intelmq/lib/test.py
+++ b/intelmq/lib/test.py
@@ -206,52 +206,29 @@ class BotTestCase(object):
         return [utils.decode(text) for text
                 in self.pipe.state["%s-output" % self.bot_id]]
 
-    def test_bot_start(self):
-        """Tests if we can start a bot and feed data into
-            it and have a reasonable output"""
-        self.run_bot()
-
-    def test_log_init(self):
-        """ Test if bot logs initialized message. """
+    def test_logs(self):
+#        """ Test if bot logs initialized message. """
         self.run_bot()
         self.assertLoglineMatches(0, "{} initialized with id {} and version"
                                      " [0-9.]{{5}} \([a-zA-Z0-9,:. ]+\)( \[GCC\])?"
                                      " as process [0-9]+\."
                                      "".format(self.bot_name,
                                                self.bot_id), "INFO")
-
-    def test_log_starting(self):
-        """ Test if bot logs starting message. """
-        self.run_bot()
         self.assertRegexpMatchesLog("INFO - Bot is starting.")
-
-    def test_log_stopped(self):
-        """ Test if bot logs stopped message. """
-        self.run_bot()
         self.assertLoglineEqual(-1, "Bot stopped.", "INFO")
-
-    def test_log_end_dot(self):
-        """ Test if every log lines ends with a dot. """
         for logline in self.loglines:
             fields = utils.parse_logline(logline)
-            self.assertTrue(fields['message'].endswith('.'),
-                            msg='Logline {} does not end with dot.'
+            self.assertTrue(fields['message'][-1] in '.?!',
+                            msg='Logline {!r} does not end with .? or !.'
                                 ''.format(fields['message']))
-
-    def test_log_not_error(self):
-        """ Test if bot does not log errors. """
-        self.run_bot()
+            self.assertTrue(fields['message'].upper() == fields['message'].upper(),
+                            msg='Logline {!r} does not beginn with an upper case char.'
+                                ''.format(fields['message']))
         self.assertNotRegexpMatchesLog("(ERROR.*?){}"
                                        "".format(self.allowed_error_count))
-
-    def test_log_not_critical(self):
-        """ Test if bot does not log critical errors. """
-        self.run_bot()
         self.assertNotRegexpMatchesLog("CRITICAL")
 
-    def test_pipe_names(self):
-        """ Test if all pipes are created with correct names. """
-        self.run_bot()
+#        """ Test if all pipes are created with correct names. """
         pipenames = ["{}-input", "{}-input-internal", "{}-output"]
         self.assertSetEqual({x.format(self.bot_id) for x in pipenames},
                             set(self.pipe.state.keys()))
@@ -291,7 +268,7 @@ class BotTestCase(object):
 
     def test_event(self):
         """ Test if event has required fields. """
-        if self.bot_type not in ['parser', 'expert']:
+        if self.bot_type != 'parser':
             return
 
         self.run_bot()

--- a/intelmq/tests/bots/parsers/vxvault/test_parser.py
+++ b/intelmq/tests/bots/parsers/vxvault/test_parser.py
@@ -20,7 +20,7 @@ EXAMPLE_EVENT = {"feed.name": "VxVault",
                  "__type": "Event",
                  "raw": "aHR0cDovL2V4YW1wbGUuY29tL2JhZC9wcm9ncmFtLmV4ZQ==",
                  "source.fqdn": "example.com",
-                 "time.observation": "2015-01-01T00:00:00+00:00",
+                 "time.source": "2015-08-17T14:36:19+00:00",
                  }
 
 

--- a/intelmq/tests/bots/test_dummy_bot.py
+++ b/intelmq/tests/bots/test_dummy_bot.py
@@ -1,23 +1,24 @@
 # -*- coding: utf-8 -*-
 
 import unittest
-import dateutil.parser
 import mock
 
 import intelmq.lib.bot
 import intelmq.lib.bot as bot
 import intelmq.lib.test as test
+import intelmq.lib.utils as utils
 from intelmq.lib.message import Event
+
+RAW = """# ignore this
+2015/06/04 13:37 +00,example.org,192.0.2.3,reverse.example.net,example description,report@example.org,0
+
+2015/06/04_13:37 +00,example.org,192.0.2.3,reverse.example.net,example description,report@example.org,0
+#ending line"""
+
 
 EXAMPLE_REPORT = {"feed.url": "http://www.example.com/",
                   "time.observation": "2015-08-11T13:03:40+00:00",
-                  "raw": """
-IyBpZ25vcmUgdGhpcwoyMDE1LzA2LzA0IDEzOjM3ICswMCxleGFtcGxlLm9yZywxOTIuMC4yLjMs
-cmV2ZXJzZS5leGFtcGxlLm5ldCxleGFtcGxlIGRlc2NyaXB0aW9uLHJlcG9ydEBleGFtcGxlLm9y
-ZywwCgoyMDE1LzA2LzA0XzEzOjM3ICswMCxleGFtcGxlLm9yZywxOTIuMC4yLjMscmV2ZXJzZS5l
-eGFtcGxlLm5ldCxleGFtcGxlIGRlc2NyaXB0aW9uLHJlcG9ydEBleGFtcGxlLm9yZywwCiNlbmRp
-bmcgbGluZQ==
-""",
+                  "raw": utils.base64_encode(RAW),
                   "__type": "Report",
                   "feed.name": "Example"}
 EXAMPLE_EVENT = {"feed.url": "http://www.example.com/",
@@ -48,12 +49,12 @@ class DummyParserBot(bot.ParserBot):
 
     def parse_line(self, line, report):
         if line.startswith('#'):
-            self.logger.info('Lorem ipsum dolor sit amet')
+            self.logger.info('Lorem ipsum dolor sit amet.')
             self.tempdata.append(line)
         else:
             event = Event(report)
             line = line.split(',')
-            event['time.source'] = str(dateutil.parser.parse(line[0]))
+            event['time.source'] = line[0]
             event['source.fqdn'] = line[1]
             event['source.ip'] = line[2]
             event['source.reverse_dns'] = line[3]
@@ -89,7 +90,7 @@ class TestDummyParserBot(test.BotTestCase, unittest.TestCase):
     def test_log_test_line(self):
         """ Test if bot does log example message. """
         self.run_bot()
-        self.assertRegexpMatchesLog("INFO - Lorem ipsum dolor sit amet")
+        self.assertRegexpMatchesLog("INFO - Lorem ipsum dolor sit amet.")
 
     def test_event(self):
         """ Test if correct Event has been produced. """


### PR DESCRIPTION
This reduces the runned bot-tests drastically from 805 to 322 and the time needed from 80s to 12s while remaining coverage.

Also, some tests haven't been effective, thus and many small issues in the bots have been fixed (missing leading dots, wrong imports, totally broken vxvault parser).

Signed-off-by: Sebastian Wagner <sebix@sebix.at>