### PR TITLE
TESTS: (minor) cleanup: Using unittest.mock now.

### DIFF
--- a/intelmq/lib/test.py
+++ b/intelmq/lib/test.py
@@ -9,8 +9,8 @@ import io
 import json
 import logging
 import os
+import unittest.mock as mock
 
-import mock
 import pkg_resources
 
 import intelmq.lib.pipeline as pipeline

--- a/intelmq/tests/bots/test_dummy_bot.py
+++ b/intelmq/tests/bots/test_dummy_bot.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import unittest
-import mock
+import unittest.mock as mock
 
 import intelmq.lib.bot
 import intelmq.lib.bot as bot

--- a/intelmq/tests/lib/test_bot.py
+++ b/intelmq/tests/lib/test_bot.py
@@ -8,8 +8,8 @@ import json
 import logging
 import os
 import unittest
+import unittest.mock as mock
 
-import mock
 import pkg_resources
 
 import intelmq.lib.pipeline as pipeline

--- a/intelmq/tests/lib/test_message.py
+++ b/intelmq/tests/lib/test_message.py
@@ -8,8 +8,8 @@ but has a valid Harmonization configuration.
 """
 import json
 import unittest
+import unittest.mock as mock
 
-import mock
 import pkg_resources
 
 import intelmq.lib.exceptions as exceptions

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,6 @@ setup(
     maintainer_email='wagner@cert.at',
     install_requires=REQUIRES,
     tests_requires=REQUIRES+[
-        'mock>=1.1.1',
         'nose',
         ],
     test_suite='nose.collector',


### PR DESCRIPTION
mock is now part of the Python standard library, available as
unittest.mock in Python 3.3 onwards. As we require python3.3,
we can use unittest.mock and remove the requirement for an external mock.
(closes #659 https://github.com/certtools/intelmq/issues/659)