### PR TITLE
ENH: Extra Fields for Generic CSV

### DIFF
--- a/intelmq/bots/parsers/generic/parser_csv.py
+++ b/intelmq/bots/parsers/generic/parser_csv.py
@@ -50,6 +50,7 @@ class GenericCsvParserBot(ParserBot):
 
     def parse_line(self, row, report):
         event = self.new_event(report)
+        additional = {}
 
         for key, value in zip(self.columns, row):
 
@@ -65,11 +66,17 @@ class GenericCsvParserBot(ParserBot):
                     value = self.type_translation[value]
                 elif not hasattr(self.parameters, 'type'):
                     continue
+            elif key.startswith("extra."):
+                _, key_ = key.split('.', 1)
+                additional[key_] = value
+                continue
             event.add(key, value)
 
         if hasattr(self.parameters, 'type')\
                 and "classification.type" not in event:
             event.add('classification.type', self.parameters.type)
+        if len(additional) > 0:
+            event.add('extra', additional)
         event.add("raw", self.recover_line(row))
         yield event
 

--- a/intelmq/tests/bots/parsers/generic/test_parser_csv.py
+++ b/intelmq/tests/bots/parsers/generic/test_parser_csv.py
@@ -27,13 +27,13 @@ EXAMPLE_EVENT = {"feed.name": "Sample CSV Feed",
                  "source.fqdn": "mail5.bulls.unisonplatform.com",
                  "event_description.text": "Really bad actor site comment",
                  "classification.type": "malware",
-                 "raw": utils.base64_encode(SAMPLE_SPLIT[1].replace('\t', ',')+'\r\n'),
+                 "raw": utils.base64_encode(SAMPLE_SPLIT[1].replace('\t', ',') + '\r\n'),
                  "time.observation": "2015-01-01T00:00:00+00:00",
                  }
 EXAMPLE_EVENT2 = EXAMPLE_EVENT.copy()
 EXAMPLE_EVENT2['time.source'] = "2016-12-14T04:19:00+00:00"
 EXAMPLE_EVENT2['source.ip'] = "198.105.221.161"
-EXAMPLE_EVENT2["raw"] = utils.base64_encode(SAMPLE_SPLIT[2].replace('\t', ',')+'\r\n')
+EXAMPLE_EVENT2["raw"] = utils.base64_encode(SAMPLE_SPLIT[2].replace('\t', ',') + '\r\n')
 
 
 class TestGenericCsvParserBot(test.BotTestCase, unittest.TestCase):

--- a/intelmq/tests/bots/parsers/generic/test_parser_csv3.py
+++ b/intelmq/tests/bots/parsers/generic/test_parser_csv3.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+
+import unittest
+
+import intelmq.lib.test as test
+from intelmq.bots.parsers.generic.parser_csv import GenericCsvParserBot
+
+EXAMPLE_REPORT = {"feed.name": "Sample CSV Feed",
+                  "feed.url": "http://www.samplecsvthreatfeed.com/list",
+                  "raw": "MjAxNi0xMi0xNCAwNDoxOTowMAlUZXN0aW5nCVJlYWxseSBiYWQgY"
+                         "WN0b3Igc2l0ZSBjb21tZW50CU5vdGhpbmcJVW5pbXBvcnRhbnQJd3"
+                         "d3LmNlbm5vd29ybGQuY29tL1BheW1lbnRfQ29uZmlybWF0aW9uL1B"
+                         "heW1lbnRfQ29uZmlybWF0aW9uLnppcAkxOTguMTA1LjIyMS4xNjEJ"
+                         "bWFpbDUuYnVsbHMudW5pc29ucGxhdGZvcm0uY29tCWp1c3QgYW5vd"
+                         "GhlciBjb21tZW50CWV4dHJhX2RhdGFfZm9yX3Rlc3QNCg==",
+                  "__type": "Report",
+                  "time.observation": "2015-01-01T00:00:00+00:00",
+                  }
+EXAMPLE_EVENT = {"feed.name": "Sample CSV Feed",
+                 "feed.url": "http://www.samplecsvthreatfeed.com/list",
+                 "__type": "Event",
+                 "time.source": "2016-12-14T04:19:00+00:00",
+                 "source.url": "http://www.cennoworld.com/Payment_Confirmation/"
+                               "Payment_Confirmation.zip",
+                 "source.ip": "198.105.221.161",
+                 "source.fqdn": "mail5.bulls.unisonplatform.com",
+                 "event_description.text": "Really bad actor site comment",
+                 "classification.type": "malware",
+                 "extra": "{\"text\": \"extra_data_for_test\"}",
+                 "raw": "MjAxNi0xMi0xNCAwNDoxOTowMCxUZXN0aW5nLFJlYWxseSBiYWQg"
+                        "YWN0b3Igc2l0ZSBjb21tZW50LE5vdGhpbmcsVW5pbXBvcnRhbnQs"
+                        "d3d3LmNlbm5vd29ybGQuY29tL1BheW1lbnRfQ29uZmlybWF0aW9u"
+                        "L1BheW1lbnRfQ29uZmlybWF0aW9uLnppcCwxOTguMTA1LjIyMS4x"
+                        "NjEsbWFpbDUuYnVsbHMudW5pc29ucGxhdGZvcm0uY29tLGp1c3Qg"
+                        "YW5vdGhlciBjb21tZW50LGV4dHJhX2RhdGFfZm9yX3Rlc3QNCg==",
+                 "time.observation": "2015-01-01T00:00:00+00:00",
+                 }
+
+
+class TestGenericCsvParserBot(test.BotTestCase, unittest.TestCase):
+    """
+    A TestCase for a GenericCsvParserBot.
+    """
+
+    @classmethod
+    def set_bot(cls):
+        cls.bot_reference = GenericCsvParserBot
+        cls.default_input_message = EXAMPLE_REPORT
+        cls.sysconfig = {"columns": ["time.source", "classification.type",
+                                     "event_description.text", "__IGNORE__",
+                                     "__IGNORE__", "source.url", "source.ip",
+                                     "source.fqdn", "__IGNORE__", "extra.text"],
+                         "delimiter": "\t",
+                         "type_translation": "{\"Testing\": \"malware\"}",
+                         "default_url_protocol": "http://"}
+
+    def test_event(self):
+        """ Test if correct Event has been produced. """
+        self.run_bot()
+        self.assertMessageEqual(0, EXAMPLE_EVENT)
+
+
+if __name__ == '__main__':  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
This patch adds the capability to have extra fields as dict (similar to otx and blueliv parsers). 
If a column name starts with `extra.` , the property of extra will be added as dict to "extra" field in event.
