### PR TITLE
Cache also invalid responses from DNS server in reverse_dns bot

### DIFF
--- a/intelmq/bots/BOTS
+++ b/intelmq/bots/BOTS
@@ -550,7 +550,8 @@
                 "redis_cache_db": "7",
                 "redis_cache_host": "127.0.0.1",
                 "redis_cache_port": "6379",
-                "redis_cache_ttl": "86400"
+                "redis_cache_ttl": "86400",
+                "cache_ttl_invalid_response": "60"
             }
         },
         "Taxonomy": {

--- a/intelmq/bots/experts/reverse_dns/expert.py
+++ b/intelmq/bots/experts/reverse_dns/expert.py
@@ -64,8 +64,10 @@ class ReverseDnsExpertBot(Bot):
                         result = None
                         raise ValueError
                 except (dns.exception.DNSException, ValueError) as e:
-                    # Set longer TTL for 'DNS query name does not exist' error
-                    ttl = 3600 if isinstance(e, dns.resolver.NXDOMAIN) else 60
+                    # Set default TTL for 'DNS query name does not exist' error
+                    ttl = None if isinstance(e, dns.resolver.NXDOMAIN) else \
+                        getattr(self.parameters, "cache_ttl_invalid_response",
+                                60)
                     self.cache.set(cache_key, DNS_EXCEPTION_VALUE, ttl)
 
                 else:

--- a/intelmq/bots/experts/reverse_dns/expert.py
+++ b/intelmq/bots/experts/reverse_dns/expert.py
@@ -12,6 +12,7 @@ from intelmq.lib.harmonization import IPAddress
 
 MINIMUM_BGP_PREFIX_IPV4 = 24
 MINIMUM_BGP_PREFIX_IPV6 = 128
+DNS_EXCEPTION_VALUE = "__dns-exception"
 
 
 class ReverseDnsExpertBot(Bot):
@@ -48,7 +49,9 @@ class ReverseDnsExpertBot(Bot):
             cachevalue = self.cache.get(cache_key)
 
             result = None
-            if cachevalue:
+            if cachevalue == DNS_EXCEPTION_VALUE:
+                continue
+            elif cachevalue:
                 result = cachevalue
             else:
                 rev_name = reversename.from_address(ip)
@@ -62,6 +65,7 @@ class ReverseDnsExpertBot(Bot):
                         raise ValueError
                 except (dns.exception.DNSException, ValueError) as e:
                     if isinstance(e, dns.resolver.NXDOMAIN):
+                        self.cache.set(cache_key, DNS_EXCEPTION_VALUE, ttl=60)
                         continue
                 else:
                     ttl = datetime.fromtimestamp(expiration) - datetime.now()

--- a/intelmq/bots/experts/reverse_dns/expert.py
+++ b/intelmq/bots/experts/reverse_dns/expert.py
@@ -64,9 +64,10 @@ class ReverseDnsExpertBot(Bot):
                         result = None
                         raise ValueError
                 except (dns.exception.DNSException, ValueError) as e:
-                    if isinstance(e, dns.resolver.NXDOMAIN):
-                        self.cache.set(cache_key, DNS_EXCEPTION_VALUE, ttl=60)
-                        continue
+                    # Set longer TTL for 'DNS query name does not exist' error
+                    ttl = 3600 if isinstance(e, dns.resolver.NXDOMAIN) else 60
+                    self.cache.set(cache_key, DNS_EXCEPTION_VALUE, ttl)
+
                 else:
                     ttl = datetime.fromtimestamp(expiration) - datetime.now()
                     self.cache.set(cache_key, str(result),


### PR DESCRIPTION
For 60 or 3600 seconds, because in some cases response can take 5 seconds and it can slow down the whole queue.