### PR TITLE
Provide bigger & diversified example config

### DIFF
--- a/intelmq/etc/pipeline.conf
+++ b/intelmq/etc/pipeline.conf
@@ -1,6 +1,52 @@
 {
+    "abusech-domain-parser": {
+        "destination-queues": [
+            "deduplicator-expert-queue"
+        ],
+        "source-queue": "abusech-domain-parser-queue"
+    },
+    "abusech-feodo-domains-collector": {
+        "destination-queues": [
+            "abusech-domain-parser-queue"
+        ]
+    },
+    "cymru-whois-expert": {
+        "destination-queues": [
+            "file-output-queue"
+        ],
+        "source-queue": "cymru-whois-expert-queue"
+    },
+    "deduplicator-expert": {
+        "destination-queues": [
+            "taxonomy-expert-queue"
+        ],
+        "source-queue": "deduplicator-expert-queue"
+    },
     "file-output": {
         "source-queue": "file-output-queue"
+    },
+    "gethostbyname-1-expert": {
+        "destination-queues": [
+            "cymru-whois-expert-queue"
+        ],
+        "source-queue": "gethostbyname-1-expert-queue"
+    },
+    "gethostbyname-2-expert": {
+        "destination-queues": [
+            "cymru-whois-expert-queue"
+        ],
+        "source-queue": "gethostbyname-2-expert-queue"
+    },
+    "malc0de-parser": {
+        "destination-queues": [
+            "deduplicator-expert-queue"
+        ],
+        "source-queue": "malc0de-parser-queue"
+    },
+    "malc0de-windows-format-collector": {
+        "destination-queues": [
+            "malc0de-parser-queue"
+        ]
     },
     "malware-domain-list-collector": {
         "destination-queues": [
@@ -9,8 +55,32 @@
     },
     "malware-domain-list-parser": {
         "destination-queues": [
-            "file-output-queue"
+            "deduplicator-expert-queue"
         ],
         "source-queue": "malware-domain-list-parser-queue"
+    },
+    "spamhaus-drop-collector": {
+        "destination-queues": [
+            "spamhaus-drop-parser-queue"
+        ]
+    },
+    "spamhaus-drop-parser": {
+        "destination-queues": [
+            "deduplicator-expert-queue"
+        ],
+        "source-queue": "spamhaus-drop-parser-queue"
+    },
+    "taxonomy-expert": {
+        "destination-queues": [
+            "url2fqdn-expert-queue"
+        ],
+        "source-queue": "taxonomy-expert-queue"
+    },
+    "url2fqdn-expert": {
+        "destination-queues": [
+            "gethostbyname-1-expert-queue",
+            "gethostbyname-2-expert-queue"
+        ],
+        "source-queue": "url2fqdn-expert-queue"
     }
 }

--- a/intelmq/etc/runtime.conf
+++ b/intelmq/etc/runtime.conf
@@ -1,4 +1,53 @@
 {
+    "abusech-domain-parser": {
+        "description": "Abuse.ch Domain Parser is the bot responsible to parse the report and sanitize the information.",
+        "group": "Parser",
+        "module": "intelmq.bots.parsers.abusech.parser_domain",
+        "name": "Abuse.ch Domain",
+        "parameters": {}
+    },
+    "abusech-feodo-domains-collector": {
+        "description": "",
+        "group": "Collector",
+        "module": "intelmq.bots.collectors.http.collector_http",
+        "name": "Abuse.ch Feodo Domains",
+        "parameters": {
+            "feed": "Abuse.ch Feodo Domains",
+            "http_password": null,
+            "http_url": "https://feodotracker.abuse.ch/blocklist/?download=domainblocklist",
+            "http_username": null,
+            "provider": "Abuse.ch",
+            "rate_limit": 129600,
+            "ssl_client_certificate": null
+        }
+    },
+    "cymru-whois-expert": {
+        "description": "Cymry Whois (IP to ASN) is the bot responsible to add network information to the events (BGP, ASN, AS Name, Country, etc..).",
+        "group": "Expert",
+        "module": "intelmq.bots.experts.cymru_whois.expert",
+        "name": "Cymru Whois",
+        "parameters": {
+            "redis_cache_db": 5,
+            "redis_cache_host": "127.0.0.1",
+            "redis_cache_password": null,
+            "redis_cache_port": 6379,
+            "redis_cache_ttl": 86400
+        }
+    },
+    "deduplicator-expert": {
+        "description": "Deduplicator is the bot responsible for detection and removal of duplicate messages. Messages get cached for <redis_cache_ttl> seconds. If found in the cache, it is assumed to be a duplicate.",
+        "group": "Expert",
+        "module": "intelmq.bots.experts.deduplicator.expert",
+        "name": "Deduplicator",
+        "parameters": {
+            "ignore_keys": "raw,time.observation",
+            "redis_cache_db": 6,
+            "redis_cache_host": "127.0.0.1",
+            "redis_cache_password": null,
+            "redis_cache_port": 6379,
+            "redis_cache_ttl": 86400
+        }
+    },
     "file-output": {
         "description": "File is the bot responsible to send events to a file.",
         "group": "Output",
@@ -9,6 +58,42 @@
             "hierarchical_output": false
         }
     },
+    "gethostbyname-1-expert": {
+        "description": "fqdn2ip is the bot responsible to parsing the ip from the fqdn.",
+        "group": "Expert",
+        "module": "intelmq.bots.experts.gethostbyname.expert",
+        "name": "Gethostbyname",
+        "parameters": {}
+    },
+    "gethostbyname-2-expert": {
+        "description": "fqdn2ip is the bot responsible to parsing the ip from the fqdn.",
+        "group": "Expert",
+        "module": "intelmq.bots.experts.gethostbyname.expert",
+        "name": "Gethostbyname",
+        "parameters": {}
+    },
+    "malc0de-parser": {
+        "description": "Malc0de Parser is the bot responsible to parse the IP Blacklist and either Windows Format or Bind Format reports and sanitize the information.",
+        "group": "Parser",
+        "module": "intelmq.bots.parsers.malc0de.parser",
+        "name": "Malc0de",
+        "parameters": {}
+    },
+    "malc0de-windows-format-collector": {
+        "description": "",
+        "group": "Collector",
+        "module": "intelmq.bots.collectors.http.collector_http",
+        "name": "Malc0de Windows Format",
+        "parameters": {
+            "feed": "Generic URL Fetcher is the bot responsible to get the report from an URL.",
+            "http_password": null,
+            "http_url": "https://malc0de.com/bl/BOOT",
+            "http_username": null,
+            "provider": "Malc0de",
+            "rate_limit": 10800,
+            "ssl_client_certificate": null
+        }
+    },
     "malware-domain-list-collector": {
         "description": "Malware Domain List Collector is the bot responsible to get the report from source of information.",
         "group": "Collector",
@@ -17,6 +102,7 @@
         "parameters": {
             "feed": "Malware Domain List",
             "http_url": "http://www.malwaredomainlist.com/updatescsv.php",
+            "provider": "Malware Domain List",
             "rate_limit": 3600
         }
     },
@@ -26,5 +112,44 @@
         "module": "intelmq.bots.parsers.malwaredomainlist.parser",
         "name": "Malware Domain List",
         "parameters": {}
+    },
+    "spamhaus-drop-collector": {
+        "description": "",
+        "group": "Collector",
+        "module": "intelmq.bots.collectors.http.collector_http",
+        "name": "Spamhaus Drop",
+        "parameters": {
+            "feed": "Spamhaus Drop",
+            "http_password": null,
+            "http_url": "https://www.spamhaus.org/drop/drop.txt",
+            "http_username": null,
+            "provider": "Spamhaus",
+            "rate_limit": 3600,
+            "ssl_client_certificate": null
+        }
+    },
+    "spamhaus-drop-parser": {
+        "description": "Spamhaus Drop Parser is the bot responsible to parse the DROP, EDROP, DROPv6, and ASN-DROP reports and sanitize the information.",
+        "group": "Parser",
+        "module": "intelmq.bots.parsers.spamhaus.parser_drop",
+        "name": "Spamhaus Drop",
+        "parameters": {}
+    },
+    "taxonomy-expert": {
+        "description": "Taxonomy is the bot responsible to apply the eCSIRT Taxonomy to all events.",
+        "group": "Expert",
+        "module": "intelmq.bots.experts.taxonomy.expert",
+        "name": "Taxonomy",
+        "parameters": {}
+    },
+    "url2fqdn-expert": {
+        "description": "url2fqdn is the bot responsible to parsing the fqdn from the url.",
+        "group": "Expert",
+        "module": "intelmq.bots.experts.url2fqdn.expert",
+        "name": "url2fqdn",
+        "parameters": {
+            "load_balance": true,
+            "overwrite": false
+        }
     }
 }


### PR DESCRIPTION
This extends the current example configuration. Now 4 different free feeds are configured: Abuse.ch, Spamhaus, malware domain list (was already default) and malc0de.
Also, some very useful experts: deduplicator, taxonomy, url2fqdn, gethostbyname, taxonomy and cymru.
The only output is still the file, all other would need proper configurations.
Additionally I added two instances for the gethostbyname (because of the lookups) to demonstrate a useful example to load balancing.

fixes certtools/intelmq#357