### PR TITLE
Remove new lines from mail subject in mail collector

### DIFF
--- a/intelmq/bots/collectors/mail/collector_mail_attach.py
+++ b/intelmq/bots/collectors/mail/collector_mail_attach.py
@@ -29,7 +29,7 @@ class MailAttachCollectorBot(CollectorBot):
 
                 if (self.parameters.subject_regex and
                         not re.search(self.parameters.subject_regex,
-                                      message.subject)):
+                                      re.sub("\r\n\s", " ", message.subject))):
                     continue
 
                 for attach in message.attachments:

--- a/intelmq/bots/collectors/mail/collector_mail_url.py
+++ b/intelmq/bots/collectors/mail/collector_mail_url.py
@@ -34,7 +34,7 @@ class MailURLCollectorBot(CollectorBot):
 
                 if (self.parameters.subject_regex and
                         not re.search(self.parameters.subject_regex,
-                                      message.subject)):
+                                      re.sub("\r\n\s", " ", message.subject))):
                     continue
 
                 for body in message.body['plain']:


### PR DESCRIPTION
E-mail subject can contain newlines characters, but in e-mail format, it is only separator with no meaning. And without removing, subject regex can stop working anytime for a long subject.