### PR TITLE
sighup handling fixes

### DIFF
--- a/intelmq/bots/collectors/http/collector_http_stream.py
+++ b/intelmq/bots/collectors/http/collector_http_stream.py
@@ -26,6 +26,8 @@ from intelmq.lib.utils import decode
 
 class HTTPStreamCollectorBot(CollectorBot):
 
+    sighup_delay = False
+
     def init(self):
         if getattr(self.parameters, 'url', False) and \
            not getattr(self.parameters, 'http_url', False):

--- a/intelmq/lib/bot.py
+++ b/intelmq/lib/bot.py
@@ -110,8 +110,8 @@ class Bot(object):
             return False
         self.logger.info('Handling SIGHUP, initializing again now.')
         self.__disconnect_pipelines()
-        self.logger.handlers = []  # remove all existing handlers
         self.shutdown()  # disconnects, stops threads etc
+        self.logger.handlers = []  # remove all existing handlers
         self.__init__(self.__bot_id)
         self.__connect_pipelines()
 

--- a/intelmq/lib/bot.py
+++ b/intelmq/lib/bot.py
@@ -29,6 +29,8 @@ class Bot(object):
     """ Not to be reset when initialized again on reload. """
     __current_message = None
     __message_counter = 0
+    # Bot is capable of SIGHUP delaying
+    sighup_delay = True
 
     def __init__(self, bot_id):
         self.__log_buffer = []
@@ -95,8 +97,10 @@ class Bot(object):
         """
         Called when signal is received and postpone.
         """
-        self.logger.info('Received SIGHUP, initializing again later.')
         self.__sighup = True
+        self.logger.info('Received SIGHUP, initializing again later.')
+        if not self.sighup_delay:
+            self.__handle_sighup()
 
     def __handle_sighup(self):
         """


### PR DESCRIPTION
Fixes two issues with SIGHUP handling:
* Logging in shutdown methods works again (e.g. done in XMPP bots)
* HTTP stream collector reloads correctly