### PR TITLE
BUG: anubis parser: Fix incomplete extra fields

### DIFF
--- a/intelmq/bots/parsers/anubisnetworks/parser.py
+++ b/intelmq/bots/parsers/anubisnetworks/parser.py
@@ -14,6 +14,7 @@ env.request_method                      => extra.method
 env.cookies                             => extra.cookies
 env.path_info                           => extra.path_info
 env.http_referer                        => extra.http_referer
+
 _origin                                 => extra._origin
 _provider                               => extra._provider
 pattern_verified                        => extra.pattern_verified
@@ -83,7 +84,7 @@ class AnubisNetworksParserBot(Bot):
                 if "server_name" in value:
                     event.add('destination.fqdn', value["server_name"],
                               raise_failure=False)
-                for k in ["request_method", "cookies", "path_info", "http_referer", "_origin", "_provider", "pattern_verified"]:
+                for k in ["request_method", "cookies", "path_info", "http_referer"]:
                     if k in value:
                         extra[k] = value[k]
             if key == "_geo_env_remote_addr":
@@ -92,6 +93,8 @@ class AnubisNetworksParserBot(Bot):
                         event[v] = value[k]
                 if "ip" in value and "netmask" in value:
                     event.add('source.network', '%s/%s' % (value["ip"], value["netmask"]))
+            if key in ["_origin", "_provider", "pattern_verified"]:
+                extra[key] = value
         if extra:
             event.add('extra', extra)
         self.send_message(event)

--- a/intelmq/tests/bots/parsers/anubisnetworks/test_parser.py
+++ b/intelmq/tests/bots/parsers/anubisnetworks/test_parser.py
@@ -35,7 +35,7 @@ EXAMPLE_EVENT  = {"classification.type": "malware",
                   "__type": "Event",
                   "feed.name": "AnubisNetworks",
                   "raw": EXAMPLE_REPORT['raw'],
-                  'extra': '{"request_method": "POST"}',
+                  'extra': '{"_origin": "dnsmalware", "_provider": "spikens", "request_method": "POST"}',
                   }
 
 EXAMPLE_REPORT2 = {"feed.name": "AnubisNetworks",


### PR DESCRIPTION
Fixes the incomplete PR #903 #904 

`_origin`, `_provider` and `pattern_verified` are not in `env`.

For pattern_verified I had no sample to verify it.

And added tests for it.