### PR TITLE
Update config.py

### DIFF
--- a/intelmq/bots/parsers/shadowserver/config.py
+++ b/intelmq/bots/parsers/shadowserver/config.py
@@ -656,7 +656,7 @@ open_netbios = {
         ('source.geolocation.region', 'region'),
         ('source.geolocation.city', 'city'),
         ('source.account', 'username'),
-        ('source.local_hostname', 'machine_name'),
+        # --- moving this to extra: ('source.local_hostname', 'machine_name'),
         # Other known fields which will go into "extra"
         # tag
         # mac_address


### PR DESCRIPTION
According to BSI, it makes more sense to have the machine name along next to the WORKGROUP  name in the extra field and not as a separate field. 
Also the machine name is not really an identifiable item. In other feeds it is. But here it's not.
Hence -> move it to extra.