### PR TITLE
intelmqctl: only remove pid file when actually stopped

### DIFF
--- a/intelmq/bin/intelmqctl.py
+++ b/intelmq/bin/intelmqctl.py
@@ -152,11 +152,11 @@ class BotProcessManager:
         log_bot_message('stopping', bot_id)
         proc = psutil.Process(int(pid))
         proc.send_signal(signal.SIGINT)
-        self.__remove_pidfile(bot_id)
         time.sleep(0.25)
         if self.__status_process(pid):
             log_bot_error('running', bot_id)
             return 'running'
+        self.__remove_pidfile(bot_id)
         log_bot_message('stopped', bot_id)
         return 'stopped'
 


### PR DESCRIPTION
If we know that the bot is running after 0.25s, we should not remove the pid file. If the bot needs some more time, the file will be removed once `intelmqctl status` is called anyway.

related:
certtools/intelmq#763
certat/intelmq#92