### PR TITLE
Clarify 'enabled' switch

### DIFF
--- a/docs/Bots.md
+++ b/docs/Bots.md
@@ -5,9 +5,13 @@
 3. [Experts](#experts)
 4. [Outputs](#outputs)
 
-All Bots can be extended with an `enabled` parameter in `runtime.conf`. If the parameter is set to `True`
-(which is assumed as defaut if it is missing) the bot will start. If the parameter was set to `False`, the
-Bot will not start, and terminate immediately. Nevertheless you will be informed about this in the bots' log file.
+By default all of the bots are started when you start the whole botnet, however there is a possibility to 
+*disable* a bot. This means that the bot will not start every time you start the botnet, but you can start 
+and stop the bot if you specify the bot explicitly. To disable a bot, add the following to your 
+`runtime.conf`: `"enabled": false`. Be aware that this is **not** a normal parameter (like the others 
+described in this file). It is set outside of the `parameters` object in `runtime.conf`. Check the 
+[User-Guide](./User-Guide.md) for an example.
+
 
 <a name="collectors"></a>
 ## Collectors

--- a/docs/User-Guide.md
+++ b/docs/User-Guide.md
@@ -275,6 +275,24 @@ This configuration is used by each bot to load the specific parameters associate
 
 More examples can be found at `intelmq/etc/runtime.conf` directory in IntelMQ repository.
 
+By default all of the bots are started when you start the whole botnet, however there is a possibility to *disable* a bot. This means that the bot will not start every time you start the botnet, but you can start and stop the bot if you specify the bot explicitly. To disable a bot, add the following to your runtime.conf: `"enabled": false`. For example: 
+
+```
+{
+    "malware-domain-list-collector": {
+        "group": "Collector",
+        "name": "Malware Domain List",
+        "module": "intelmq.bots.collectors.http.collector_http",
+        "description": "Malware Domain List Collector is the bot responsible to get the report from source of information.",
+        "enabled": false,
+        "parameters": {
+            "http_url": "http://www.malwaredomainlist.com/updatescsv.php",
+            "feed": "Malware Domain List",
+            "rate_limit": 3600
+        }
+    }
+}
+```
 
 ## Harmonization Configuration
 


### PR DESCRIPTION
Fixes certtools/intelmq#825.

After much discussion and misunderstanding, I think this is what we decided on in #825. This  PR replaces #830 and #838. 

Changes for the intelmq-manager are still needed. See issue certtools/intelmq-manager#92