### PR TITLE
Added ability to connect password protected Redis

### DIFF
--- a/docs/User-Guide.md
+++ b/docs/User-Guide.md
@@ -254,11 +254,15 @@ More examples can be found at `intelmq/etc/pipeline.conf` directory in IntelMQ r
 
 * **`source_pipeline_port`** - broker port that the bot will use to connect and receive messages. Can be empty for Unix socket.
 
+* **`source_pipeline_password`** - broker password that the bot will use to connect and receive messages. Can be empty for unprotected broker.
+
 * **`source_pipeline_db`** - broker database that the bot will use to connect and receive messages (requirement from redis broker).
 
 * **`destination_pipeline_host`** - broker IP, FQDN or Unix socket that the bot will use to connect and send messages. 
 
 * **`destination_pipeline_port`** - broker port that the bot will use to connect and send messages. Can be empty for Unix socket.
+
+* **`destination_pipeline_password`** - broker password that the bot will use to connect and send messages. Can be empty for unprotected broker.
 
 * **`destination_pipeline_db`** - broker database that the bot will use to connect and send messages (requirement from redis broker).
 

--- a/intelmq/bots/BOTS
+++ b/intelmq/bots/BOTS
@@ -439,6 +439,7 @@
                 "redis_cache_db": "5",
                 "redis_cache_host": "127.0.0.1",
                 "redis_cache_port": "6379",
+                "redis_cache_password": "",
                 "redis_cache_ttl": "86400"
             }
         },
@@ -458,6 +459,7 @@
                 "redis_cache_db": "5",
                 "redis_cache_host": "127.0.0.1",
                 "redis_cache_port": "6379",
+                "redis_cache_password": "",
                 "redis_cache_ttl": "86400"
             }
         },
@@ -469,6 +471,7 @@
                 "redis_cache_db": "6",
                 "redis_cache_host": "127.0.0.1",
                 "redis_cache_port": "6379",
+                "redis_cache_password": "",
                 "redis_cache_ttl": "86400"
             }
         },
@@ -540,6 +543,7 @@
                 "redis_cache_db": "5",
                 "redis_cache_host": "127.0.0.1",
                 "redis_cache_port": "6379",
+                "redis_cache_password": "",
                 "redis_cache_ttl": "86400"
             }
         },
@@ -550,6 +554,7 @@
                 "redis_cache_db": "7",
                 "redis_cache_host": "127.0.0.1",
                 "redis_cache_port": "6379",
+                "redis_cache_password": "",
                 "redis_cache_ttl": "86400"
             }
         },

--- a/intelmq/bots/experts/cymru_whois/expert.py
+++ b/intelmq/bots/experts/cymru_whois/expert.py
@@ -18,6 +18,7 @@ class CymruExpertBot(Bot):
                            self.parameters.redis_cache_port,
                            self.parameters.redis_cache_db,
                            self.parameters.redis_cache_ttl,
+                           self.parameters.get("redis_cache_password", None)
                            )
 
     def process(self):

--- a/intelmq/bots/experts/cymru_whois/expert.py
+++ b/intelmq/bots/experts/cymru_whois/expert.py
@@ -18,7 +18,8 @@ class CymruExpertBot(Bot):
                            self.parameters.redis_cache_port,
                            self.parameters.redis_cache_db,
                            self.parameters.redis_cache_ttl,
-                           self.parameters.get("redis_cache_password", None)
+                           getattr(self.parameters, "redis_cache_password",
+                                   None)
                            )
 
     def process(self):

--- a/intelmq/bots/experts/deduplicator/expert.py
+++ b/intelmq/bots/experts/deduplicator/expert.py
@@ -12,6 +12,7 @@ class DeduplicatorExpertBot(Bot):
                            self.parameters.redis_cache_port,
                            self.parameters.redis_cache_db,
                            self.parameters.redis_cache_ttl,
+                           self.parameters.get("redis_cache_password", None)
                            )
 
     def process(self):

--- a/intelmq/bots/experts/deduplicator/expert.py
+++ b/intelmq/bots/experts/deduplicator/expert.py
@@ -12,7 +12,8 @@ class DeduplicatorExpertBot(Bot):
                            self.parameters.redis_cache_port,
                            self.parameters.redis_cache_db,
                            self.parameters.redis_cache_ttl,
