### PR TITLE
Redis UNIX socket support

### DIFF
--- a/docs/User-Guide.md
+++ b/docs/User-Guide.md
@@ -249,15 +249,15 @@ More examples can be found at `intelmq/etc/pipeline.conf` directory in IntelMQ r
 
 * **`rate_limit`** - time interval (in seconds) between messages processing. The value must be an `integer value`.
 
-* **`source_pipeline_host`** - broker IP or FQDN that the bot will use to connect and receive messages.
+* **`source_pipeline_host`** - broker IP, FQDN or Unix socket that the bot will use to connect and receive messages.
 
-* **`source_pipeline_port`** - broker port that the bot will use to connect and receive messages.
+* **`source_pipeline_port`** - broker port that the bot will use to connect and receive messages. Can be empty for Unix socket.
 
 * **`source_pipeline_db`** - broker database that the bot will use to connect and receive messages (requirement from redis broker).
 
-* **`destination_pipeline_host`** - broker IP or FQDN that the bot will use to connect and send messages.
+* **`destination_pipeline_host`** - broker IP, FQDN or Unix socket that the bot will use to connect and send messages. 
 
-* **`destination_pipeline_port`** - broker port that the bot will use to connect and send messages.
+* **`destination_pipeline_port`** - broker port that the bot will use to connect and send messages. Can be empty for Unix socket.
 
 * **`destination_pipeline_db`** - broker database that the bot will use to connect and send messages (requirement from redis broker).
 

--- a/intelmq/lib/cache.py
+++ b/intelmq/lib/cache.py
@@ -17,10 +17,20 @@ __all__ = ['Cache']
 class Cache():
 
     def __init__(self, host, port, db, ttl):
-        self.redis = redis.Redis(host=host,
-                                 port=int(port),
-                                 db=db,
-                                 socket_timeout=5)
+        if host.startswith("/"):
+            kwargs = {"unix_socket_path": host}
+
+        elif host.startswith("unix://"):
+            kwargs = {"unix_socket_path": host.replace("unix://", "")}
+
+        else:
+            kwargs = {
+                "host": host,
+                "port": int(port),
+                "socket_timeout": 5,
+            }
+
+        self.redis = redis.Redis(db=db, **kwargs)
 
         self.ttl = ttl
 

--- a/intelmq/lib/pipeline.py
+++ b/intelmq/lib/pipeline.py
@@ -72,11 +72,20 @@ class Redis(Pipeline):
         self.load_balance_iterator = 0
 
     def connect(self):
-        self.pipe = redis.Redis(host=self.host,
-                                port=int(self.port),
-                                db=self.db,
-                                socket_timeout=self.socket_timeout
-                                )
+        if self.host.startswith("/"):
+            kwargs = {"unix_socket_path": self.host}
+
+        elif self.host.startswith("unix://"):
+            kwargs = {"unix_socket_path": self.host.replace("unix://", "")}
+
+        else:
+            kwargs = {
+                "host": self.host,
+                "port": int(self.port),
+                "socket_timeout": self.socket_timeout,
+            }
+
+        self.pipe = redis.Redis(db=self.db, **kwargs)
 
     def disconnect(self):
         pass


### PR DESCRIPTION
UNIX socket can be faster (see http://redis.io/topics/benchmarks) and sometimes is easier to connect Redis with a socket instead of TCP.