### PR TITLE
Better handle misconfigurations by stopping the bot

### DIFF
--- a/intelmq/bin/intelmqctl.py
+++ b/intelmq/bin/intelmqctl.py
@@ -653,7 +653,7 @@ Outputs are additionally logged to /opt/intelmq/var/log/intelmqctl'''
     def list_queues(self):
         source_queues, destination_queues, internal_queues, all_queues = self.get_queues()
         pipeline = PipelineFactory.create(self.parameters)
-        pipeline.set_queues(source_queues, "source")
+        pipeline.set_queues(None, "source")
         pipeline.connect()
 
         counters = pipeline.count_queued_messages(*all_queues)

--- a/intelmq/lib/bot.py
+++ b/intelmq/lib/bot.py
@@ -352,8 +352,13 @@ class Bot(object):
         # handle a sighup which happened during blocking read
         self.__handle_sighup()
 
-        self.__current_message = libmessage.MessageFactory.unserialize(message,
-                                                                       harmonization=self.harmonization)
+        try:
+            self.__current_message = libmessage.MessageFactory.unserialize(message,
+                                                                           harmonization=self.harmonization)
+        except exceptions.InvalidKey as exc:
+            # In case a incoming message is malformed an does not conform with the currently
+            # loaded harmonization, stop now as this will happen repeatedly without any change
+            raise exceptions.ConfigurationError('harmonization', exc.args[0])
 
         if 'raw' in self.__current_message and len(self.__current_message['raw']) > 400:
             tmp_msg = self.__current_message.to_dict(hierarchical=False)

--- a/intelmq/lib/bot.py
+++ b/intelmq/lib/bot.py
@@ -159,6 +159,7 @@ class Bot(object):
                 self.__disconnect_pipelines()
 
             except Exception as exc:
+                # in case of serious system issues, exit immediately
                 if isinstance(exc, MemoryError):
                     self.logger.exception('Out of memory. Exit immediately.')
                     self.stop()
@@ -178,6 +179,10 @@ class Bot(object):
                     # Dump full message if explicitly requested by config
                     self.logger.info("Current Message(event): {!r}."
                                      "".format(self.__current_message))
+
+                # In case of permanent failures, stop now
+                if isinstance(exc, exceptions.ConfigurationError):
+                    self.stop()
 
             except KeyboardInterrupt:
                 self.logger.error("Received KeyboardInterrupt.")
@@ -322,6 +327,10 @@ class Bot(object):
             if not message:
                 self.logger.warning("Ignoring empty message at sending. Possible bug in bot.")
                 continue
+            if not self.__destination_pipeline:
+                raise exceptions.ConfigurationError('pipeline', 'No destination pipline given, '
+                                                    'but needed')
+                self.stop()
 
             self.logger.debug("Sending message.")
             self.__message_counter += 1
@@ -445,8 +454,8 @@ class Bot(object):
                     self.__bot_id]['destination-queues']
 
         else:
-            raise ValueError("Pipeline configuration: no key "
-                             "{!r}.".format(self.__bot_id))
+            raise exceptions.ConfigurationError('pipeline', "no key "
+                                                "{!r}.".format(self.__bot_id))
 
     def __log_configuration_parameter(self, config_name, option, value):
         if "password" in option or "token" in option:

--- a/intelmq/lib/exceptions.py
+++ b/intelmq/lib/exceptions.py
@@ -49,8 +49,8 @@ class PipelineError(IntelMQException):
 class ConfigurationError(IntelMQException):
 
     def __init__(self, config, argument):
-        message = "%s configuration failed - %s" % (config, repr(argument))
-        super(PipelineError, self).__init__(message)
+        message = "%s configuration failed - %s" % (config, argument)
+        super(ConfigurationError, self).__init__(message)
 
 
 class PipelineFactoryError(IntelMQException):

--- a/intelmq/lib/pipeline.py
+++ b/intelmq/lib/pipeline.py
@@ -40,8 +40,11 @@ class Pipeline(object):
 
     def set_queues(self, queues, queues_type):
         if queues_type == "source":
-            self.source_queue = str(queues)
-            self.internal_queue = str(queues) + "-internal"
+            self.source_queue = queues
+            if queues is not None:
+                self.internal_queue = queues + "-internal"
+            else:
+                self.internal_queue = None
 
         elif queues_type == "destination":
             if queues and type(queues) is not list:
@@ -124,6 +127,8 @@ class Redis(Pipeline):
                     raise exceptions.PipelineError(exc)
 
     def receive(self):
+        if self.source_queue is None:
+            raise exceptions.ConfigurationError('pipeline', 'No source queue gievn.')
         try:
             retval = self.pipe.lindex(self.internal_queue, -1)  # returns None if no value
             if not retval:


### PR DESCRIPTION
Two bugs are fixed:

* Handle non existing src or dest queues
  Currently, a bot without destination queue is retrying forever, now it stops immediately with a ConfigurationError
* bots handle invalid keys in incoming messages
  If an incoming message does contain an key/value which is not valid, we are retrying too, now it stops immediately with a ConfigurationError