### PR TITLE
Changed keymapping in Shadowserver Open-LDAP config

### DIFF
--- a/intelmq/bots/parsers/shadowserver/config.py
+++ b/intelmq/bots/parsers/shadowserver/config.py
@@ -1168,7 +1168,7 @@ open_ldap = {
         ('extra.', 'configuration_naming_context', validate_to_none),
         ('extra.', 'current_time', validate_to_none),
         ('extra.', 'default_naming_context', validate_to_none),
-        ('destination.local_hostname', 'dns_host_name'),
+        ('source.local_hostname', 'dns_host_name'),
         ('extra.', 'domain_controller_functionality', convert_int),
         ('extra.', 'domain_functionality', convert_int),
         ('extra.', 'ds_service_name', validate_to_none),


### PR DESCRIPTION
This fixes https://github.com/certtools/intelmq/issues/864 by moving "destination" to "source".


# Required Migrations

**Only necessary if you are running a setup that is already using the Shadowserver Open-LDAP, or has been using this feed**

1) This commit will require migrations in the EventDB, an example SQL-statement will be provided in issue #864, soon
2) If you are using Filter-Experts looking for the key `destination.local_hostname`, you need to update them to `source.local_hostname`