### PR TITLE
Shadowserver Compromised-Website: handle missing / in URL

### DIFF
--- a/intelmq/bots/parsers/shadowserver/config.py
+++ b/intelmq/bots/parsers/shadowserver/config.py
@@ -125,7 +125,8 @@ def convert_hostname_and_url(value, row):
     """
     if row['application'] in ['http', 'https', 'irc']:
         if row['hostname'] and row['url']:
-            return row['application'] + '://' + row['hostname'] + row['url']
+            url = row['url'] if row['url'].startswith('/') else '/' + row['url']
+            return row['application'] + '://' + row['hostname'] + url
 
         elif row['hostname'] and not row['url']:
             return row['application'] + '://' + row['hostname']

--- a/intelmq/tests/bots/parsers/shadowserver/compromised_website.csv
+++ b/intelmq/tests/bots/parsers/shadowserver/compromised_website.csv
@@ -1,2 +1,3 @@
 "timestamp","ip","port","hostname","tag","application","asn","geo","region","city","url","http_host","category","system","detected_since","server","redirect_target","naics","sic","sector"
 "2017-01-16 00:43:48","203.0.113.1",80,"example.com","hacked-webserver-stealrat-t1","http",64496,"AT","WIEN","VIENNA","/header.php","example.com","spam","WINNT","2015-05-09 05:51:12","Microsoft-IIS/7.5",,0,0,
+"2017-01-16 00:43:48","203.0.113.1",80,"example.com","hacked-webserver-stealrat-t1","http",64496,"AT","WIEN","VIENNA","header.php","example.com","spam","WINNT","2015-05-09 05:51:12","Microsoft-IIS/7.5",,0,0,

--- a/intelmq/tests/bots/parsers/shadowserver/compromised_website_RECONSTRUCTED.csv
+++ b/intelmq/tests/bots/parsers/shadowserver/compromised_website_RECONSTRUCTED.csv
@@ -1,2 +1,4 @@
 "timestamp","ip","port","hostname","tag","application","asn","geo","region","city","url","http_host","category","system","detected_since","server","redirect_target","naics","sic","sector"
 "2017-01-16 00:43:48","203.0.113.1","80","example.com","hacked-webserver-stealrat-t1","http","64496","AT","WIEN","VIENNA","/header.php","example.com","spam","WINNT","2015-05-09 05:51:12","Microsoft-IIS/7.5","","0","0",""
+"2017-01-16 00:43:48","203.0.113.1","80","example.com","hacked-webserver-stealrat-t1","http","64496","AT","WIEN","VIENNA","header.php","example.com","spam","WINNT","2015-05-09 05:51:12","Microsoft-IIS/7.5","","0","0",""
+

--- a/intelmq/tests/bots/parsers/shadowserver/test_compromised_website.py
+++ b/intelmq/tests/bots/parsers/shadowserver/test_compromised_website.py
@@ -2,6 +2,7 @@
 
 import os
 import unittest
+import copy
 
 import intelmq.lib.test as test
 import intelmq.lib.utils as utils
@@ -21,7 +22,7 @@ EXAMPLE_REPORT = {"feed.name": "ShadowServer Compromised Website",
                   "__type": "Report",
                   "time.observation": "2015-01-01T00:00:00+00:00",
                   }
-EVENT = {'__type': 'Event',
+EVENT00 = {'__type': 'Event',
          'feed.name': 'ShadowServer Compromised Website',
          'classification.type': 'compromised',
          'classification.identifier': 'compromised-website',
@@ -44,6 +45,9 @@ EVENT = {'__type': 'Event',
        'time.observation': '2015-01-01T00:00:00+00:00',
        'time.source': '2017-01-16T00:43:48+00:00'}
 
+EVENT01 = copy.copy(EVENT00)
+EVENT01['raw'] = utils.base64_encode('\n'.join([RECONSTRUCTED_LINES[0],
+                                               RECONSTRUCTED_LINES[2], '']))
 
 class TestShadowserverParserBot(test.BotTestCase, unittest.TestCase):
     """
@@ -59,7 +63,8 @@ class TestShadowserverParserBot(test.BotTestCase, unittest.TestCase):
     def test_event(self):
         """ Test if correct Event has been produced. """
         self.run_bot()
-        self.assertMessageEqual(0, EVENT)
+        self.assertMessageEqual(0, EVENT00)
+        self.assertMessageEqual(1, EVENT01)
 
 
 if __name__ == '__main__':  # pragma: no cover

--- a/intelmq/tests/bots/parsers/shadowserver/test_compromised_website.py
+++ b/intelmq/tests/bots/parsers/shadowserver/test_compromised_website.py
@@ -2,7 +2,6 @@
 
 import os
 import unittest
-import copy
 
 import intelmq.lib.test as test
 import intelmq.lib.utils as utils
@@ -45,7 +44,7 @@ EVENT00 = {'__type': 'Event',
        'time.observation': '2015-01-01T00:00:00+00:00',
        'time.source': '2017-01-16T00:43:48+00:00'}
 
-EVENT01 = copy.copy(EVENT00)
+EVENT01 = EVENT00.copy()
 EVENT01['raw'] = utils.base64_encode('\n'.join([RECONSTRUCTED_LINES[0],
                                                RECONSTRUCTED_LINES[2], '']))
 


### PR DESCRIPTION
Recently, some occurences of compromised-website reports were not sound: the 'url' value did not start with a /. As a consequence, the resulting 'source.url' field was erroneous, since it is the concatenation of 'hostname' + 'url'.

Example:
...,"hostname",...,"url",...
...,"example.com",...,"blip.php",...

results in: "http://example.comblip.php" instead of "http://example.com/blip.php"