### PR TITLE
Introduction of the Enabled-Switch for Collectors.

### DIFF
--- a/docs/Bots.md
+++ b/docs/Bots.md
@@ -9,6 +9,10 @@
 <a name="collectors"></a>
 ## Collectors
 
+* All Collector-Bots can be extended with an `enabled` parameter in `runtime.conf`. If the parameter is set to `True`
+  (which is assumed as defaut if it is missing) the bot will start. If the parameter was set to `False`, the
+  Bot will not start, and terminate immediately. Nevertheless you will be informed about this in the bots' log file.
+
 ### HTTP
 
 #### Information:

--- a/intelmq/lib/bot.py
+++ b/intelmq/lib/bot.py
@@ -558,6 +558,34 @@ class CollectorBot(Bot):
                               'Possible Misconfiguration.')
             self.stop()
 
+    def start(self, starting=True, error_on_pipeline=True,
+              error_on_message=False, source_pipeline=None,
+              destination_pipeline=None):
+        """
+        Collector-Bots have their own start-method,
+        in order to enable the deactivation of a Collector-Bot,
+        one can use the 'enabled' parameter in the Bot's
+        JSON configuration if no paramter is provided, the bot will
+        start up normally.
+        """
+        if hasattr(self.parameters, 'enabled'):
+            enabled = utils.to_bool(self.parameters.enabled, True)
+            # Set to_bool fallback mode to True, in order to always
+            # start a bot, even when the value in the config could not
+            # be mapped to a boolean
+
+            if not enabled:
+                self.logger.warn('The bot was disabled by configuration. '
+                                 'It will not be started as long as this '
+                                 'configuration is present')
+                self.stop()
+                # code should have exited by now... just to be sure
+                return None
+
+        super(CollectorBot, self).start(starting, error_on_pipeline,
+                                        error_on_message, source_pipeline,
+                                        destination_pipeline)
+
     def __filter_empty_report(self, message):
         if 'raw' not in message:
             self.logger.warning('Ignoring report without raw field. '

--- a/intelmq/lib/utils.py
+++ b/intelmq/lib/utils.py
@@ -26,7 +26,7 @@ import intelmq
 
 __all__ = ['base64_decode', 'base64_encode', 'decode', 'encode',
            'load_configuration', 'load_parameters', 'log', 'parse_logline',
-           'reverse_readline', 'error_message_from_exc',
+           'reverse_readline', 'error_message_from_exc', 'to_bool',
            ]
 
 # Used loglines format
@@ -331,3 +331,44 @@ def error_message_from_exc(exc):
         The error message of exc
     """
     return traceback.format_exception_only(type(exc), exc)[-1].strip().replace(type(exc).__name__ + ': ', '')
+
+
+def to_bool(inStr, fallbackmode=False):
+    """
+    This method tries to convert an input value to a boolean.
+    The function is handy when user-input comes as a String
+    (i.e. from intelmq-manager) and should still be interpreted
+    as a bool. We use it to circumvent the "False" == True problem
+    :param inStr: An arbitrary String
+    :param fallbackmode: The fallback of the method. If it is True the function
+                  will evaluate to True if the input inStr could not be mapped
+                  in the function. If it is False, the function will evaluate
+                  to False as a fallback.
+    :return: True or False based on the boolmap and the fallbackmode
+    """
+    boolmap = {
+        "yes": True,
+        "no": False,
+        "true": True,
+        "false": False,
+        "0": False,
+        "1": True,
+    }
+
+    if inStr is True:
+        return True
+    elif inStr is False:
+        return False
+    elif inStr is None:
+        return False
+    elif inStr is 0:
+        return False
+    elif inStr is 1:
+        return True
+    else:
+        inStr = str.lower(str(inStr))
+        if inStr in boolmap:
+            return boolmap[inStr]
+        else:
+            return fallbackmode
+


### PR DESCRIPTION
This introduces the enabled-switch for all Collector-Bots.
By doing so it fixes #715.

The Collectorbot was extended with an own start-function
which checks if the enabled parameter is present and was set
to a representation of False. To check the "representation of
False" the function to_bool was introduced in utils.py, which
maps well-known-text to booleans. It has a a fallbackmode parameter
which determines if the function returns true of false if no
mapping  was found.

As long as to_bool does not evaluate to False the bot will be started.
