### PR TITLE
intelmqctl argument parsing and error handling

### DIFF
--- a/docs/User-Guide.md
+++ b/docs/User-Guide.md
@@ -370,14 +370,45 @@ See [IntelMQ Manager repository](https://github.com/certtools/intelmq-manager).
 
 ```bash
 # su - intelmq
-
 $ intelmqctl -h
-usage: 
-        intelmqctl [start|stop|restart|status|run] bot-id
-        intelmqctl [start|stop|restart|status]
+intelmqctl [-h] [-v] [--type {text,json}] [--quiet]
+                  {list,check,clear,log,run,help,start,stop,restart,reload,status}
+                  ...
+
+        description: intelmqctl is the tool to control intelmq system.
+
+        Outputs are logged to /opt/intelmq/var/log/intelmqctl
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -v, --version         show program's version number and exit
+  --type {text,json}, -t {text,json}
+                        choose if it should return regular text or other
+                        machine-readable
+  --quiet, -q           Quiet mode, useful for reloads initiated scripts like
+                        logrotate
+
+subcommands:
+  {list,check,clear,log,run,help,start,stop,restart,reload,status}
+    list                Listing bots or queues
+    check               Check installation and configuration
+    clear               Clear a queue
+    log                 Get last log lines of a bot
+    run                 Run a bot interactively
+    check               Check installation and configuration
+    help                Show the help
+    start               Start a bot or botnet
+    stop                Stop a bot or botnet
+    restart             Restart a bot or botnet
+    reload              Reload a bot or botnet
+    status              Status of a bot or botnet
+
+        intelmqctl [start|stop|restart|status|reload|run] bot-id
+        intelmqctl [start|stop|restart|status|reload]
         intelmqctl list [bots|queues]
         intelmqctl log bot-id [number-of-lines [log-level]]
         intelmqctl clear queue-id
+        intelmqctl check
 
 Starting a bot:
     intelmqctl start bot-id
@@ -400,32 +431,19 @@ Get a list of all configured bots:
 
 Get a list of all queues:
     intelmqctl list queues
+If -q is given, only queues with more than one item are listed.
 
 Clear a queue:
     intelmqctl clear queue-id
 
 Get logs of a bot:
-    intelmqctl log bot-id [number-of-lines [log-level]]
-    Reads the last lines from bot log, or from system log if no bot ID was
-    given. Log level should be one of DEBUG, INFO, ERROR or CRITICAL.
-    Default is INFO. Number of lines defaults to 10, -1 gives all. Result
-    can be longer due to our logging format!
+    intelmqctl log bot-id number-of-lines log-level
+Reads the last lines from bot log.
+Log level should be one of DEBUG, INFO, ERROR or CRITICAL.
+Default is INFO. Number of lines defaults to 10, -1 gives all. Result
+can be longer due to our logging format!
 
-positional arguments:
-  [start|stop|restart|status|run|list|clear|log]
-  parameter
-
-optional arguments:
-  -h, --help            show this help message and exit
-  -v, --version         show program's version number and exit
-  --type {text,json}, -t {text,json}
-                        choose if it should return regular text or other
-                        machine-readable
-  --quiet, -q           Quiet mode, useful for reloads initiatedscripts like
-                        logrotate
-
-description: intelmqctl is the tool to control intelmq system. Outputs are
-logged to /opt/intelmq/var/log/intelmqctl
+Outputs are additionally logged to /opt/intelmq/var/log/intelmqctl
 ```
 
 #### Botnet Concept

--- a/intelmq/bin/intelmqctl.py
+++ b/intelmq/bin/intelmqctl.py
@@ -489,7 +489,7 @@ Outputs are additionally logged to /opt/intelmq/var/log/intelmqctl'''
                 config = utils.load_configuration(SYSTEM_CONF_FILE)
             except ValueError as exc:  # pragma: no cover
                 msg = 'Error loading %r: %s' % (SYSTEM_CONF_FILE, exc)
-                if interactive:
+                if self.interactive:
                     exit(msg)
                 else:
                     raise ValueError(msg)
@@ -502,7 +502,7 @@ Outputs are additionally logged to /opt/intelmq/var/log/intelmqctl'''
             config = utils.load_configuration(DEFAULTS_CONF_FILE)
         except ValueError as exc:  # pragma: no cover
             msg = 'Error loading %r: %s' % (DEFAULTS_CONF_FILE, exc)
-            if interactive:
+            if self.interactive:
                 exit(msg)
             else:
                 raise ValueError(msg)
@@ -512,6 +512,8 @@ Outputs are additionally logged to /opt/intelmq/var/log/intelmqctl'''
     def run(self):
         results = None
         args = self.parser.parse_args()
+        if 'func' not in args:
+            exit(self.parser.print_help())
         args_dict = vars(args).copy()
 
         global RETURN_TYPE, QUIET

--- a/intelmq/bin/intelmqctl.py
+++ b/intelmq/bin/intelmqctl.py
@@ -44,8 +44,6 @@ ERROR_MESSAGES = {
     'running': '{} is still running.',
     'stopped': '{} was NOT RUNNING.',
     'stopping': '{} failed to STOP.',
-    'noid': 'No or unconfigured ID was given, use --id',
-    'notfound': '{} not found.'
 }
 
 LOG_LEVEL = {
@@ -127,18 +125,13 @@ class BotProcessManager:
             else:
                 self.__remove_pidfile(bot_id)
         log_bot_message('starting', bot_id)
-        try:
-            module = self.__runtime_configuration[bot_id]['module']
-        except KeyError:
-            log_bot_error('notfound', bot_id)
-            return 'error'
-        else:
-            cmdargs = [module, bot_id]
-            with open('/dev/null', 'w') as devnull:
-                proc = psutil.Popen(cmdargs, stdout=devnull, stderr=devnull)
-                filename = self.PIDFILE.format(bot_id)
-                with open(filename, 'w') as fp:
-                    fp.write(str(proc.pid))
+        module = self.__runtime_configuration[bot_id]['module']
+        cmdargs = [module, bot_id]
+        with open('/dev/null', 'w') as devnull:
+            proc = psutil.Popen(cmdargs, stdout=devnull, stderr=devnull)
+            filename = self.PIDFILE.format(bot_id)
+            with open(filename, 'w') as fp:
+                fp.write(str(proc.pid))
 
         time.sleep(0.25)
         return self.bot_status(bot_id)
@@ -194,10 +187,6 @@ class BotProcessManager:
         if pid and self.__status_process(pid):
             log_bot_message('running', bot_id)
             return 'running'
-
-        if bot_id not in self.__runtime_configuration:
-            log_bot_error('notfound', bot_id)
-            return 'error'
 
         if self._is_enabled(bot_id):
             log_bot_message('stopped', bot_id)

--- a/intelmq/bin/intelmqctl.py
+++ b/intelmq/bin/intelmqctl.py
@@ -64,7 +64,8 @@ QUIET = False
 def log_list_queues(queues):
     if RETURN_TYPE == 'text':
         for queue, counter in sorted(queues.items()):
-            logger.info("{} - {}".format(queue, counter))
+            if counter or not QUIET:
+                logger.info("{} - {}".format(queue, counter))
 
 
 def log_bot_error(status, *args):
@@ -312,6 +313,7 @@ Get a list of all configured bots:
 
 Get a list of all queues:
     intelmqctl list queues
+If -q is given, only queues with more than one item are listed.
 
 Clear a queue:
     intelmqctl clear queue-id

--- a/intelmq/bin/intelmqctl.py
+++ b/intelmq/bin/intelmqctl.py
@@ -333,11 +333,11 @@ Get logs of a bot:
         try:
             self.pipeline_configuration = utils.load_configuration(PIPELINE_CONF_FILE)
         except ValueError as exc:
-            exit('Invalid syntax in %r: %s' % (PIPELINE_CONF_FILE, exc))
+            exit('Error loading %r: %s' % (PIPELINE_CONF_FILE, exc))
         try:
             self.runtime_configuration = utils.load_configuration(RUNTIME_CONF_FILE)
         except ValueError as exc:
-            exit('Invalid syntax in %r: %s' % (RUNTIME_CONF_FILE, exc))
+            exit('Error loading %r: %s' % (RUNTIME_CONF_FILE, exc))
 
         if os.path.exists(STARTUP_CONF_FILE):
             self.logger.warning('Deprecated startup.conf file found, please migrate to runtime.conf soon.')
@@ -411,7 +411,7 @@ Get logs of a bot:
                 setattr(self.parameters, option, value)
 
     def load_defaults_configuration(self):
-        # Load defaults configuration section
+        # Load defaults configuration
         try:
             config = utils.load_configuration(DEFAULTS_CONF_FILE)
         except ValueError as exc:

--- a/intelmq/bin/intelmqctl.py
+++ b/intelmq/bin/intelmqctl.py
@@ -341,7 +341,9 @@ Get logs of a bot:
 Reads the last lines from bot log.
 Log level should be one of DEBUG, INFO, ERROR or CRITICAL.
 Default is INFO. Number of lines defaults to 10, -1 gives all. Result
-can be longer due to our logging format!'''
+can be longer due to our logging format!
+
+Outputs are additionally logged to /opt/intelmq/var/log/intelmqctl'''
 
         # stolen functions from the bot file
         # this will not work with various instances of REDIS

--- a/intelmq/lib/utils.py
+++ b/intelmq/lib/utils.py
@@ -159,9 +159,7 @@ def load_configuration(configuration_filepath):
     Parameters:
     -----------
     configuration_filepath : string
-        Path to JSON file to load. If file does not exist, and the path begins
-        with CONFIG_DIR (`/opt/intelmq/etc` by default), the file from it's
-        package data is used.
+        Path to JSON file to load.
 
     Returns:
     --------
@@ -171,13 +169,6 @@ def load_configuration(configuration_filepath):
     if os.path.exists(configuration_filepath):
         with open(configuration_filepath, 'r') as fpconfig:
             config = json.loads(fpconfig.read())
-    elif configuration_filepath.find(intelmq.CONFIG_DIR) == 0:  # at beginning
-        newpath = pkg_resources.resource_filename('intelmq', 'etc/')
-        filepath = configuration_filepath.replace(intelmq.CONFIG_DIR,
-                                                  newpath)
-        if os.path.exists(filepath):
-            with open(filepath, 'r') as fpconfig:
-                config = json.loads(fpconfig.read())
     else:
         raise ValueError('File not found: %r.' % configuration_filepath)
     return config

--- a/intelmq/lib/utils.py
+++ b/intelmq/lib/utils.py
@@ -226,6 +226,7 @@ def log(name, log_path=intelmq.DEFAULT_LOGGING_PATH, log_level="DEBUG",
         filename for logfile or string preceding lines in stream
     log_path : string
         Path to log directory, defaults to DEFAULT_LOGGING_PATH
+        If False, nothing is logged to files.
     log_level : string
         default is "DEBUG"
     stream : object
@@ -251,19 +252,20 @@ def log(name, log_path=intelmq.DEFAULT_LOGGING_PATH, log_level="DEBUG",
     logger = logging.getLogger(name)
     logger.setLevel(log_level)
 
-    if not syslog:
+    if log_path and not syslog:
         handler = FileHandler("%s/%s.log" % (log_path, name))
         handler.setLevel(log_level)
-    else:
+    elif syslog:
         if type(syslog) is tuple or type(syslog) is list:
             handler = logging.handlers.SysLogHandler(address=tuple(syslog))
         else:
             handler = logging.handlers.SysLogHandler(address=syslog)
         handler.setLevel(log_level)
 
-    formatter = logging.Formatter(LOG_FORMAT)
-    handler.setFormatter(formatter)
-    logger.addHandler(handler)
+    if log_path or syslog:
+        formatter = logging.Formatter(LOG_FORMAT)
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
 
     if stream or stream is None:
         console_formatter = logging.Formatter(LOG_FORMAT_STREAM)


### PR DESCRIPTION
### Handle more errors
In case of misconfigrations or incomplete installations, better error messages/warnings are shown. Also `check` is now capable of checking the existence of bot executables.

### Quiet `list queues`
If `-q` is given, non-empty queues are not shown.

### Rewrite of argument parsing

Now, argparse validates all given actions and parameters. This gives much better help and error messages, e.g.:
```
$ intelmqctl status --help
usage: intelmqctl status [-h]
                         [{file-output,abusech-feodo-domains-collector,abusech-domain-parser,deduplicator-expert}]

positional arguments:
  {file-output,abusech-feodo-domains-collector,abusech-domain-parser,deduplicator-expert}

optional arguments:
  -h, --help            show this help message and exit
```
or:
```
$ intelmqctl list
usage: intelmqctl list [-h] [--quiet] {bots,queues}
intelmqctl list: error: the following arguments are required: kind
```
and
```$ intelmqctl list --help
usage: intelmqctl list [-h] [--quiet] {bots,queues}

positional arguments:
  {bots,queues}

optional arguments:
  -h, --help     show this help message and exit
  --quiet, -q    Only list non-empty queues
```

Please try it yoruself and give feedback / report any problems. As it is a full rewrite of the argument parsing, there may be still some hidden errors.
Then I'll update the documentation.

For the manager, https://github.com/certtools/intelmq-manager/commit/88f276bfc1f7efbf9050e41bb873f415130a6f3c is needed