### PR TITLE
Add "feed.provider" to the DHO

### DIFF
--- a/docs/Harmonization-fields.md
+++ b/docs/Harmonization-fields.md
@@ -14,7 +14,7 @@ Harmonization field names
 |Destination|destination.as_name|[String](#string)|The autonomous system name to which the connection headed.|
 |Destination|destination.asn|[Integer](#integer)|The autonomous system number from which originated the connection.|
 |Destination|destination.fqdn|[FQDN](#fqdn)|A DNS name related to the host from which the connection originated. DNS allows even binary data in DNS, so we have to allow everything. A final point is stripped, string is converted to lower case characters.|
-|Destination Geolocation|destination.geolocation.cc|[UppercaseString](#uppercasestring)|Country-Code accoriding to ISO3166-1 alpha-2 for the destination IP.|
+|Destination Geolocation|destination.geolocation.cc|[UppercaseString](#uppercasestring)|Country-Code according to ISO3166-1 alpha-2 for the destination IP.|
 |Destination Geolocation|destination.geolocation.city|[String](#string)|Some geolocation services refer to city-level geolocation.|
 |Destination Geolocation|destination.geolocation.country|[String](#string)|The country name derived from the ISO3166 country code (assigned to cc field).|
 |Destination Geolocation|destination.geolocation.latitude|[Float](#float)|Latitude coordinates derived from a geolocation service, such as MaxMind geoip db.|
@@ -38,6 +38,7 @@ Harmonization field names
 |Feed|feed.accuracy|[Accuracy](#accuracy)|A float between 0 and 100 that represents how accurate the data in the feed is|
 |Feed|feed.code|[String](#string)|Code name for the feed, e.g. DFGS, HSDAG etc.|
 |Feed|feed.name|[String](#string)|Name for the feed, usually found in collector bot configuration.|
+|Feed|feed.provider|[String](#string)|Name for the provider of the feed, usually found in collector bot configuration.|
 |Feed|feed.url|[URL](#url)|The URL of a given abuse feed, where applicable|
 |Malware|malware.hash|[String](#string)|A string depicting a checksum for a file, be it a malware sample for example. You may include the hash type according to https://en.wikipedia.org/wiki/Crypt_%28C%29 and use only printable characters. Please see https://github.com/certtools/intelmq/pull/634 for a discussion on this issue.|
 |Malware Hash|malware.hash.md5|[String](#string)|A string depicting an MD5 checksum for a file, be it a malware sample for example. You may include the hash type according to https://en.wikipedia.org/wiki/Crypt_%28C%29 and use only printable characters. Please see https://github.com/certtools/intelmq/pull/634 for a discussion on this issue.|
@@ -57,7 +58,7 @@ Harmonization field names
 |Source|source.as_name|[String](#string)|The autonomous system name from which the connection originated.|
 |Source|source.asn|[Integer](#integer)|The autonomous system number from which originated the connection.|
 |Source|source.fqdn|[FQDN](#fqdn)|A DNS name related to the host from which the connection originated. DNS allows even binary data in DNS, so we have to allow everything. A final point is stripped, string is converted to lower case characters.|
-|Source Geolocation|source.geolocation.cc|[UppercaseString](#uppercasestring)|Country-Code accoriding to ISO3166-1 alpha-2 for the source IP.|
+|Source Geolocation|source.geolocation.cc|[UppercaseString](#uppercasestring)|Country-Code according to ISO3166-1 alpha-2 for the source IP.|
 |Source Geolocation|source.geolocation.city|[String](#string)|Some geolocation services refer to city-level geolocation.|
 |Source Geolocation|source.geolocation.country|[String](#string)|The country name derived from the ISO3166 country code (assigned to cc field).|
 |Source Geolocation|source.geolocation.cymru_cc|[UppercaseString](#uppercasestring)|The country code denoted for the ip by the Team Cymru asn to ip mapping service.|

--- a/intelmq/bots/BOTS
+++ b/intelmq/bots/BOTS
@@ -6,6 +6,7 @@
             "parameters": {
                 "delete_file": false,
                 "feed": "FileCollector",
+                "provider": "",
                 "path": "/tmp/",
                 "postfix": ".csv",
                 "rate_limit": 300
@@ -18,6 +19,7 @@
                 "attach_regex": "csv.zip",
                 "attach_unzip": true,
                 "feed": "",
+                "provider": "",
                 "folder": "INBOX",
                 "mail_host": "<host>",
                 "mail_password": "<password>",
@@ -32,6 +34,7 @@
             "module": "intelmq.bots.collectors.mail.collector_mail_url",
             "parameters": {
                 "feed": "",
+                "provider": "",
                 "folder": "INBOX",
                 "http_password": "<password>",
                 "http_user": "<user>",
@@ -49,6 +52,7 @@
             "module": "intelmq.bots.collectors.http.collector_http",
             "parameters": {
                 "feed": "",
+                "provider": "",
                 "http_url": "<insert url of feed>",
                 "rate_limit": 3600
             }
@@ -58,6 +62,7 @@
             "module": "intelmq.bots.collectors.misp.collector",
             "parameters": {
                 "feed": "misp_generic",
+                "provider": "",
                 "misp_key": "<insert MISP Authkey>",
                 "misp_tag_processed": "<insert MISP tag for processed events>",
                 "misp_tag_to_process": "<insert MISP tag for events to be processed>",
@@ -72,6 +77,7 @@
             "parameters": {
                 "attachment_regex": "\\.csv\\.zip$",
                 "feed": "Request Tracker",
+                "provider": "",
                 "password": "password",
                 "rate_limit": 3600,
                 "search_owner": "nobody",
@@ -92,6 +98,7 @@
             "parameters": {
                 "ca_certs": "/etc/ssl/certs/ca-certificates.crt",
                 "feed": "XMPP",
+                "provider": "",
                 "pass_full_xml": false,
                 "rate_limit": 3600,
                 "strip_message": true,
@@ -109,6 +116,7 @@
             "parameters": {
                 "api_key": "<insert your api key>",
                 "feed": "AlienVault OTX",
+                "provider": "AlienVault",
                 "rate_limit": 3600
             }
         },
@@ -117,6 +125,7 @@
             "module": "intelmq.bots.collectors.bitsight.collector",
             "parameters": {
                 "feed": "BitSight",
+                "provider": "BitSight",
                 "http_url": "http://alerts.bitsighttech.com:8080/stream?key=<api>"
             }
         },
@@ -126,6 +135,7 @@
             "parameters": {
                 "api_key": "<insert your api key>",
                 "feed": "Blueliv Crimeserver",
+                "provider": "Blueliv",
                 "rate_limit": 3600
             }
         },
@@ -135,6 +145,7 @@
             "parameters": {
                 "exchange": "<INSERT your exchange point as given by CERT.pl>",
                 "feed": "n6stomp",
+                "provider": "N6",
                 "port": 61614,
                 "server": "n6stream.cert.pl",
                 "ssl_ca_certificate": "<insert path to CA file for CERT.pl's n6>",

--- a/intelmq/etc/harmonization.conf
+++ b/intelmq/etc/harmonization.conf
@@ -43,7 +43,7 @@
             "type": "FQDN"
         },
         "destination.geolocation.cc": {
-            "description": "Country-Code accoriding to ISO3166-1 alpha-2 for the destination IP.",
+            "description": "Country-Code according to ISO3166-1 alpha-2 for the destination IP.",
             "length": 2,
             "regex": "^[a-zA-Z0-9]{2}$",
             "type": "UppercaseString"
@@ -145,6 +145,10 @@
             "description": "Name for the feed, usually found in collector bot configuration.",
             "type": "String"
         },
+        "feed.provider": {
+            "description": "Name for the provider of the feed, usually found in collector bot configuration.",
+            "type": "String"
+        },
         "feed.url": {
             "description": "The URL of a given abuse feed, where applicable",
             "type": "URL"
@@ -239,7 +243,7 @@
             "type": "FQDN"
         },
         "source.geolocation.cc": {
-            "description": "Country-Code accoriding to ISO3166-1 alpha-2 for the source IP.",
+            "description": "Country-Code according to ISO3166-1 alpha-2 for the source IP.",
             "length": 2,
             "regex": "^[a-zA-Z0-9]{2}$",
             "type": "UppercaseString"
@@ -344,6 +348,10 @@
         },
         "feed.name": {
             "description": "Name for the feed, usually found in collector bot configuration.",
+            "type": "String"
+        },
+        "feed.provider": {
+            "description": "Name for the provider of the feed, usually found in collector bot configuration.",
             "type": "String"
         },
         "feed.url": {

--- a/intelmq/lib/bot.py
+++ b/intelmq/lib/bot.py
@@ -563,7 +563,7 @@ class CollectorBot(Bot):
     def __filter_empty_report(self, message):
         if 'raw' not in message:
             self.logger.warning('Ignoring report without raw field. '
-                                'Possible bug or miconfiguration of this bot.')
+                                'Possible bug or misconfiguration of this bot.')
             return False
         return True
 
@@ -571,6 +571,8 @@ class CollectorBot(Bot):
         report.add("feed.name", self.parameters.feed)
         if hasattr(self.parameters, 'code'):
             report.add("feed.code", self.parameters.code)
+        if hasattr(self.parameters, 'provider'):
+            report.add("feed.provider", self.parameters.provider)
         report.add("feed.accuracy", self.parameters.accuracy)
         return report
 

--- a/intelmq/lib/message.py
+++ b/intelmq/lib/message.py
@@ -288,6 +288,8 @@ class Event(Message):
                 template['feed.code'] = message['feed.code']
             if 'feed.name' in message:
                 template['feed.name'] = message['feed.name']
+            if 'feed.provider' in message:
+                template['feed.provider'] = message['feed.provider']
             if 'feed.url' in message:
                 template['feed.url'] = message['feed.url']
             if 'rtir_id' in message:

--- a/intelmq/tests/bin/initdb.sql
+++ b/intelmq/tests/bin/initdb.sql
@@ -34,6 +34,7 @@ CREATE TABLE events (
     "feed.accuracy" real,
     "feed.code" varchar(100),
     "feed.name" text,
+    "feed.provider" text,
     "feed.url" text,
     "malware.hash" varchar(200),
     "malware.hash.md5" varchar(200),

--- a/intelmq/tests/bots/test_dummy_collectorbot.py
+++ b/intelmq/tests/bots/test_dummy_collectorbot.py
@@ -57,7 +57,7 @@ class TestDummyCollectorBot(test.BotTestCase, unittest.TestCase):
         self.sysconfig['raw'] = False
         self.run_bot()
         self.assertAnyLoglineEqual(message='Ignoring report without raw field. '
-                                           'Possible bug or miconfiguration of this bot.',
+                                           'Possible bug or misconfiguration of this bot.',
                                    levelname='WARNING')
 
 


### PR DESCRIPTION
This implements #725 (also mentioned in #733) and includes some typo fixes.

This only adds `feed.provider` to the DHO and implements adding it to the report if the parameter `provider` is set in a collector (analogous to `feed.code`). Whether this value is set in the parsers is still open for discussion.
