### PR TITLE
Extended to_json with a "with_type" option.

### DIFF
--- a/intelmq/bots/outputs/xmpp/output.py
+++ b/intelmq/bots/outputs/xmpp/output.py
@@ -74,7 +74,8 @@ class XMPPOutputBot(Bot):
         receiver = self.parameters.xmpp_to_user + '@' +\
             self.parameters.xmpp_to_server
 
-        jevent = event.to_json(hierarchical=self.parameters.hierarchical_output)
+        jevent = event.to_json(hierarchical=self.parameters.hierarchical_output,
+                               with_type=True)
 
         try:
             # TODO: proper error handling. Right now it cannot be

--- a/intelmq/lib/message.py
+++ b/intelmq/lib/message.py
@@ -243,8 +243,11 @@ class Message(dict):
 
         return event_hash.hexdigest()
 
-    def to_dict(self, hierarchical=False):
+    def to_dict(self, hierarchical=False, with_type=False):
         json_dict = dict()
+
+        if with_type:
+            self['__type'] = self.__class__.__name__
 
         for key, value in self.items():
             if hierarchical:
@@ -262,10 +265,14 @@ class Message(dict):
                     json_dict_fp[subkey] = dict()
 
                 json_dict_fp = json_dict_fp[subkey]
+
+        if with_type:
+            del self['__type']
+
         return json_dict
 
-    def to_json(self, hierarchical=False):
-        json_dict = self.to_dict(hierarchical=hierarchical)
+    def to_json(self, hierarchical=False, with_type=False):
+        json_dict = self.to_dict(hierarchical=hierarchical, with_type=with_type)
         return json.dumps(json_dict, ensure_ascii=False)
 
 


### PR DESCRIPTION
In order to process events sent by XMPP within
the JSON-Parser, the to_json method of a message
needed to be extendet to add the type
of the message