### PR TITLE
Fixed MISP parser issue with raw field

### DIFF
--- a/intelmq/bots/parsers/misp/parser.py
+++ b/intelmq/bots/parsers/misp/parser.py
@@ -103,8 +103,7 @@ class MISPParserBot(Bot):
 
                 # Create and send the intelmq event
                 event = Event(report)
-                # FIXME: Send the whole MISP event with each attribute?
-                event.add('raw', json.dumps(misp_event, sort_keys=True))
+                event.add('raw', json.dumps(attribute, sort_keys=True))
                 event.add(self.MISP_TYPE_MAPPING[type_], value)
                 event.add('misp.event_uuid', misp_event['uuid'])
                 event.add('misp.attribute_uuid', uuid)


### PR DESCRIPTION
Raw field previously contained the entire MISP event for each attribute, resulting in massive duplication. It now just stores the JSON data for the MISP attribute.