### PR TITLE
Tests: Lazy imports of some libs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_script:
   - sed -i 's/events/tests/g' /tmp/initdb.sql
   - psql -v ON_ERROR_STOP=on -f /tmp/initdb.sql intelmq -U intelmq
 script:
-  - INTELMQ_TEST_DATABASES=1 INTELMQ_TEST_LOCAL_WEB=1 nosetests --with-coverage --cover-package=intelmq
+  - INTELMQ_TEST_DATABASES=1 INTELMQ_TEST_LOCAL_WEB=1 INTELMQ_TEST_EXOTIC=1 nosetests --with-coverage --cover-package=intelmq
   - dpkg-buildpackage -us -uc
   - pep8 intelmq/{bots,lib,bin}
 services:

--- a/docs/Developers-Guide.md
+++ b/docs/Developers-Guide.md
@@ -99,6 +99,21 @@ It may be necessary to switch the user to `intelmq` if the run-path (`/opt/intel
 
 There is a [Travis-CI](https://travis-ci.org/certtools/intelmq/builds) setup for automatic testing, which triggers on pull requests. You can also easily activate it for your forks.
 
+### Environment variables
+
+There are a bunch of environemnt variables which switch on/off some tests:
+
+* `INTELMQ_TEST_DATABASES`: databases such as postgres, elasticsearch, mongodb are not tested by default, set to 1 to test those bots.
+* `INTELMQ_SKIP_INTERNET`: tests requiring internet connection will be skipped if this is set to 1.
+* `INTELMQ_SKIP_REDIS`: redis-related tests are ran by default, set this to 1 to skip those.
+* `INTELMQ_TEST_LOCAL_WEB`: tests which connect to local web servers or proxies are active when set to 1.
+* `INTELMQ_TEST_EXOTIC`: some bots and tests require libraries which may not be available, those are skipped by default. To run them, set this to 1.
+
+For example, to run all tests you can use:
+
+```bash
+INTELMQ_TEST_DATABASES=1 INTELMQ_TEST_LOCAL_WEB=1 INTELMQ_TEST_EXOTIC=1 nosetests
+```
 
 # Development Guidelines
 
@@ -581,6 +596,8 @@ if __name__ == '__main__':  # pragma: no cover
 ```
 
 When calling the file directly, only the tests in this file for the bot will be expected. Some default tests are always executed (via the `test.BotTestCase` class), such as pipeline and message checks, logging, bot naming or empty message handling.
+
+See the [testing section](#testing) about how to run the tests.
 
 ## Configuration
 

--- a/intelmq/bots/collectors/alienvault_otx/collector.py
+++ b/intelmq/bots/collectors/alienvault_otx/collector.py
@@ -3,12 +3,18 @@ import json
 
 from intelmq.lib.bot import CollectorBot
 
-from OTXv2 import OTXv2
+try:
+    from OTXv2 import OTXv2
+except ImportError:
+    OTXv2 = None
 
 
 class AlienVaultOTXCollectorBot(CollectorBot):
 
     def init(self):
+        if OTXv2 is None:
+            raise ValueError('Could not import OTXv2. Please install it.')
+
         if hasattr(self.parameters, 'http_ssl_proxy'):
             self.logger.warning("Parameter 'http_ssl_proxy' is deprecated and will be removed in "
                                 "version 1.0!")

--- a/intelmq/lib/test.py
+++ b/intelmq/lib/test.py
@@ -89,6 +89,11 @@ def skip_local_web():
                                'Skipping local web tests.')
 
 
+def skip_exotic():
+    return unittest.skipUnless(os.environ.get('INTELMQ_TEST_EXOTIC'),
+                               'Skipping tests requiring exotic libs.')
+
+
 class BotTestCase(object):
     """
     Provides common tests and assert methods for bot testing.

--- a/intelmq/tests/bots/collectors/alienvault_otx/test_collector.py
+++ b/intelmq/tests/bots/collectors/alienvault_otx/test_collector.py
@@ -2,5 +2,7 @@
 """
 Testing Alienvault OTX collector
 """
+import os
 
-import intelmq.bots.collectors.alienvault_otx.collector
+if os.environ.get('INTELMQ_TEST_EXOTIC'):
+    import intelmq.bots.collectors.alienvault_otx.collector

--- a/intelmq/tests/bots/collectors/blueliv/test_collector.py
+++ b/intelmq/tests/bots/collectors/blueliv/test_collector.py
@@ -2,5 +2,7 @@
 """
 Testing Blueliv crimeserver collector
 """
+import os
 
-import intelmq.bots.collectors.blueliv.collector_crimeserver
+if os.environ.get('INTELMQ_TEST_EXOTIC'):
+    import intelmq.bots.collectors.blueliv.collector_crimeserver

--- a/intelmq/tests/bots/collectors/mail/test_collector_attach.py
+++ b/intelmq/tests/bots/collectors/mail/test_collector_attach.py
@@ -2,5 +2,7 @@
 """
 Testing Mail Attach collector
 """
+import os
 
-import intelmq.bots.collectors.mail.collector_mail_attach
+if os.environ.get('INTELMQ_TEST_EXOTIC'):
+    import intelmq.bots.collectors.mail.collector_mail_attach

--- a/intelmq/tests/bots/collectors/mail/test_collector_url.py
+++ b/intelmq/tests/bots/collectors/mail/test_collector_url.py
@@ -2,5 +2,7 @@
 """
 Testing Mail URL collector
 """
+import os
 
-import intelmq.bots.collectors.mail.collector_mail_url
+if os.environ.get('INTELMQ_TEST_EXOTIC'):
+    import intelmq.bots.collectors.mail.collector_mail_url

--- a/intelmq/tests/bots/collectors/misp/test_collector_attach.py
+++ b/intelmq/tests/bots/collectors/misp/test_collector_attach.py
@@ -2,5 +2,7 @@
 """
 Testing MISP collector
 """
+import os
 
-import intelmq.bots.collectors.misp.collector
+if os.environ.get('INTELMQ_TEST_EXOTIC'):
+    import intelmq.bots.collectors.misp.collector

--- a/intelmq/tests/bots/collectors/n6/test_collector.py
+++ b/intelmq/tests/bots/collectors/n6/test_collector.py
@@ -2,5 +2,7 @@
 """
 Testing n6 stomp collector
 """
+import os
 
-import intelmq.bots.collectors.n6.collector_stomp
+if os.environ.get('INTELMQ_TEST_EXOTIC'):
+    import intelmq.bots.collectors.n6.collector_stomp

--- a/intelmq/tests/bots/collectors/rt/test_collector.py
+++ b/intelmq/tests/bots/collectors/rt/test_collector.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 """
 """
+import os
 
-import intelmq.bots.collectors.rt.collector_rt
+if os.environ.get('INTELMQ_TEST_EXOTIC'):
+    import intelmq.bots.collectors.rt.collector_rt

--- a/intelmq/tests/bots/collectors/xmpp/test_collector.py
+++ b/intelmq/tests/bots/collectors/xmpp/test_collector.py
@@ -1,7 +1,9 @@
 """
 Test for the XMPP Collector Bot
 """
+import os
 
-import intelmq.bots.collectors.xmpp.collector
+if os.environ.get('INTELMQ_TEST_EXOTIC'):
+    import intelmq.bots.collectors.xmpp.collector
 
 # This file is a stub.

--- a/intelmq/tests/bots/experts/maxmind_geoip/test_expert.py
+++ b/intelmq/tests/bots/experts/maxmind_geoip/test_expert.py
@@ -1,3 +1,5 @@
 # -*- coding: utf-8 -*-
+import os
 
-import intelmq.bots.experts.maxmind_geoip.expert
+if os.environ.get('INTELMQ_TEST_EXOTIC'):
+    import intelmq.bots.experts.maxmind_geoip.expert

--- a/intelmq/tests/bots/outputs/amqptopic/test_output.py
+++ b/intelmq/tests/bots/outputs/amqptopic/test_output.py
@@ -1,3 +1,5 @@
 # -*- coding: utf-8 -*-
+import os
 
-import intelmq.bots.outputs.amqptopic.output
+if os.environ.get('INTELMQ_TEST_EXOTIC'):
+    import intelmq.bots.outputs.amqptopic.output

--- a/intelmq/tests/bots/outputs/elasticsearch/test_output.py
+++ b/intelmq/tests/bots/outputs/elasticsearch/test_output.py
@@ -1,11 +1,14 @@
 # -*- coding: utf-8 -*-
+import os
 import time
 import unittest
 
-import elasticsearch
-
 import intelmq.lib.test as test
 from intelmq.bots.outputs.elasticsearch.output import ElasticsearchOutputBot
+
+if os.environ.get('INTELMQ_TEST_DATABASES'):
+    import elasticsearch
+
 
 INPUT1 = {"__type": "Event",
           "classification.type": "botnet drone",
@@ -40,7 +43,8 @@ class TestElasticsearchOutputBot(test.BotTestCase, unittest.TestCase):
         cls.bot_reference = ElasticsearchOutputBot
         cls.default_input_message = INPUT1
         cls.sysconfig = {"flatten_fields": "extra"}
-        cls.con = elasticsearch.Elasticsearch()
+        if os.environ.get('INTELMQ_TEST_DATABASES'):
+            cls.con = elasticsearch.Elasticsearch()
 
     def test_event(self):
         self.run_bot()

--- a/intelmq/tests/bots/outputs/mongodb/test_output.py
+++ b/intelmq/tests/bots/outputs/mongodb/test_output.py
@@ -1,10 +1,12 @@
 # -*- coding: utf-8 -*-
+import os
 import unittest
-
-import pymongo
 
 import intelmq.lib.test as test
 from intelmq.bots.outputs.mongodb.output import MongoDBOutputBot
+
+if os.environ.get('INTELMQ_TEST_DATABASES'):
+    import pymongo
 
 INPUT1 = {"__type": "Event",
           "classification.type": "botnet drone",
@@ -34,6 +36,8 @@ class TestMongoDBOutputBot(test.BotTestCase, unittest.TestCase):
                          "host": "localhost",
                          "port": 27017,
                          "hierarchical_output": True}
+        if not os.environ.get('INTELMQ_TEST_DATABASES'):
+            return
         cls.con = pymongo.MongoClient()
         cls.db = cls.con['tests']
 

--- a/intelmq/tests/bots/outputs/postgresql/test_output.py
+++ b/intelmq/tests/bots/outputs/postgresql/test_output.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import os
 import unittest
 
 import intelmq.lib.test as test
@@ -29,6 +30,8 @@ class TestPostgreSQLOutputBot(test.BotTestCase, unittest.TestCase):
                          "password": "intelmq",
                          "sslmode": "require",
                          "table": "tests"}
+        if not os.environ.get('INTELMQ_TEST_DATABASES'):
+            return
         cls.con = psycopg2.connect(database=cls.sysconfig['database'],
                                    user=cls.sysconfig['user'],
                                    password=cls.sysconfig['password'],

--- a/intelmq/tests/bots/outputs/stomp/test_output.py
+++ b/intelmq/tests/bots/outputs/stomp/test_output.py
@@ -1,3 +1,5 @@
 # -*- coding: utf-8 -*-
+import os
 
-import intelmq.bots.outputs.stomp.output
+if os.environ.get('INTELMQ_TEST_EXOTIC'):
+    import intelmq.bots.outputs.stomp.output

--- a/intelmq/tests/bots/outputs/xmpp/test_output.py
+++ b/intelmq/tests/bots/outputs/xmpp/test_output.py
@@ -1,7 +1,9 @@
 """
 Test for the XMPP Output Bot
 """
+import os
 
-import intelmq.bots.outputs.xmpp.output
+if os.environ.get('INTELMQ_TEST_EXOTIC'):
+    import intelmq.bots.outputs.xmpp.output
 
 # This file is a stub.


### PR DESCRIPTION
Makes testing easier if not all libraries are installed:
* OTXv2
* python-rt
* sleekxmpp
* imbox
* pymisp
* geoip2
* stomp
* pika
* elasticsearch
* pymongo

Components depending on these libs can be tested by setting `INTELMQ_TEST_EXOTIC=1` (default on travis).

Motivation: Run tests in build environment where I don't have all this libs, but also very useful for devs.