### PR TITLE
Dev sanitize ip

### DIFF
--- a/docs/Harmonization-fields.md
+++ b/docs/Harmonization-fields.md
@@ -127,8 +127,21 @@ Sanitation accepts strings and everything float() accepts.
 
 ### IPAddress
 
+Type for IP addresses, all families. Uses the ipaddress module.
+
+Sanitation accepts strings and objects of ipaddress.IPv4Address and ipaddress.IPv4Address.
+
+Valid values are only strings. 0.0.0.0 is explictly not allowed.
+
 
 ### IPNetwork
+
+Type for IP networks, all families. Uses the ipaddress module.
+
+Sanitation accepts strings and objects of ipaddress.IPv4Network and ipaddress.IPv4Network.
+If host bits in strings are set, they will be ignored (e.g 127.0.0.1/32).
+
+Valid values are only strings.
 
 
 ### Integer

--- a/intelmq/bots/parsers/anubisnetworks/parser.py
+++ b/intelmq/bots/parsers/anubisnetworks/parser.py
@@ -92,9 +92,7 @@ class AnubisNetworksParserBot(Bot):
                     if k in value:
                         event[v] = value[k]
                 if "ip" in value and "netmask" in value:
-                    event.add('source.network',
-                              str(ipaddress.ip_network('%s/%s' % (value["ip"], value["netmask"]),
-                                                       strict=False)))
+                    event.add('source.network', '%s/%s' % (value["ip"], value["netmask"]))
         if extra:
             event.add('extra', extra)
         self.send_message(event)

--- a/intelmq/lib/harmonization.py
+++ b/intelmq/lib/harmonization.py
@@ -392,6 +392,13 @@ class Integer(GenericType):
 
 
 class IPAddress(GenericType):
+    """
+    Type for IP addresses, all families. Uses the ipaddress module.
+
+    Sanitation accepts strings and objects of ipaddress.IPv4Address and ipaddress.IPv4Address.
+
+    Valid values are only strings. 0.0.0.0 is explictly not allowed.
+    """
 
     @staticmethod
     def is_valid(value, sanitize=False):
@@ -450,6 +457,14 @@ class IPAddress(GenericType):
 
 
 class IPNetwork(GenericType):
+    """
+    Type for IP networks, all families. Uses the ipaddress module.
+
+    Sanitation accepts strings and objects of ipaddress.IPv4Network and ipaddress.IPv4Network.
+    If host bits in strings are set, they will be ignored (e.g 127.0.0.1/32).
+
+    Valid values are only strings.
+    """
 
     @staticmethod
     def is_valid(value, sanitize=False):

--- a/intelmq/lib/harmonization.py
+++ b/intelmq/lib/harmonization.py
@@ -68,7 +68,7 @@ class GenericType(object):
                 value = value.decode('utf-8', 'ignore')
             return value.strip()
 
-        return None
+        return str(value)
 
 
 class Base64(GenericType):
@@ -471,7 +471,7 @@ class IPNetwork(GenericType):
     def sanitize(value):
 
         try:
-            ipaddress.ip_network(str(value))
+            ipaddress.ip_network(str(value), strict=False)
         except ValueError:
             return None
 

--- a/intelmq/lib/harmonization.py
+++ b/intelmq/lib/harmonization.py
@@ -471,7 +471,7 @@ class IPNetwork(GenericType):
     def sanitize(value):
 
         try:
-            ipaddress.ip_network(str(value), strict=False)
+            value = str(ipaddress.ip_network(str(value), strict=False))
         except ValueError:
             return None
 

--- a/intelmq/tests/lib/test_harmonization.py
+++ b/intelmq/tests/lib/test_harmonization.py
@@ -2,7 +2,7 @@
 """
 Testing harmonization classes
 """
-
+import ipaddress
 import unittest
 
 import intelmq.lib.harmonization as harmonization
@@ -127,6 +127,8 @@ class TestHarmonization(unittest.TestCase):
                                                          sanitize=True))
         self.assertTrue(harmonization.IPAddress.is_valid(b'2001:DB8::1',
                                                          sanitize=True))
+        self.assertTrue(harmonization.IPAddress.is_valid(ipaddress.ip_address('192.0.2.1'),
+                                                         sanitize=True))
 
     def test_ipaddress_sanitize_invalid(self):
         """ Test IPAddress.is_valid ans sanitize with invalid arguments. """
@@ -155,6 +157,10 @@ class TestHarmonization(unittest.TestCase):
         self.assertTrue(harmonization.IPNetwork.is_valid(' 192.0.2.0/24\r\n',
                                                          sanitize=True))
         self.assertTrue(harmonization.IPNetwork.is_valid(b'2001:DB8::/32',
+                                                         sanitize=True))
+        self.assertTrue(harmonization.IPNetwork.is_valid('127.0.0.1/32',
+                                                         sanitize=True))
+        self.assertTrue(harmonization.IPNetwork.is_valid(ipaddress.ip_network('192.0.2.0/32'),
                                                          sanitize=True))
 
     def test_ipnetwork_sanitize_invalid(self):


### PR DESCRIPTION
Allows non-string values to be uses for events (for sanitation). They will now be converted to strings automatically. And allow host bits for networks in sanitation.

And docs of course :)

Also a very small step towards #671 