### PR TITLE
RT collector: error handling and time filtering

### DIFF
--- a/intelmq/bots/BOTS
+++ b/intelmq/bots/BOTS
@@ -98,6 +98,7 @@
                 "provider": "",
                 "password": "password",
                 "rate_limit": 3600,
+                "search_newer_than": null,
                 "search_owner": "nobody",
                 "search_queue": "Incident Reports",
                 "search_status": "new",

--- a/intelmq/bots/BOTS
+++ b/intelmq/bots/BOTS
@@ -98,7 +98,7 @@
                 "provider": "",
                 "password": "password",
                 "rate_limit": 3600,
-                "search_newer_than": null,
+                "search_not_older_than": null,
                 "search_owner": "nobody",
                 "search_queue": "Incident Reports",
                 "search_status": "new",

--- a/intelmq/bots/collectors/rt/README.md
+++ b/intelmq/bots/collectors/rt/README.md
@@ -33,3 +33,5 @@ Optionally, the RT bot can "take" RT tickets (i.e. the `user` is assigned this t
         "unzip_attachment": true
     },
 
+In case a resource needs to be fetched and this resource is permanently not available (status code is 4xx), the ticket status will be set according to the configuration to avoid processing the ticket over and over.
+For temporary failures the status is not modified, instead the ticket will be skipped in this run.

