### PR TITLE
Mail collectors: explicitly close IMAP connection

### DIFF
--- a/intelmq/bots/collectors/mail/collector_mail_attach.py
+++ b/intelmq/bots/collectors/mail/collector_mail_attach.py
@@ -65,6 +65,7 @@ class MailAttachCollectorBot(Bot):
                         # check it.
                         mailbox.mark_seen(uid)
                 self.logger.info("Email report read")
+        mailbox.logout()
 
 
 if __name__ == "__main__":

--- a/intelmq/bots/collectors/mail/collector_mail_url.py
+++ b/intelmq/bots/collectors/mail/collector_mail_url.py
@@ -90,6 +90,7 @@ class MailURLCollectorBot(Bot):
                         # check it.
                         mailbox.mark_seen(uid)
                 self.logger.info("Email report read")
+        mailbox.logout()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This patch adds an explicit mailbox.close() command to end the IMAP
connection.  Without this, mail does not get marked as \Seen reliably.