### PR TITLE
MAINT: logging: remove manual interpolation

### DIFF
--- a/intelmq/bots/collectors/file/collector_file.py
+++ b/intelmq/bots/collectors/file/collector_file.py
@@ -54,7 +54,7 @@ class FileCollectorBot(CollectorBot):
                 filename = os.path.join(p, f)
                 if os.path.isfile(filename):
                     if fnmatch.fnmatch(f, '*' + self.parameters.postfix):
-                        self.logger.info("Processing file %r." % filename)
+                        self.logger.info("Processing file %r.", filename)
 
                         with open(filename, 'r') as f:
 
@@ -66,9 +66,9 @@ class FileCollectorBot(CollectorBot):
                         if self.parameters.delete_file:
                             try:
                                 os.remove(filename)
-                                self.logger.debug("Deleted file: %r." % filename)
+                                self.logger.debug("Deleted file: %r.", filename)
                             except PermissionError:
-                                self.logger.error("Could not delete file %r." % filename)
+                                self.logger.error("Could not delete file %r.", filename)
                                 self.logger.info("Maybe I don't have sufficient rights on that file?")
                                 self.logger.error("Stopping now, to prevent reading this file again.")
                                 self.stop()

--- a/intelmq/bots/collectors/ftp/collector_ftp.py
+++ b/intelmq/bots/collectors/ftp/collector_ftp.py
@@ -22,9 +22,8 @@ from intelmq.lib.bot import CollectorBot
 
 class FTPCollectorBot(CollectorBot):
     def process(self):
-        self.logger.info("Downloading report from %s." %
-                         (self.parameters.ftp_host + ':' +
-                          str(self.parameters.ftp_port)))
+        self.logger.info("Downloading report from %s.",
+                         self.parameters.ftp_host + ':' + str(self.parameters.ftp_port))
 
         ftp = FTP()
         ftp.connect(host=self.parameters.ftp_host,
@@ -35,22 +34,20 @@ class FTPCollectorBot(CollectorBot):
                       passwd=self.parameters.ftp_password)
         cwd = '/'
         if hasattr(self.parameters, 'ftp_directory'):
-            self.logger.debug('Changing working directory to: %r.'
-                              '' % self.parameters.ftp_directory)
+            self.logger.debug('Changing working directory to: %r.', self.parameters.ftp_directory)
             cwd = self.parameters.ftp_directory
         ftp.cwd(cwd)
 
         filemask = '*'
         if hasattr(self.parameters, 'ftp_file'):
-            self.logger.debug('Setting filemask to to: %r.'
-                              '' % self.parameters.ftp_file)
+            self.logger.debug('Setting filemask to to: %r.', self.parameters.ftp_file)
             filemask = self.parameters.ftp_file
 
         mem = io.BytesIO()
         files = fnmatch.filter(ftp.nlst(), filemask)
 
         if files:
-            self.logger.info('Retrieving file: %r.' % files[-1])
+            self.logger.info('Retrieving file: %r.', files[-1])
             ftp.retrbinary("RETR " + files[-1], mem.write)
         else:
             self.logger.info("No file found, terminating download.")
@@ -64,8 +61,8 @@ class FTPCollectorBot(CollectorBot):
         except zipfile.BadZipfile:
             raw_reports.append(mem.getvalue())
         else:
-            self.logger.info('Downloaded zip file, extracting following files: %r'
-                             '' % zfp.namelist())
+            self.logger.info('Downloaded zip file, extracting following files: %r',
+                             zfp.namelist())
             for filename in zfp.namelist():
                 raw_reports.append(zfp.read(filename))
 

--- a/intelmq/bots/collectors/ftp/collector_ftps.py
+++ b/intelmq/bots/collectors/ftp/collector_ftps.py
@@ -56,9 +56,8 @@ class FTPS(FTP_TLS):
 
 class FTPSCollectorBot(CollectorBot):
     def process(self):