--- a/intelmq/bots/collectors/rt/README.md
+++ b/intelmq/bots/collectors/rt/README.md
@@ -20,7 +20,7 @@ Optionally, the RT bot can "take" RT tickets (i.e. the `user` is assigned this t
         "attachment_regex": "\\.csv\\.zip$",
         "feed": "Request Tracker",
         "password": "intelmq",
-        "search_newer_than": null,
+        "search_not_older_than": null,
         "search_queue": "Incident Reports",
         "search_subject_like": "Report",
         "search_owner": "nobody",
@@ -39,6 +39,6 @@ For temporary failures the status is not modified, instead the ticket will be sk
 
 ## Time search
 
-To find only tickets newer than a given absolute or relative time, you can use the `search_newer_than` parameter. Absolute time specification can be anything parseable by dateutil, best use a ISO format.
+To find only tickets newer than a given absolute or relative time, you can use the `search_not_older_than` parameter. Absolute time specification can be anything parseable by dateutil, best use a ISO format.
 
 Relative must be in this format: `[number] [timespan]s`, e.g. `3 days`. Timespan can be hour, day, week, month, year. Trailing 's' is supported for all timespans. Relative times are subtracted from the current time directly before the search is performed.

--- a/intelmq/bots/collectors/rt/README.md
+++ b/intelmq/bots/collectors/rt/README.md
@@ -20,6 +20,7 @@ Optionally, the RT bot can "take" RT tickets (i.e. the `user` is assigned this t
         "attachment_regex": "\\.csv\\.zip$",
         "feed": "Request Tracker",
         "password": "intelmq",
+        "search_newer_than": null,
         "search_queue": "Incident Reports",
         "search_subject_like": "Report",
         "search_owner": "nobody",
@@ -35,3 +36,9 @@ Optionally, the RT bot can "take" RT tickets (i.e. the `user` is assigned this t
 
 In case a resource needs to be fetched and this resource is permanently not available (status code is 4xx), the ticket status will be set according to the configuration to avoid processing the ticket over and over.
 For temporary failures the status is not modified, instead the ticket will be skipped in this run.
+
+## Time search
+
+To find only tickets newer than a given absolute or relative time, you can use the `search_newer_than` parameter. Absolute time specification can be anything parseable by dateutil, best use a ISO format.
+
+Relative must be in this format: `[number] [timespan]s`, e.g. `3 days`. Timespan can be hour, day, week, month, year. Trailing 's' is supported for all timespans. Relative times are subtracted from the current time directly before the search is performed.

--- a/intelmq/bots/collectors/rt/collector_rt.py
+++ b/intelmq/bots/collectors/rt/collector_rt.py
@@ -25,15 +25,15 @@ class RTCollectorBot(CollectorBot):
 
         self.set_request_parameters()
 
-        if getattr(self.parameters, 'search_newer_than', None):
+        if getattr(self.parameters, 'search_not_older_than', None):
             try:
-                self.newer_than = parser.parse(self.parameters.search_newer_than)
-                self.newer_than_type = 'absolute'
+                self.not_older_than = parser.parse(self.parameters.search_not_older_than)
+                self.not_older_than_type = 'absolute'
             except ValueError:
-                self.newer_than_relative = timedelta(minutes=FilterExpertBot.parse_relative(self.parameters.search_newer_than))
-                self.newer_than_type = 'relative'
+                self.not_older_than_relative = timedelta(minutes=FilterExpertBot.parse_relative(self.parameters.search_not_older_than))
+                self.not_older_than_type = 'relative'
         else:
-            self.newer_than_type = False
+            self.not_older_than_type = False
 
     def process(self):
         RT = rt.Rt(self.parameters.uri, self.parameters.user,
@@ -41,10 +41,10 @@ class RTCollectorBot(CollectorBot):
         if not RT.login():
             raise ValueError('Login failed.')
 
-        if self.newer_than_type:
-            if self.newer_than_type == 'relative':
-                self.newer_than = datetime.now() - self.newer_than_relative
-            kwargs = {'Created__gt': self.newer_than.isoformat()}
+        if self.not_older_than_type:
+            if self.not_older_than_type == 'relative':
+                self.not_older_than = datetime.now() - self.not_older_than_relative
+            kwargs = {'Created__gt': self.not_older_than.isoformat()}
             self.logger.debug('Searching for tickets newer than %r.' % kwargs['Created__gt'])
         else:
             kwargs = {}

--- a/intelmq/bots/collectors/rt/collector_rt.py
+++ b/intelmq/bots/collectors/rt/collector_rt.py
@@ -30,7 +30,12 @@ class RTCollectorBot(CollectorBot):
                 self.not_older_than = parser.parse(self.parameters.search_not_older_than)
                 self.not_older_than_type = 'absolute'
             except ValueError:
-                self.not_older_than_relative = timedelta(minutes=parse_relative(self.parameters.search_not_older_than))
+                try:
+                    self.not_older_than_relative = timedelta(minutes=parse_relative(self.parameters.search_not_older_than))
+                except ValueError:
+                    self.logger.error("Parameter 'search_not_older_than' could not be parsed. "
+                                      "Check your configuration.")
+                    raise
                 self.not_older_than_type = 'relative'
         else:
             self.not_older_than_type = False

--- a/intelmq/bots/collectors/rt/collector_rt.py
+++ b/intelmq/bots/collectors/rt/collector_rt.py
@@ -7,8 +7,8 @@ from datetime import datetime, timedelta
 import requests
 from dateutil import parser
 
-from intelmq.bots.experts.filter.expert import FilterExpertBot
 from intelmq.lib.bot import CollectorBot
+from intelmq.lib.utils import parse_relative
 
 try:
     import rt
@@ -30,7 +30,7 @@ class RTCollectorBot(CollectorBot):
                 self.not_older_than = parser.parse(self.parameters.search_not_older_than)
                 self.not_older_than_type = 'absolute'
             except ValueError:
-                self.not_older_than_relative = timedelta(minutes=FilterExpertBot.parse_relative(self.parameters.search_not_older_than))
+                self.not_older_than_relative = timedelta(minutes=parse_relative(self.parameters.search_not_older_than))
                 self.not_older_than_type = 'relative'
         else:
             self.not_older_than_type = False

--- a/intelmq/bots/experts/filter/expert.py
+++ b/intelmq/bots/experts/filter/expert.py
@@ -7,33 +7,17 @@ import pytz
 from dateutil import parser
 
 from intelmq.lib.bot import Bot
+from intelmq.lib.utils import parse_relative
 
 
 class FilterExpertBot(Bot):
-
-    # number of minutes in time units
-    timespans = {'hour': 60, 'day': 24 * 60, 'week': 7 * 24 * 60,
-                 'month': 30 * 24 * 60, 'year': 365 * 24 * 60}
-
-    # parse relative time attributes
-    @staticmethod
-    def parse_relative(relative_time):
-        try:
-            result = re.findall(r'^(\d+)\s+(\w+[^s])s?$', relative_time, re.UNICODE)
-        except ValueError as e:
-            raise ValueError("Could not apply regex to attribute \"%s\" with exception %s.",
-                             repr(relative_time), repr(e.args))
-        if len(result) == 1 and len(result[0]) == 2 and result[0][1] in FilterExpertBot.timespans:
-            return int(result[0][0]) * FilterExpertBot.timespans[result[0][1]]
-        else:
-            raise ValueError("Could not process result of regex for attribute " + repr(relative_time))
 
     # decide format of timefilter value and parse it
     def parse_timeattr(self, time_attr):
         try:
             absolute = parser.parse(time_attr)
         except ValueError:
-            relative = timedelta(minutes=self.parse_relative(time_attr))
+            relative = timedelta(minutes=parse_relative(time_attr))
             self.logger.info("Filtering out events to (relative time) {!r}.".format(relative))
             return relative
         else:

--- a/intelmq/lib/utils.py
+++ b/intelmq/lib/utils.py
@@ -28,7 +28,7 @@ import pytz
 
 __all__ = ['base64_decode', 'base64_encode', 'decode', 'encode',
            'load_configuration', 'load_parameters', 'log', 'parse_logline',
-           'reverse_readline', 'error_message_from_exc',
+           'reverse_readline', 'error_message_from_exc', 'parse_relative'
            ]
 
 # Used loglines format
@@ -344,3 +344,38 @@ def error_message_from_exc(exc: Exception) -> str:
         result: The error message of exc
     """
     return traceback.format_exception_only(type(exc), exc)[-1].strip().replace(type(exc).__name__ + ': ', '')
+
+
+# number of minutes in time units
+TIMESPANS = {'hour': 60, 'day': 24 * 60, 'week': 7 * 24 * 60,
+             'month': 30 * 24 * 60, 'year': 365 * 24 * 60}
+
+
+def parse_relative(relative_time: str) -> int:
+    """
+    Parse relative time attributes and returns the corresponding minutes.
+
+    >>> parse_relative('4 hours')
+    240
+
+    Parameters:
+        relative_time: a string holding a relative time specification
+
+    Returns:
+        result: Minutes
+
+    Raises:
+        ValueError: If relative_time is not parseable
+
+    See also:
+        TIMESPANS: Defines the conversion of verbal timespans to minutes
+    """
+    try:
+        result = re.findall(r'^(\d+)\s+(\w+[^s])s?$', relative_time, re.UNICODE)
+    except ValueError as e:
+        raise ValueError("Could not apply regex to attribute \"%s\" with exception %s.",
+                         repr(relative_time), repr(e.args))
+    if len(result) == 1 and len(result[0]) == 2 and result[0][1] in TIMESPANS:
+        return int(result[0][0]) * TIMESPANS[result[0][1]]
+    else:
+        raise ValueError("Could not process result of regex for attribute " + repr(relative_time))

--- a/intelmq/tests/lib/test_utils.py
+++ b/intelmq/tests/lib/test_utils.py
@@ -144,6 +144,18 @@ class TestUtils(unittest.TestCase):
         exc = IndexError('This is a test')
         self.assertEqual(utils.error_message_from_exc(exc), 'This is a test')
 
+    def test_parse_relative(self):
+        """Tests if parse_reltive returns the correct timespan."""
+        self.assertEqual(utils.parse_relative('1 hour'), 60)
+        self.assertEqual(utils.parse_relative('2\tyears'), 1051200)
+
+    def test_parse_relative_raises(self):
+        """Tests if parse_reltive correctly raises ValueError."""
+        with self.assertRaises(ValueError):
+            utils.parse_relative('1 hou')
+        with self.assertRaises(ValueError):
+            utils.parse_relative('1 minute')
+
 
 if __name__ == '__main__':  # pragma: no cover
     unittest.main()


### PR DESCRIPTION
* If a resource needs to be fetched via download and the resource is not available, we now skip the creation of a report. (bugfix) Also, the ticket status will be changed according to the configuration
* Allows optional time-based searches, both absolute and relative, see the added docs.