### PR TITLE
REST API output: fixes and HTTP Basic Authentication

### DIFF
--- a/docs/Bots.md
+++ b/docs/Bots.md
@@ -618,9 +618,12 @@ from your installation.
 
 #### Configuration Parameters:
 
-* `auth_token`: FIXME
-* `auth_token_name`: FIXME
-* `host`: FIXME
+* `auth_token`: the user name / http header key
+* `auth_token_name`: the password / http header value
+* `auth_type`: one of: `"http_basic_auth"`, `"http_header"`
+* `hierarchical_output`: boolean
+* `host`: destination URL
+* `use_json`: boolean
 
 
 * * *

--- a/intelmq/bots/BOTS
+++ b/intelmq/bots/BOTS
@@ -620,6 +620,7 @@
             "parameters": {
                 "auth_token": "<token>",
                 "auth_token_name": "<token name>",
+                "auth_type": "<http_basic_auth/http_header>",
                 "hierarchical_output": false,
                 "host": "<host>",
                 "use_json": true

--- a/intelmq/bots/BOTS
+++ b/intelmq/bots/BOTS
@@ -621,7 +621,8 @@
                 "auth_token": "<token>",
                 "auth_token_name": "<token name>",
                 "hierarchical_output": false,
-                "host": "<host>"
+                "host": "<host>",
+                "use_json": true
             }
         },
         "Redis": {

--- a/intelmq/bots/outputs/restapi/output.py
+++ b/intelmq/bots/outputs/restapi/output.py
@@ -23,17 +23,8 @@ class RestAPIOutputBot(Bot):
         else:
             kwargs = {'data': event.to_dict(hierarchical=self.parameters.hierarchical_output)}
 
-        try:
-            r = self.session.post(self.parameters.host, **kwargs)
-            r.raise_for_status()
-        except requests.exceptions.RequestException as e:
-            if r:
-                self.logger.error('Response code: {1}\nHeaders: '
-                                  '{2}\nResponse body: {3}'
-                                  ''.format(r, r.headers,
-                                            r.text))
-            else:
-                self.logger.error(repr(e))
+        r = self.session.post(self.parameters.host, **kwargs)
+        r.raise_for_status()
         self.acknowledge_message()
 
 

--- a/intelmq/bots/outputs/restapi/output.py
+++ b/intelmq/bots/outputs/restapi/output.py
@@ -10,8 +10,11 @@ class RestAPIOutputBot(Bot):
     def init(self):
         self.session = requests.Session()
         if self.parameters.auth_token_name and self.parameters.auth_token:
-            self.session.headers.update(
-                {self.parameters.auth_token_name: self.parameters.auth_token})
+            if self.parameters.auth_type == 'http_header':
+                self.session.headers.update(
+                    {self.parameters.auth_token_name: self.parameters.auth_token})
+            elif self.parameters.auth_type == 'http_basic_auth':
+                self.session.auth = self.parameters.auth_token_name, self.parameters.auth_token
         self.session.headers.update({"content-type":
                                      "application/json; charset=utf-8"})
         self.session.keep_alive = False
@@ -25,6 +28,7 @@ class RestAPIOutputBot(Bot):
 
         r = self.session.post(self.parameters.host, **kwargs)
         r.raise_for_status()
+        self.logger.debug('Sent message.')
         self.acknowledge_message()
 
 


### PR DESCRIPTION
Fixes bugs:
 * missing parameter use_json in BOTS
 * some missing parameters in docs plus explanation
 * errors during sending led to data loss

Newly added feature: HTTP Basic Authentication instead of using headers and new parameter auth_type to chose between authentication types.