-        self.logger.info("Downloading report from %s." %
-                         (self.parameters.ftp_host + ':' +
-                          str(self.parameters.ftp_port)))
+        self.logger.info("Downloading report from %s.",
+                         self.parameters.ftp_host + ':' + str(self.parameters.ftp_port))
 
         ftps = FTPS()
         ftps.connect(host=self.parameters.ftps_host,
@@ -71,15 +70,15 @@ class FTPSCollectorBot(CollectorBot):
 
         cwd = '/'
         if hasattr(self.parameters, 'ftps_directory'):
-            self.logger.debug('Changing working directory to: %r.'
-                              '' % self.parameters.ftp_directory)
+            self.logger.debug('Changing working directory to: %r.',
+                              self.parameters.ftp_directory)
             cwd = self.parameters.ftps_directory
         ftps.cwd(cwd)
 
         filemask = '*'
         if hasattr(self.parameters, 'ftps_file'):
-            self.logger.debug('Setting filemask to to: %r.'
-                              '' % self.parameters.ftp_file)
+            self.logger.debug('Setting filemask to to: %r.',
+                              self.parameters.ftp_file)
             filemask = self.parameters.ftps_file
 
         mem = io.BytesIO()
@@ -100,8 +99,8 @@ class FTPSCollectorBot(CollectorBot):
         except zipfile.BadZipfile:
             raw_reports.append(mem.getvalue())
         else:
-            self.logger.info('Downloaded zip file, extracting following files: %r'
-                             '' % zfp.namelist())
+            self.logger.info('Downloaded zip file, extracting following files: %r.',
+                             zfp.namelist())
             for filename in zfp.namelist():
                 raw_reports.append(zfp.read(filename))
 

--- a/intelmq/bots/collectors/http/collector_http.py
+++ b/intelmq/bots/collectors/http/collector_http.py
@@ -29,8 +29,7 @@ class HTTPCollectorBot(CollectorBot):
         self.set_request_parameters()
 
     def process(self):
-        self.logger.info("Downloading report from %s" %
-                         self.parameters.http_url)
+        self.logger.info("Downloading report from %s", self.parameters.http_url)
 
         resp = requests.get(url=self.parameters.http_url, auth=self.auth,
                             proxies=self.proxy, headers=self.http_header,

--- a/intelmq/bots/collectors/http/collector_http_stream.py
+++ b/intelmq/bots/collectors/http/collector_http_stream.py
@@ -34,8 +34,7 @@ class HTTPStreamCollectorBot(CollectorBot):
         self.set_request_parameters()
 
     def process(self):
-        self.logger.info("Connecting to stream at %r." %
-                         self.parameters.http_url)
+        self.logger.info("Connecting to stream at %r.", self.parameters.http_url)
 
         try:
             req = requests.get(url=self.parameters.http_url, auth=self.auth,

--- a/intelmq/bots/collectors/mail/collector_mail_url.py
+++ b/intelmq/bots/collectors/mail/collector_mail_url.py
@@ -45,7 +45,7 @@ class MailURLCollectorBot(CollectorBot):
                         # carriage returns
                         url = url.strip()
 
-                        self.logger.info("Downloading report from %r." % url)
+                        self.logger.info("Downloading report from %r.", url)
                         resp = requests.get(url=url,
                                             auth=self.auth, proxies=self.proxy,
                                             headers=self.http_header,

--- a/intelmq/bots/collectors/microsoft/collector_azure.py
+++ b/intelmq/bots/collectors/microsoft/collector_azure.py
@@ -38,14 +38,14 @@ class MicrosoftAzureCollectorBot(CollectorBot):
             blob_service.set_proxy(**self.proxy)
         containers = blob_service.list_containers()
         for container in containers:
-            self.logger.info('Processing Container %r.' % container.name)
+            self.logger.info('Processing Container %r.', container.name)
             if container.name == 'heartbeat':
                 if self.parameters.delete:
                     blob_service.delete_container(container.name)
                 continue
             time_container_fetch = datetime.datetime.now(pytz.timezone('UTC'))
             for blob in blob_service.list_blobs(container.name):
-                self.logger.debug('Processing blob %r.' % blob.name)
+                self.logger.debug('Processing blob %r.', blob.name)
                 time_blob_fetch = datetime.datetime.now(pytz.timezone('UTC'))
                 blob_obj = io.BytesIO(blob_service.get_blob_to_bytes(container.name,
                                                                      blob.name).content)

--- a/intelmq/bots/collectors/n6/collector_stomp.py
+++ b/intelmq/bots/collectors/n6/collector_stomp.py
@@ -17,14 +17,13 @@ try:
             self.n6stomper.logger.warn("Heartbeat timeout. Attempting to re-connect.")
             self.n6stomper.conn.disconnect()
             status = self.n6stomper.conn.connect(wait=False)
-            self.n6stomper.logger.info("Re-connected: {}.".format(status))
+            self.n6stomper.logger.info("Re-connected: %s.", status)
 
         def on_error(self, headers, message):
-            self.n6stomper.logger.error('Received an error :"%s".' % repr(message))
+            self.n6stomper.logger.error('Received an error: %r.', message)
 
         def on_message(self, headers, message):
-            self.n6stomper.logger.debug('Receive message '
-                                        '{!r}...'.format(message[:500]))
+            self.n6stomper.logger.debug('Receive message %r...', message[:500])
             report = self.n6stomper.new_report()
             report.add("raw", message.rstrip())
             report.add("feed.url", "stomp://" +
@@ -76,8 +75,8 @@ class n6stompCollectorBot(CollectorBot):
         self.conn.start()
         self.conn.connect(wait=False)
         self.conn.subscribe(destination=self.exchange, id=1, ack='auto')
-        self.logger.info('Successfully connected and subscribed to {}:{}.'
-                         ''.format(self.server, self.port))
+        self.logger.info('Successfully connected and subscribed to %s:%s.',
+                         self.server, self.port)
 
     def disconnect(self):
         self.conn.disconnect()

--- a/intelmq/bots/collectors/rt/collector_rt.py
+++ b/intelmq/bots/collectors/rt/collector_rt.py
@@ -50,7 +50,7 @@ class RTCollectorBot(CollectorBot):
             if self.not_older_than_type == 'relative':
                 self.not_older_than = datetime.now() - self.not_older_than_relative
             kwargs = {'Created__gt': self.not_older_than.isoformat()}
-            self.logger.debug('Searching for tickets newer than %r.' % kwargs['Created__gt'])
+            self.logger.debug('Searching for tickets newer than %r.', kwargs['Created__gt'])
         else:
             kwargs = {}
 
@@ -59,16 +59,16 @@ class RTCollectorBot(CollectorBot):
                           Owner=self.parameters.search_owner,
                           Status=self.parameters.search_status,
                           order='Created', **kwargs)
-        self.logger.info('{} results on search query.'.format(len(query)))
+        self.logger.info('%s results on search query.', len(query))
 
         for ticket in query:
             ticket_id = int(ticket['id'].split('/')[1])
-            self.logger.debug('Process ticket {}.'.format(ticket_id))
+            self.logger.debug('Process ticket %s.', ticket_id)
             content = 'attachment'
             for (att_id, att_name, _, _) in RT.get_attachments(ticket_id):
                 if re.search(self.parameters.attachment_regex, att_name):
-                    self.logger.debug('Found attachment {}: {!r}.'
-                                      ''.format(att_id, att_name))
+                    self.logger.debug('Found attachment %s: %r.',
+                                      att_id, att_name)
                     break
             else:
                 ticket = RT.get_history(ticket_id)[0]
@@ -100,10 +100,10 @@ class RTCollectorBot(CollectorBot):
 
                 response_code_class = resp.status_code // 100
                 if response_code_class != 2:
-                    self.logger.error('HTTP response status code for {!r} was {}.'
-                                      ''.format(url, resp.status_code))
+                    self.logger.error('HTTP response status code for %r was %s.',
+                                      url, resp.status_code)
                     if response_code_class == 4:
-                        self.logger.debug('Server response: {!r}.'.format(resp.text))
+                        self.logger.debug('Server response: %r.', resp.text)
                         self.logger.warning('Setting status of unprocessable ticket.')
                         if self.parameters.set_status:
                             RT.edit_ticket(ticket_id, status=self.parameters.set_status)
@@ -123,7 +123,7 @@ class RTCollectorBot(CollectorBot):
                 try:
                     RT.take(ticket_id)
                 except rt.BadRequest:
-                    self.logger.exception("Could not take ticket %s." % ticket_id)
+                    self.logger.exception("Could not take ticket %s.", ticket_id)
             if self.parameters.set_status:
                 RT.edit_ticket(ticket_id, status=self.parameters.set_status)
 

--- a/intelmq/bots/collectors/xmpp/collector.py
+++ b/intelmq/bots/collectors/xmpp/collector.py
@@ -66,7 +66,7 @@ try:
                 self.disconnect()
 
             if self.xmpp_room:  # and self.plugin.get('xep_0045') # this check should also exist!
-                self.logger.debug("Joining room: %s." % self.xmpp_room)
+                self.logger.debug("Joining room: %s.", self.xmpp_room)
                 pwd = self.xmpp_room_password if self.xmpp_room_password else ""
                 self.plugin['xep_0045'].joinMUC(self.xmpp_room,
                                                 self.xmpp_room_nick,
@@ -91,7 +91,7 @@ class XMPPCollectorBot(CollectorBot):
         xmpp_password = getattr(self.parameters, "xmpp_password", None)
 
         if None in (xmpp_user, xmpp_server, xmpp_password):
-            self.logger.error('No User / Password provided')
+            self.logger.error('No User / Password provided.')
             self.stop()
         else:
             xmpp_login = xmpp_user + '@' + xmpp_server
@@ -116,7 +116,7 @@ class XMPPCollectorBot(CollectorBot):
         ca_certs = getattr(self.parameters, "ca_certs", None)
 
         if self.muc and not xmpp_room:
-            self.logger.error('No room provided')
+            self.logger.error('No room provided.')
             self.stop()
 
         if self.muc:
@@ -187,7 +187,7 @@ class XMPPCollectorBot(CollectorBot):
             else:
                 tmp_body = body
 
-            self.logger.debug("Received Stanza: %r from %r." % (tmp_body, msg['from']))
+            self.logger.debug("Received Stanza: %r from %r.", tmp_body, msg['from'])
 
             raw_msg = body
             # Read msg-body and add as raw to a new report.

--- a/intelmq/bots/experts/asn_lookup/expert.py
+++ b/intelmq/bots/experts/asn_lookup/expert.py
@@ -20,9 +20,9 @@ class ASNLookupExpertBot(Bot):
             self.database = pyasn.pyasn(self.parameters.database)
         except IOError:
             self.logger.error("pyasn data file does not exist or could not be "
-                              "accessed in '%s'" % self.parameters.database)
+                              "accessed in %r.", self.parameters.database)
             self.logger.error("Read 'bots/experts/asn_lookup/README' and "
-                              "follow the procedure")
+                              "follow the procedure.")
             self.stop()
 
     def process(self):

--- a/intelmq/bots/experts/filter/expert.py
+++ b/intelmq/bots/experts/filter/expert.py
@@ -18,10 +18,10 @@ class FilterExpertBot(Bot):
             absolute = parser.parse(time_attr)
         except ValueError:
             relative = timedelta(minutes=parse_relative(time_attr))
-            self.logger.info("Filtering out events to (relative time) {!r}.".format(relative))
+            self.logger.info("Filtering out events to (relative time) %r.", relative)
             return relative
         else:
-            self.logger.info("Filtering out events to (absolute time) {!r}.".format(absolute))
+            self.logger.info("Filtering out events to (absolute time) %r.", absolute)
             return absolute
         return None
 
@@ -65,25 +65,25 @@ class FilterExpertBot(Bot):
             try:
                 event_time = parser.parse(str(event.get('time.source'))).replace(tzinfo=pytz.timezone('UTC'))
             except ValueError:
-                self.logger.error("Could not parse time.source {!s}.".format(event.get('time.source')))
+                self.logger.error("Could not parse time.source %s.", event.get('time.source'))
             else:
                 if type(self.not_after) is datetime and event_time > self.not_after:
                     self.acknowledge_message()
-                    self.logger.debug("Filtered out event with time.source {!s}.".format(event.get('time.source')))
+                    self.logger.debug("Filtered out event with time.source %s.", event.get('time.source'))
                     return
                 if type(self.not_before) is datetime and event_time < self.not_before:
                     self.acknowledge_message()
-                    self.logger.debug("Filtered out event with time.source {!r}.".format(event.get('time.source')))
+                    self.logger.debug("Filtered out event with time.source %r.", event.get('time.source'))
                     return
 
                 now = datetime.now(tz=pytz.timezone('UTC'))
                 if type(self.not_after) is timedelta and event_time > (now - self.not_after):
                     self.acknowledge_message()
-                    self.logger.debug("Filtered out event with time.source {!r}.".format(event.get('time.source')))
+                    self.logger.debug("Filtered out event with time.source %r.", event.get('time.source'))
                     return
                 if type(self.not_before) is timedelta and event_time < (now - self.not_before):
                     self.acknowledge_message()
-                    self.logger.debug("Filtered out event with time.source {!r}.".format(event.get('time.source')))
+                    self.logger.debug("Filtered out event with time.source %r.", event.get('time.source'))
                     return
 
         # key/value based filtering

--- a/intelmq/bots/experts/generic_db_lookup/expert.py
+++ b/intelmq/bots/experts/generic_db_lookup/expert.py
@@ -55,7 +55,7 @@ class GenericDBLookupExpertBot(Bot):
         # Skip events with missing match-keys
         for key in self.match.keys():
             if key not in event:
-                self.logger.debug('%s not present in event. Skipping event.' % key)
+                self.logger.debug('%s not present in event. Skipping event.', key)
                 self.send_message(event)
                 self.acknowledge_message()
                 return
@@ -67,8 +67,8 @@ class GenericDBLookupExpertBot(Bot):
             return
 
         try:
-            self.logger.debug('Executing %r.' % self.cur.mogrify(self.query,
-                                                                 [event[key] for key in self.match.keys()]))
+            self.logger.debug('Executing %r.', self.cur.mogrify(self.query,
+                                                                [event[key] for key in self.match.keys()]))
             self.cur.execute(self.query, [event[key] for key in self.match.keys()])
             self.logger.debug('Done.')
         except (psycopg2.InterfaceError, psycopg2.InternalError,

--- a/intelmq/bots/experts/maxmind_geoip/expert.py
+++ b/intelmq/bots/experts/maxmind_geoip/expert.py
@@ -19,10 +19,10 @@ class GeoIPExpertBot(Bot):
             self.database = geoip2.database.Reader(self.parameters.database)
         except IOError:
             self.logger.exception("GeoIP Database does not exist or could not "
-                                  "be accessed in {}"
-                                  "".format(self.parameters.database))
+                                  "be accessed in %r.",
+                                  self.parameters.database)
             self.logger.error("Read 'bots/experts/geoip/README' and follow the"
-                              " procedure")
+                              " procedure.")
             self.stop()
 
     def process(self):

--- a/intelmq/bots/experts/modify/expert.py
+++ b/intelmq/bots/experts/modify/expert.py
@@ -60,9 +60,9 @@ class ModifyExpertBot(Bot):
                     else:
                         matches[name] = match
                 else:
-                    self.logger.warn("Type of rule ({!r}) and data ({!r}) do not "
-                                     "match in {!s}, {}!".format(type(rule), type(event[name]),
-                                                                 identifier, name))
+                    self.logger.warn("Type of rule (%r) and data (%r) do not "
+                                     "match in %s, %s!",
+                                     type(rule), type(event[name]), identifier, name)
             elif not isinstance(event[name], str):  # int, float, etc
                 if event[name] != rule:
                     return None
@@ -89,7 +89,7 @@ class ModifyExpertBot(Bot):
             rule_id, rule_selection, rule_action = rule['rulename'], rule['if'], rule['then']
             matches = self.matches(rule_id, event, rule_selection)
             if matches is not None:
-                self.logger.debug('Apply rule {}.'.format(rule_id))
+                self.logger.debug('Apply rule %s.', rule_id)
                 self.apply_action(event, rule_action, matches)
 
         self.send_message(event)

--- a/intelmq/bots/experts/rfc1918/expert.py
+++ b/intelmq/bots/experts/rfc1918/expert.py
@@ -58,7 +58,7 @@ class RFC1918ExpertBot(Bot):
                             for domain in DOMAINS)
             if check:
                 if policy == 'del':
-                    self.logger.debug("Value removed from %s." % (field))
+                    self.logger.debug("Value removed from %s.", field)
                     del event[field]
                 elif policy == 'drop':
                     self.acknowledge_message()

--- a/intelmq/bots/outputs/amqptopic/output.py
+++ b/intelmq/bots/outputs/amqptopic/output.py
@@ -37,9 +37,8 @@ class AMQPTopicBot(Bot):
         self.connect_server()
 
     def connect_server(self):
-        self.logger.info('AMQP Connecting to {}:{}{}.'.format(self.connection_host,
-                                                              self.connection_port,
-                                                              self.connection_vhost))
+        self.logger.info('AMQP Connecting to %s:%s%s.',
+                         self.connection_host, self.connection_port, self.connection_vhost)
         try:
             self.connection = pika.BlockingConnection(self.connection_parameters)
         except pika.exceptions.ProbableAuthenticationError:
@@ -52,7 +51,7 @@ class AMQPTopicBot(Bot):
             self.logger.error('AMQP connection failed!')
             raise
         else:
-            self.logger.info('AMQP connection succesfull.')
+            self.logger.info('AMQP connection succesful.')
             self.channel = self.connection.channel()
             try:
                 self.channel.exchange_declare(exchange=self.exchange, type=self.exchange_type,

--- a/intelmq/bots/outputs/file/output.py
+++ b/intelmq/bots/outputs/file/output.py
@@ -7,9 +7,9 @@ from intelmq.lib.bot import Bot
 class FileOutputBot(Bot):
 
     def init(self):
-        self.logger.debug("Opening %r file." % self.parameters.file)
+        self.logger.debug("Opening %r file.", self.parameters.file)
         self.file = io.open(self.parameters.file, mode='at', encoding="utf-8")
-        self.logger.info("File %r is open." % self.parameters.file)
+        self.logger.info("File %r is open.", self.parameters.file)
 
     def process(self):
         event = self.receive_message()

--- a/intelmq/bots/outputs/mongodb/output.py
+++ b/intelmq/bots/outputs/mongodb/output.py
@@ -30,7 +30,8 @@ class MongoDBOutputBot(Bot):
         else:
             db = self.client[self.parameters.database]
             if hasattr(self.parameters, 'db_user') and hasattr(self.parameters, 'db_pass'):
-                self.logger.debug('Trying to authenticate to database {}.'.format(self.parameters.database))
+                self.logger.debug('Trying to authenticate to database %s.',
+                                  self.parameters.database)
                 try:
                     db.authenticate(name=self.parameters.db_user,
                                     password=self.parameters.db_pass)

--- a/intelmq/bots/outputs/postgresql/output.py
+++ b/intelmq/bots/outputs/postgresql/output.py
@@ -57,7 +57,7 @@ class PostgreSQLOutputBot(Bot):
         query = ('INSERT INTO {table} ("{keys}") VALUES ({values})'
                  ''.format(table=self.table, keys=keys, values=fvalues[:-2]))
 
-        self.logger.debug('Query: {!r} with values {!r}.'.format(query, values))
+        self.logger.debug('Query: %r with values %r.', query, values)
         try:
             # note: this assumes, the DB was created with UTF-8 support!
             self.cur.execute(query, values)

--- a/intelmq/bots/outputs/redis/output.py
+++ b/intelmq/bots/outputs/redis/output.py
@@ -34,10 +34,11 @@ class RedisOutputBot(Bot):
             self.output = redis.StrictRedis(connection_pool=self.conn, socket_timeout=self.timeout, password=self.password)
             info = self.output.info()
         except redis.ConnectionError:
-            self.logger.exception("Redis connection to {}:{} failed!!".format(self.host, self.port))
+            self.logger.exception("Redis connection to %s:%s failed!", self.host, self.port)
             self.stop()
         else:
-            self.logger.info("Connected successfully to Redis {} at {}:{}!".format(info['redis_version'], self.host, self.port))
+            self.logger.info("Connected successfully to Redis %s at %s:%s!",
+                             info['redis_version'], self.host, self.port)
 
 
 BOT = RedisOutputBot

--- a/intelmq/bots/outputs/tcp/output.py
+++ b/intelmq/bots/outputs/tcp/output.py
@@ -18,8 +18,8 @@ class TCPOutputBot(Bot):
         data = event.to_json(hierarchical=self.parameters.hierarchical_output)
         try:
             self.con.sendall(utils.encode(data) + self.separator)
-        except socket.error as exc:
-            self.logger.exception(exc.args[1] + ". Reconnecting..")
+        except socket.error:
+            self.logger.exception("Reconnecting.")
             self.con.close()
             self.connect()
         except AttributeError:
@@ -35,8 +35,8 @@ class TCPOutputBot(Bot):
         except:
             raise
         else:
-            self.logger.info("Connected successfully to {!s}: {}"
-                             "".format(self.address[0], self.address[1]))
+            self.logger.info("Connected successfully to %s:%s.",
+                             self.address[0], self.address[1])
 
 
 BOT = TCPOutputBot

--- a/intelmq/bots/outputs/udp/output.py
+++ b/intelmq/bots/outputs/udp/output.py
@@ -17,7 +17,7 @@ class UDPBot(Bot):
         self.keep_raw_field = bool(self.parameters.keep_raw_field)
         self.format = self.parameters.format.lower()
         if self.format not in ['json', 'delimited']:
-            self.logger.error('Unknown format %r given. Check your configuration.' % self.format)
+            self.logger.error('Unknown format %r given. Check your configuration.', self.format)
             self.stop()
 
     def process(self):
@@ -46,8 +46,8 @@ class UDPBot(Bot):
         try:
             self.udp.sendto(data, self.upd_address)
         except:
-            self.logger.exception('Failled to sent message to {}:{} !'
-                                  .format(self.udp_host, self.udp_port))
+            self.logger.exception('Failed to send message to %s:%s!',
+                                  self.udp_host, self.udp_port)
         else:
             self.acknowledge_message()
 

--- a/intelmq/bots/outputs/xmpp/output.py
+++ b/intelmq/bots/outputs/xmpp/output.py
@@ -63,10 +63,8 @@ try:
                 self.logger.error('Server is taking too long to respond.')
                 self.disconnect()
 
-            self.logger.debug('Room:' + self.xmpp_room)
-
             if self.xmpp_room:  # and self.plugin.get('xep_0045') # this check should also exist!
-                self.logger.debug("Joining room: %s." % self.xmpp_room)
+                self.logger.debug("Joining room: %s.", self.xmpp_room)
                 pwd = self.xmpp_room_password if self.xmpp_room_password else ""
                 self.plugin['xep_0045'].joinMUC(self.xmpp_room,
                                                 self.xmpp_room_nick,
@@ -92,7 +90,7 @@ class XMPPOutputBot(Bot):
         xmpp_password = getattr(self.parameters, "xmpp_password", None)
 
         if None in (xmpp_user, xmpp_server, xmpp_password):
-            self.logger.error('No User / Password provided')
+            self.logger.error('No User / Password provided.')
             self.stop()
         else:
             xmpp_login = xmpp_user + '@' + xmpp_server
@@ -108,14 +106,14 @@ class XMPPOutputBot(Bot):
 
         # Be sure the receiver was set up
         if not self.muc and None in (xmpp_to_user, xmpp_to_server):
-            self.logger.error('No receiver for direct messages provided')
+            self.logger.error('No receiver for direct messages provided.')
             self.stop()
         else:
             self.xmpp_receiver = xmpp_to_user + '@' +\
                 xmpp_to_server
 
         if self.muc and not xmpp_room:
-            self.logger.error('No room provided')
+            self.logger.error('No room provided.')
             self.stop()
         else:
             self.xmpp_receiver = xmpp_room
@@ -154,10 +152,10 @@ class XMPPOutputBot(Bot):
             # TODO: proper error handling.
             # Right now it cannot be detected if the message was sent successfully.
             if self.muc:
-                self.logger.debug("Trying to send to room %s." % self.xmpp_receiver)
+                self.logger.debug("Trying to send to room %s.", self.xmpp_receiver)
                 self.xmpp.send_message(mto=self.xmpp_receiver, mbody=jevent, mtype='groupchat')
             else:
-                self.logger.debug("Trying to send to %s." % (self.xmpp_receiver))
+                self.logger.debug("Trying to send to %s.", self.xmpp_receiver)
                 self.xmpp.send_message(mto=self.xmpp_receiver, mbody=jevent)
         except sleekxmpp.exceptions.XMPPError as err:
             self.logger.error('There was an error when sending the event.')

--- a/intelmq/bots/parsers/cleanmx/parser.py
+++ b/intelmq/bots/parsers/cleanmx/parser.py
@@ -81,7 +81,7 @@ class CleanMXParserBot(ParserBot):
 
             if key is None:
                 self.logger.warning('Value without key found, skipping the'
-                                    ' value: {!r}'.format(value))
+                                    ' value: %r', value)
                 continue
 
             key_orig = key

--- a/intelmq/bots/parsers/n6/parser_n6stomp.py
+++ b/intelmq/bots/parsers/n6/parser_n6stomp.py
@@ -69,7 +69,7 @@ class N6StompParserBot(Bot):
         report = self.receive_message()
 
         peek = utils.base64_decode(report.get("raw"))
-        self.logger.debug("Peeking at event '%s'." % peek)
+        self.logger.debug("Peeking at event %r.", peek)
         if "TEST MESSAGE" in peek:
             self.logger.debug("Ignoring test message/event.")
             self.acknowledge_message()

--- a/intelmq/bots/parsers/shadowserver/parser.py
+++ b/intelmq/bots/parsers/shadowserver/parser.py
@@ -91,8 +91,8 @@ class ShadowserverParserBot(ParserBot):
         for item in conf.get('required_fields'):
             intelmqkey, shadowkey = item[:2]
             if shadowkey not in fields:  # key does not exist in data (not even in the header)
-                self.logger.warning('Required key {!r} not found data. Possible change in data'
-                                    ' format or misconfiguration.'.format(shadowkey))
+                self.logger.warning('Required key %r not found data. Possible change in data'
+                                    ' format or misconfiguration.', shadowkey)
             if len(item) > 2:
                 conv_func = item[2]
             else:
@@ -118,8 +118,8 @@ class ShadowserverParserBot(ParserBot):
         for item in conf.get('optional_fields'):
             intelmqkey, shadowkey = item[:2]
             if shadowkey not in fields:  # key does not exist in data (not even in the header)
-                self.logger.warning('Optional key {!r} not found data. Possible change in data'
-                                    ' format or misconfiguration.'.format(shadowkey))
+                self.logger.warning('Optional key %r not found data. Possible change in data'
+                                    ' format or misconfiguration.', shadowkey)
                 continue
             if len(item) > 2:
                 conv_func = item[2]
@@ -135,8 +135,9 @@ class ShadowserverParserBot(ParserBot):
                     try:
                         value = conv_func(raw_value)
                     except:
-                        self.logger.error('Could not convert shadowkey: "{}", ' +
-                                          'value: "{}" via conversion function {}.'.format(shadowkey, raw_value, repr(conv_func)))
+                        self.logger.error('Could not convert shadowkey: %r, '
+                                          'value: %r via conversion function %r.',
+                                          shadowkey, raw_value, conv_func)
                         value = None
                         # """ fail early and often in this case. We want to be able to convert everything """
                         # self.stop()
@@ -150,10 +151,7 @@ class ShadowserverParserBot(ParserBot):
                     event.add(intelmqkey, value)
                     fields.remove(shadowkey)
                 except InvalidValue:
-                    self.logger.debug(
-                        'Could not add key {!r};'
-                        ' adding it to extras.'.format(shadowkey)
-                    )
+                    self.logger.debug('Could not add key %r adding it to extras.', shadowkey)
                 except InvalidKey:
                     extra[intelmqkey] = value
                     fields.remove(shadowkey)

--- a/intelmq/lib/bot.py
+++ b/intelmq/lib/bot.py
@@ -127,7 +127,7 @@ class Bot(object):
         while True:
             try:
                 if not starting and (error_on_pipeline or error_on_message):
-                    self.logger.info('Bot will continue in %s seconds.' %
+                    self.logger.info('Bot will continue in %s seconds.',
                                      self.parameters.error_retry_delay)
                     time.sleep(self.parameters.error_retry_delay)
 
@@ -177,8 +177,8 @@ class Bot(object):
 
                 if self.parameters.error_log_message:
                     # Dump full message if explicitly requested by config
-                    self.logger.info("Current Message(event): {!r}."
-                                     "".format(self.__current_message))
+                    self.logger.info("Current Message(event): %r.",
+                                     self.__current_message)
 
                 # In case of permanent failures, stop now
                 if isinstance(exc, exceptions.ConfigurationError):
@@ -288,15 +288,15 @@ class Bot(object):
             self.stop()
 
     def __connect_pipelines(self):
-        self.logger.debug("Loading source pipeline and queue %r." % self.__source_queues)
+        self.logger.debug("Loading source pipeline and queue %r.", self.__source_queues)
         self.__source_pipeline = PipelineFactory.create(self.parameters)
         self.__source_pipeline.set_queues(self.__source_queues, "source")
         self.__source_pipeline.connect()
         self.logger.debug("Connected to source queue.")
 
         if self.__destination_queues:
-            self.logger.debug("Loading destination pipeline and queues %r."
-                              "" % self.__destination_queues)
+            self.logger.debug("Loading destination pipeline and queues %r.",
+                              self.__destination_queues)
             self.__destination_pipeline = PipelineFactory.create(self.parameters)
             self.__destination_pipeline.set_queues(self.__destination_queues,
                                                    "destination")
@@ -331,7 +331,7 @@ class Bot(object):
             self.logger.debug("Sending message.")
             self.__message_counter += 1
             if self.__message_counter % 500 == 0:
-                self.logger.info("Processed %s messages." % self.__message_counter)
+                self.logger.info("Processed %s messages.", self.__message_counter)
 
             raw_message = libmessage.MessageFactory.serialize(message)
             self.__destination_pipeline.send(raw_message)
@@ -361,7 +361,7 @@ class Bot(object):
             tmp_msg['raw'] = tmp_msg['raw'][:397] + '...'
         else:
             tmp_msg = self.__current_message
-        self.logger.debug('Received message {!r}.'.format(tmp_msg))
+        self.logger.debug('Received message %r.', tmp_msg)
 
         return self.__current_message
 
@@ -423,7 +423,7 @@ class Bot(object):
                 self.__log_configuration_parameter("system", option, value)
 
     def __load_runtime_configuration(self):
-        self.logger.debug("Loading runtime configuration from %r." % RUNTIME_CONF_FILE)
+        self.logger.debug("Loading runtime configuration from %r.", RUNTIME_CONF_FILE)
         config = utils.load_configuration(RUNTIME_CONF_FILE)
 
         if self.__bot_id in list(config.keys()):
@@ -438,7 +438,7 @@ class Bot(object):
                 self.__log_configuration_parameter("runtime", option, value)
 
     def __load_pipeline_configuration(self):
-        self.logger.debug("Loading pipeline configuration from %r." % PIPELINE_CONF_FILE)
+        self.logger.debug("Loading pipeline configuration from %r.", PIPELINE_CONF_FILE)
         config = utils.load_configuration(PIPELINE_CONF_FILE)
 
         self.__source_queues = None
@@ -471,7 +471,7 @@ class Bot(object):
             self.__log_buffer.append(("debug", message))
 
     def __load_harmonization_configuration(self):
-        self.logger.debug("Loading Harmonization configuration from %r." % HARMONIZATION_CONF_FILE)
+        self.logger.debug("Loading Harmonization configuration from %r.", HARMONIZATION_CONF_FILE)
         self.harmonization = utils.load_configuration(HARMONIZATION_CONF_FILE)
 
     def new_event(self, *args, **kwargs):
@@ -508,9 +508,9 @@ class Bot(object):
             self.proxy = {'http': self.parameters.http_proxy,
                           'https': self.parameters.https_proxy}
         elif self.parameters.http_proxy or self.parameters.https_proxy:
-            self.logger.warning('Only {}_proxy seems to be set.'
-                                'Both http and https proxies must be set.'
-                                .format('http' if self.parameters.http_proxy else 'https'))
+            self.logger.warning('Only %s_proxy seems to be set.'
+                                'Both http and https proxies must be set.',
+                                'http' if self.parameters.http_proxy else 'https')
             self.proxy = None
         else:
             self.proxy = None


### PR DESCRIPTION
pylint warnings 1201 and 1202:

```
> pylint --help-msg W1201
No config file found, using default configuration
:logging-not-lazy (W1201): *Specify string format arguments as logging function parameters*
  Used when a logging statement has a call form of "logging.<logging
  method>(format_string % (format_args...))". Such calls should leave string
  interpolation to the logging method itself and be written "logging.<logging
  method>(format_string, format_args...)" so that the program may avoid
  incurring the cost of the interpolation in those cases in which no message
  will be logged. For more, see http://www.python.org/dev/peps/pep-0282/. This
  message belongs to the logging checker.

> pylint --help-msg W1202
No config file found, using default configuration
:logging-format-interpolation (W1202): *Use % formatting in logging functions but pass the % parameters as arguments*
  Used when a logging statement has a call form of "logging.<logging
  method>(format_string.format(format_args...))". Such calls should use %
  formatting instead, but leave interpolation to the logging function by passing
  the parameters as arguments. This message belongs to the logging checker.
```

See also https://www.simonmweber.com/2014/11/24/python-logging-traps.html
https://bitbucket.org/logilab/pylint/src/467e659fd2eb3dcd96f608b2765b9d6e623d4880/pylint/checkers/logging.py?at=default&fileviewer=file-view-default#logging.py-29