-                           self.parameters.get("redis_cache_password", None)
+                           getattr(self.parameters, "redis_cache_password",
+                                   None)
                            )
 
     def process(self):

--- a/intelmq/bots/experts/reverse_dns/expert.py
+++ b/intelmq/bots/experts/reverse_dns/expert.py
@@ -21,6 +21,7 @@ class ReverseDnsExpertBot(Bot):
                            self.parameters.redis_cache_port,
                            self.parameters.redis_cache_db,
                            self.parameters.redis_cache_ttl,
+                           self.parameters.get("redis_cache_password", None)
                            )
 
     def process(self):

--- a/intelmq/bots/experts/reverse_dns/expert.py
+++ b/intelmq/bots/experts/reverse_dns/expert.py
@@ -21,7 +21,8 @@ class ReverseDnsExpertBot(Bot):
                            self.parameters.redis_cache_port,
                            self.parameters.redis_cache_db,
                            self.parameters.redis_cache_ttl,
-                           self.parameters.get("redis_cache_password", None)
+                           getattr(self.parameters, "redis_cache_password",
+                                   None)
                            )
 
     def process(self):

--- a/intelmq/etc/defaults.conf
+++ b/intelmq/etc/defaults.conf
@@ -4,6 +4,7 @@
     "destination_pipeline_db": 2,
     "destination_pipeline_host": "127.0.0.1",
     "destination_pipeline_port": 6379,
+    "destination_pipeline_password": null,
     "error_dump_message": true,
     "error_log_exception": true,
     "error_log_message": true,
@@ -22,5 +23,6 @@
     "rate_limit": 0,
     "source_pipeline_db": 2,
     "source_pipeline_host": "127.0.0.1",
-    "source_pipeline_port": 6379
+    "source_pipeline_port": 6379,
+    "source_pipeline_password": null,
 }

--- a/intelmq/lib/cache.py
+++ b/intelmq/lib/cache.py
@@ -16,7 +16,7 @@ __all__ = ['Cache']
 
 class Cache():
 
-    def __init__(self, host, port, db, ttl):
+    def __init__(self, host, port, db, ttl, password=None):
         if host.startswith("/"):
             kwargs = {"unix_socket_path": host}
 
@@ -30,7 +30,7 @@ class Cache():
                 "socket_timeout": 5,
             }
 
-        self.redis = redis.Redis(db=db, **kwargs)
+        self.redis = redis.Redis(db=db, password=password, **kwargs)
 
         self.ttl = ttl
 

--- a/intelmq/lib/pipeline.py
+++ b/intelmq/lib/pipeline.py
@@ -63,6 +63,8 @@ class Redis(Pipeline):
                             "{}_pipeline_port".format(queues_type), "6379")
         self.db = getattr(self.parameters,
                           "{}_pipeline_db".format(queues_type), 2)
+        self.password = getattr(self.parameters,
+                          "{}_pipeline_password".format(queues_type), None)
         #  socket_timeout is None by default, which means no timeout
         self.socket_timeout = getattr(self.parameters,
                                       "{}_pipeline_socket_timeout".format(
@@ -85,7 +87,7 @@ class Redis(Pipeline):
                 "socket_timeout": self.socket_timeout,
             }
 
-        self.pipe = redis.Redis(db=self.db, **kwargs)
+        self.pipe = redis.Redis(db=self.db, password=self.password, **kwargs)
 
     def disconnect(self):
         pass

--- a/intelmq/lib/pipeline.py
+++ b/intelmq/lib/pipeline.py
@@ -64,7 +64,8 @@ class Redis(Pipeline):
         self.db = getattr(self.parameters,
                           "{}_pipeline_db".format(queues_type), 2)
         self.password = getattr(self.parameters,
-                          "{}_pipeline_password".format(queues_type), None)
+                                "{}_pipeline_password".format(queues_type),
+                                None)
         #  socket_timeout is None by default, which means no timeout
         self.socket_timeout = getattr(self.parameters,
                                       "{}_pipeline_socket_timeout".format(


### PR DESCRIPTION
In some cases (for example `rhscl/redis-32-rhel7` RedHat Docker image) is required to run password protected Redis. This pull makes this possible for Pipeline and Cache.