### PR TITLE
Bot debugging

### DIFF
--- a/docs/intelmqctl.md
+++ b/docs/intelmqctl.md
@@ -126,7 +126,7 @@ Run a bot directly for debugging purpose. Command temporarily leverages the logg
 If launched with no arguments, the bot will call its init method and start processing messages as usual – but you see everything happens.
 
 ```bash
-> intelmqctl run file-output 
+> intelmqctl run file-output
 file-output: RestAPIOutputBot initialized with id file-output and version 3.5.2 as process 12345.
 file-output: Bot is starting.
 file-output: Loading source pipeline and queue 'file-output-queue'.
@@ -140,12 +140,12 @@ Should you get lost any time, just use the **--help** after any argument for fur
 
 ```bash
 > intelmqctl run file-output --help
-```        
+```
 
 Note that if another instance of the bot is running, only warning will be displayed.
 
 ```bash
-> intelmqctl run file-output 
+> intelmqctl run file-output
 intelmqctl: Main instance of the bot is running in the background. You may want to launch: intelmqctl stop file-output
 ```
 
@@ -168,7 +168,7 @@ You may specify the desired console in the next argument.
 
 #### message
 
-Operate directly with the input / output pipelines. 
+Operate directly with the input / output pipelines.
 
 If **get** is the parameter, you see the message that waits in the input (source or internal) queue. If the argument is **pop**, the message gets popped as well.
 
@@ -176,8 +176,8 @@ If **get** is the parameter, you see the message that waits in the input (source
 > intelmqctl run file-output message get
 file-output: Waiting for a message to get...
 {
-    "classification.type": "c&c",    
-    "feed.url": "https://example.com",    
+    "classification.type": "c&c",
+    "feed.url": "https://example.com",
     "raw": "1233",
     "source.ip": "1.2.3.4",
     "time.observation": "2017-05-17T22:00:33+00:00",
@@ -185,7 +185,7 @@ file-output: Waiting for a message to get...
 }
 ```
 
-To send directly to the bot's ouput queue, just as it was sent by ```self.send_message()``` in bot's ```process()``` method, use the **send** argument.  
+To send directly to the bot's ouput queue, just as it was sent by ```self.send_message()``` in bot's ```process()``` method, use the **send** argument.
 In our case of ```file-output```, it has no destionation queue so that nothing happens.
 
 ```bash
@@ -276,8 +276,8 @@ intelmqctl: Starting abusech-domain-parser...
 intelmqctl: abusech-domain-parser is running.
 intelmqctl: Starting abusech-feodo-domains-collector...
 intelmqctl: abusech-feodo-domains-collector is running.
-intelmqctl: Starting file-output...
-intelmqctl: file-output is running.
+intelmqctl: Starting deduplicator-expert...
+intelmqctl: deduplicator-expert is running.
 intelmqctl: file-output is disabled.
 intelmqctl: Botnet is running.
 ```
@@ -288,8 +288,8 @@ intelmqctl: Stopping abusech-domain-parser...
 intelmqctl: abusech-domain-parser is stopped.
 intelmqctl: Stopping abusech-feodo-domains-collector...
 intelmqctl: abusech-feodo-domains-collector is stopped.
-intelmqctl: Stopping file-output...
-intelmqctl: file-output is stopped.
+intelmqctl: Stopping deduplicator-expert...
+intelmqctl: deduplicator-expert is stopped.
 intelmqctl: Stopping file-output...
 intelmqctl: file-output is stopped.
 intelmqctl: Botnet is stopped.
@@ -305,8 +305,8 @@ intelmqctl: Stopping abusech-domain-parser...
 intelmqctl: abusech-domain-parser is stopped.
 intelmqctl: Stopping abusech-feodo-domains-collector...
 intelmqctl: abusech-feodo-domains-collector is stopped.
-intelmqctl: Stopping file-output...
-intelmqctl: file-output is stopped.
+intelmqctl: Stopping deduplicator-expert...
+intelmqctl: deduplicator-expert is stopped.
 intelmqctl: Stopping file-output...
 intelmqctl: file-output is stopped.
 intelmqctl: Botnet is stopped.
@@ -319,7 +319,7 @@ With this command we can see the status of all configured bots. Here, the botnet
 > intelmqctl status
 intelmqctl: abusech-domain-parser is running.
 intelmqctl: abusech-feodo-domains-collector is running.
-intelmqctl: file-output is running.
+intelmqctl: deduplicator-expert is running.
 intelmqctl: file-output is disabled.
 ```
 And if the disabled bot has also been started:
@@ -327,7 +327,7 @@ And if the disabled bot has also been started:
 > intelmqctl status
 intelmqctl: abusech-domain-parser is running.
 intelmqctl: abusech-feodo-domains-collector is running.
-intelmqctl: file-output is running.
+intelmqctl: deduplicator-expert is running.
 intelmqctl: file-output is running.
 ```
 
@@ -336,7 +336,7 @@ If the botnet is stopped, the output looks like this:
 > intelmqctl status
 intelmqctl: abusech-domain-parser is stopped.
 intelmqctl: abusech-feodo-domains-collector is stopped.
-intelmqctl: file-output is stopped.
+intelmqctl: deduplicator-expert is stopped.
 intelmqctl: file-output is disabled.
 ```
 
@@ -376,8 +376,8 @@ intelmqctl: malware-domain-list-parser is stopped.
 > intelmqctl list queues
 intelmqctl: abusech-domain-parser-queue - 0
 intelmqctl: abusech-domain-parser-queue-internal - 0
-intelmqctl: file-output-queue - 0
-intelmqctl: file-output-queue-internal - 0
+intelmqctl: deduplicator-expert-queue - 0
+intelmqctl: deduplicator-expert-queue-internal - 0
 intelmqctl: file-output-queue - 234
 intelmqctl: file-output-queue-internal - 0
 ```

--- a/intelmq/bin/intelmqctl.py
+++ b/intelmq/bin/intelmqctl.py
@@ -901,5 +901,6 @@ def main():  # pragma: no cover
     x = IntelMQController(interactive=True)
     return x.run()
 
+
 if __name__ == "__main__":  # pragma: no cover
     exit(main())

--- a/intelmq/bin/intelmqctl.py
+++ b/intelmq/bin/intelmqctl.py
@@ -132,7 +132,7 @@ class IntelMQProcessManager:
             fp.write(str(os.getpid()))
 
         try:
-            BotDebugger(self.__runtime_configuration[bot_id]['module'], bot_id, run_subcommand, console_type, dryrun, message_action_kind, msg)
+            BotDebugger(self.__runtime_configuration[bot_id], bot_id, run_subcommand, console_type, dryrun, message_action_kind, msg)
             retval = 0
         except KeyboardInterrupt:
             print('Keyboard interrupt.')
@@ -444,13 +444,16 @@ Outputs are additionally logged to /opt/intelmq/var/log/intelmqctl'''
             parser_run.add_argument('bot_id',
                                     choices=self.runtime_configuration.keys())
             parser_run_subparsers = parser_run.add_subparsers(title='run-subcommands')
+
             parser_run_console = parser_run_subparsers.add_parser('console', help='Get a ipdb live console.')
             parser_run_console.add_argument('console_type', nargs='?', help='You may specify which console should be run. Default is ipdb (if installed) or pudb (if installed) or pdb but you may want to use another one.')
             parser_run_console.set_defaults(run_subcommand="console")
+
             parser_run_message = parser_run_subparsers.add_parser('message', help='Debug bot\'s pipelines. Get the message in the input pipeline, pop it (cut it) and display it, or send the message directly to bot\'s output pipeline.')
             parser_run_message.add_argument('message_action_kind', choices = ["get","pop","send"])
             parser_run_message.add_argument('msg', nargs='?', help='If send was chosen, put here the message in JSON.')
             parser_run_message.set_defaults(run_subcommand="message")
+
             parser_run_process = parser_run_subparsers.add_parser('process', help='Single run of bot\'s process() method.')
             parser_run_process.add_argument('--dryrun', '-d', action='store_true',
                                             help='Never really pop the message from the input pipeline '

--- a/intelmq/bin/intelmqctl.py
+++ b/intelmq/bin/intelmqctl.py
@@ -118,7 +118,7 @@ class IntelMQProcessManager:
                 self.logger.error('Directory %s does not exist and cannot be '
                                   'created: %s.', self.PIDDIR, exc)
 
-    def bot_run(self, bot_id, run_subcommand=None, message_action_kind=None, dryrun=None, msg=None):
+    def bot_run(self, bot_id, run_subcommand=None, console_type=None, message_action_kind=None, dryrun=None, msg=None):
         pid = self.__read_pidfile(bot_id)
         if pid and self.__status_process(pid):
             paused = True
@@ -132,7 +132,7 @@ class IntelMQProcessManager:
             fp.write(str(os.getpid()))
 
         try:
-            BotDebugger(self.__runtime_configuration[bot_id]['module'], bot_id, run_subcommand, message_action_kind, dryrun, msg)
+            BotDebugger(self.__runtime_configuration[bot_id]['module'], bot_id, run_subcommand, console_type, dryrun, message_action_kind, msg)
             retval = 0
         except KeyboardInterrupt:
             print('Keyboard interrupt.')
@@ -309,8 +309,9 @@ class IntelMQController():
         intelmqctl [start|stop|restart|status|reload]
         intelmqctl list [bots|queues]
         intelmqctl log bot-id [number-of-lines [log-level]]
-        intelmqctl run bot-id message [get|pop|send --msg]
+        intelmqctl run bot-id message [get|pop|send]
         intelmqctl run bot-id process [--msg|--dryrun]
+        intelmqctl run bot-id console
         intelmqctl clear queue-id
         intelmqctl check
 
@@ -325,6 +326,8 @@ Get status of a bot:
 
 Run a bot directly for debugging purpose and temporarily leverage the logging level to DEBUG:
     intelmqctl run bot-id
+Get a pdb (or ipdb if installed) live console.
+    intelmqctl run bot-id console
 See the message that waits in the input queue.
     intelmqctl run bot-id message get
 See additional help for further explanation.
@@ -441,8 +444,11 @@ Outputs are additionally logged to /opt/intelmq/var/log/intelmqctl'''
             parser_run.add_argument('bot_id',
                                     choices=self.runtime_configuration.keys())
             parser_run_subparsers = parser_run.add_subparsers(title='run-subcommands')
+            parser_run_console = parser_run_subparsers.add_parser('console', help='Get a ipdb live console.')
+            parser_run_console.add_argument('console_type', nargs='?', help='You may specify which console should be run. Default is ipdb (if installed) or pudb (if installed) or pdb but you may want to use another one.')
+            parser_run_console.set_defaults(run_subcommand="console")
             parser_run_message = parser_run_subparsers.add_parser('message', help='Debug bot\'s pipelines. Get the message in the input pipeline, pop it (cut it) and display it, or send the message directly to bot\'s output pipeline.')
-            parser_run_message.add_argument('message_action_kind', choices=["get", "pop", "send"])
+            parser_run_message.add_argument('message_action_kind', choices = ["get","pop","send"])
             parser_run_message.add_argument('msg', nargs='?', help='If send was chosen, put here the message in JSON.')
             parser_run_message.set_defaults(run_subcommand="message")
             parser_run_process = parser_run_subparsers.add_parser('process', help='Single run of bot\'s process() method.')
@@ -537,8 +543,8 @@ Outputs are additionally logged to /opt/intelmq/var/log/intelmqctl'''
         elif results == 'error':
             return 1
 
-    def bot_run(self, bot_id, run_subcommand=None, message_action_kind=None, dryrun=None, msg=None):
-        return self.bot_process_manager.bot_run(bot_id, run_subcommand, message_action_kind, dryrun, msg)
+    def bot_run(self, **kwargs): #bot_id, run_subcommand=None, console_type=None, dryrun=None, message_action_kind=None, msg=None
+        return self.bot_process_manager.bot_run(**kwargs) #bot_id, run_subcommand, console_type, message_action_kind, dryrun, msg
 
     def bot_start(self, bot_id, getstatus=True):
         if bot_id is None:

--- a/intelmq/bin/intelmqctl.py
+++ b/intelmq/bin/intelmqctl.py
@@ -122,7 +122,7 @@ class IntelMQProcessManager:
         pid = self.__read_pidfile(bot_id)
         if pid and self.__status_process(pid):
             self.logger.warning("Main instance of the bot is running in the background and will be stopped; "
-                                "when finished, we try to relaunch it again."
+                                "when finished, we try to relaunch it again. "
                                 "You may want to launch: 'intelmqctl stop {}' to prevent this message."
                                 .format(bot_id))
             paused = True
@@ -130,10 +130,10 @@ class IntelMQProcessManager:
         else:
             paused = False
 
-        # log_bot_message('starting', bot_id)
-        # filename = self.PIDFILE.format(bot_id)
-        # with open(filename, 'w') as fp:
-        #    fp.write(str(os.getpid()))
+        log_bot_message('starting', bot_id)
+        filename = self.PIDFILE.format(bot_id)
+        with open(filename, 'w') as fp:
+           fp.write(str(os.getpid()))
 
         try:
             BotDebugger(self.__runtime_configuration[bot_id], bot_id, run_subcommand,
@@ -146,7 +146,7 @@ class IntelMQProcessManager:
             print('Bot exited with code %s.' % exc)
             retval = exc
 
-        # self.__remove_pidfile(bot_id)
+        self.__remove_pidfile(bot_id)
         if paused:
             self.bot_start(bot_id)
         return retval

--- a/intelmq/bin/intelmqctl.py
+++ b/intelmq/bin/intelmqctl.py
@@ -440,10 +440,10 @@ Outputs are additionally logged to /opt/intelmq/var/log/intelmqctl'''
             parser_run = subparsers.add_parser('run', help='Run a bot interactively')
             parser_run.add_argument('bot_id',
                                     choices=self.runtime_configuration.keys())
-            parser_run_subparsers = parser_run.add_subparsers(title='run-subcommands')            
+            parser_run_subparsers = parser_run.add_subparsers(title='run-subcommands')
             parser_run_message = parser_run_subparsers.add_parser('message', help='Debug bot\'s pipelines. Get the message in the input pipeline, pop it (cut it) and display it, or send the message directly to bot\'s output pipeline.')
-            parser_run_message.add_argument('message_action_kind', choices = ["get","pop","send"])
-            parser_run_message.add_argument('msg', nargs = '?', help='If send was chosen, put here the message in JSON.')
+            parser_run_message.add_argument('message_action_kind', choices=["get", "pop", "send"])
+            parser_run_message.add_argument('msg', nargs='?', help='If send was chosen, put here the message in JSON.')
             parser_run_message.set_defaults(run_subcommand="message")
             parser_run_process = parser_run_subparsers.add_parser('process', help='Single run of bot\'s process() method.')
             parser_run_process.add_argument('--dryrun', '-d', action='store_true',

--- a/intelmq/bin/intelmqctl.py
+++ b/intelmq/bin/intelmqctl.py
@@ -121,7 +121,8 @@ class IntelMQProcessManager:
     def bot_run(self, bot_id, run_subcommand=None, console_type=None, message_action_kind=None, dryrun=None, msg=None):
         pid = self.__read_pidfile(bot_id)
         if pid and self.__status_process(pid):
-            self.logger.warning("Main instance of the bot is running in the background. You may want to launch: intelmqctl stop {}".format(bot_id))
+            self.logger.warning("Main instance of the bot is running in the background. You may want to launch: intelmqctl stop {}"
+                                .format(bot_id))
         #    paused = True
         #    self.bot_stop(bot_id)
         # else:
@@ -133,7 +134,8 @@ class IntelMQProcessManager:
         #    fp.write(str(os.getpid()))
 
         try:
-            BotDebugger(self.__runtime_configuration[bot_id], bot_id, run_subcommand, console_type, dryrun, message_action_kind, msg)
+            BotDebugger(self.__runtime_configuration[bot_id], bot_id, run_subcommand,
+                        console_type, dryrun, message_action_kind, msg)
             retval = 0
         except KeyboardInterrupt:
             print('Keyboard interrupt.')
@@ -447,12 +449,15 @@ Outputs are additionally logged to /opt/intelmq/var/log/intelmqctl'''
             parser_run_subparsers = parser_run.add_subparsers(title='run-subcommands')
 
             parser_run_console = parser_run_subparsers.add_parser('console', help='Get a ipdb live console.')
-            parser_run_console.add_argument('console_type', nargs='?', help='You may specify which console should be run. Default is ipdb (if installed)'
-                                                                            ' or pudb (if installed) or pdb but you may want to use another one.')
+            parser_run_console.add_argument('console_type', nargs='?',
+                                            help='You may specify which console should be run. Default is ipdb (if installed)'
+                                            ' or pudb (if installed) or pdb but you may want to use another one.')
             parser_run_console.set_defaults(run_subcommand="console")
 
-            parser_run_message = parser_run_subparsers.add_parser('message', help='Debug bot\'s pipelines. Get the message in the input pipeline, pop it (cut it)'
-                                                                                  ' and display it, or send the message directly to bot\'s output pipeline.')
+            parser_run_message = parser_run_subparsers.add_parser('message',
+                                                                  help='Debug bot\'s pipelines. Get the message in the'
+                                                                  ' input pipeline, pop it (cut it) and display it, or'
+                                                                  ' send the message directly to bot\'s output pipeline.')
             parser_run_message.add_argument('message_action_kind', choices=["get", "pop", "send"])
             parser_run_message.add_argument('msg', nargs='?', help='If send was chosen, put here the message in JSON.')
             parser_run_message.set_defaults(run_subcommand="message")

--- a/intelmq/bin/intelmqctl.py
+++ b/intelmq/bin/intelmqctl.py
@@ -121,12 +121,14 @@ class IntelMQProcessManager:
     def bot_run(self, bot_id, run_subcommand=None, console_type=None, message_action_kind=None, dryrun=None, msg=None):
         pid = self.__read_pidfile(bot_id)
         if pid and self.__status_process(pid):
-            self.logger.warning("Main instance of the bot is running in the background. You may want to launch: intelmqctl stop {}"
+            self.logger.warning("Main instance of the bot is running in the background and will be stopped; "
+                                "when finished, we try to relaunch it again."
+                                "You may want to launch: 'intelmqctl stop {}' to prevent this message."
                                 .format(bot_id))
-        #    paused = True
-        #    self.bot_stop(bot_id)
-        # else:
-        #    paused = False
+            paused = True
+            self.bot_stop(bot_id)
+        else:
+            paused = False
 
         # log_bot_message('starting', bot_id)
         # filename = self.PIDFILE.format(bot_id)
@@ -145,8 +147,8 @@ class IntelMQProcessManager:
             retval = exc
 
         # self.__remove_pidfile(bot_id)
-        # if paused:
-        #    self.bot_start(bot_id)
+        if paused:
+            self.bot_start(bot_id)
         return retval
 
     def bot_start(self, bot_id, getstatus=True):

--- a/intelmq/bin/intelmqctl.py
+++ b/intelmq/bin/intelmqctl.py
@@ -121,15 +121,16 @@ class IntelMQProcessManager:
     def bot_run(self, bot_id, run_subcommand=None, console_type=None, message_action_kind=None, dryrun=None, msg=None):
         pid = self.__read_pidfile(bot_id)
         if pid and self.__status_process(pid):
-            paused = True
-            self.bot_stop(bot_id)
-        else:
-            paused = False
+            self.logger.warning("Main instance of the bot is running in the background. You may want to launch: intelmqctl stop {}".format(bot_id))
+        #    paused = True
+        #    self.bot_stop(bot_id)
+        # else:
+        #    paused = False
 
-        log_bot_message('starting', bot_id)
-        filename = self.PIDFILE.format(bot_id)
-        with open(filename, 'w') as fp:
-            fp.write(str(os.getpid()))
+        # log_bot_message('starting', bot_id)
+        # filename = self.PIDFILE.format(bot_id)
+        # with open(filename, 'w') as fp:
+        #    fp.write(str(os.getpid()))
 
         try:
             BotDebugger(self.__runtime_configuration[bot_id], bot_id, run_subcommand, console_type, dryrun, message_action_kind, msg)
@@ -141,9 +142,9 @@ class IntelMQProcessManager:
             print('Bot exited with code %s.' % exc)
             retval = exc
 
-        self.__remove_pidfile(bot_id)
-        if paused:
-            self.bot_start(bot_id)
+        # self.__remove_pidfile(bot_id)
+        # if paused:
+        #    self.bot_start(bot_id)
         return retval
 
     def bot_start(self, bot_id, getstatus=True):
@@ -446,11 +447,13 @@ Outputs are additionally logged to /opt/intelmq/var/log/intelmqctl'''
             parser_run_subparsers = parser_run.add_subparsers(title='run-subcommands')
 
             parser_run_console = parser_run_subparsers.add_parser('console', help='Get a ipdb live console.')
-            parser_run_console.add_argument('console_type', nargs='?', help='You may specify which console should be run. Default is ipdb (if installed) or pudb (if installed) or pdb but you may want to use another one.')
+            parser_run_console.add_argument('console_type', nargs='?', help='You may specify which console should be run. Default is ipdb (if installed)'
+                                                                            ' or pudb (if installed) or pdb but you may want to use another one.')
             parser_run_console.set_defaults(run_subcommand="console")
 
-            parser_run_message = parser_run_subparsers.add_parser('message', help='Debug bot\'s pipelines. Get the message in the input pipeline, pop it (cut it) and display it, or send the message directly to bot\'s output pipeline.')
-            parser_run_message.add_argument('message_action_kind', choices = ["get","pop","send"])
+            parser_run_message = parser_run_subparsers.add_parser('message', help='Debug bot\'s pipelines. Get the message in the input pipeline, pop it (cut it)'
+                                                                                  ' and display it, or send the message directly to bot\'s output pipeline.')
+            parser_run_message.add_argument('message_action_kind', choices=["get", "pop", "send"])
             parser_run_message.add_argument('msg', nargs='?', help='If send was chosen, put here the message in JSON.')
             parser_run_message.set_defaults(run_subcommand="message")
 
@@ -546,8 +549,8 @@ Outputs are additionally logged to /opt/intelmq/var/log/intelmqctl'''
         elif results == 'error':
             return 1
 
-    def bot_run(self, **kwargs): #bot_id, run_subcommand=None, console_type=None, dryrun=None, message_action_kind=None, msg=None
-        return self.bot_process_manager.bot_run(**kwargs) #bot_id, run_subcommand, console_type, message_action_kind, dryrun, msg
+    def bot_run(self, **kwargs):
+        return self.bot_process_manager.bot_run(**kwargs)
 
     def bot_start(self, bot_id, getstatus=True):
         if bot_id is None:

--- a/intelmq/bin/intelmqctl.py
+++ b/intelmq/bin/intelmqctl.py
@@ -15,6 +15,7 @@ from intelmq import (DEFAULTS_CONF_FILE, PIPELINE_CONF_FILE, RUNTIME_CONF_FILE,
                      STARTUP_CONF_FILE, SYSTEM_CONF_FILE, VAR_RUN_PATH,
                      BOTS_FILE)
 from intelmq.lib import utils
+from intelmq.lib.bot_debugger import BotDebugger
 from intelmq.lib.pipeline import PipelineFactory
 
 
@@ -117,33 +118,32 @@ class IntelMQProcessManager:
                 self.logger.error('Directory %s does not exist and cannot be '
                                   'created: %s.', self.PIDDIR, exc)
 
-    def bot_run(self, bot_id):
+    def bot_run(self, bot_id, run_subcommand=None, message_action_kind=None, dryrun=None, msg=None):
         pid = self.__read_pidfile(bot_id)
-        if pid:
-            if self.__status_process(pid):
-                log_bot_error('running', bot_id)
-                return 'running'
-            else:
-                self.__remove_pidfile(bot_id)
+        if pid and self.__status_process(pid):
+            paused = True
+            self.bot_stop(bot_id)
+        else:
+            paused = False
+
         log_bot_message('starting', bot_id)
         filename = self.PIDFILE.format(bot_id)
         with open(filename, 'w') as fp:
             fp.write(str(os.getpid()))
 
-        bot_module = self.__runtime_configuration[bot_id]['module']
-        module = importlib.import_module(bot_module)
-        bot = getattr(module, 'BOT')
         try:
-            instance = bot(bot_id)
-            instance.start()
-        except (Exception, KeyboardInterrupt) as exc:
-            print('Bot failed: %s' % exc)
-            retval = 1
+            BotDebugger(self.__runtime_configuration[bot_id]['module'], bot_id, run_subcommand, message_action_kind, dryrun, msg)
+            retval = 0
+        except KeyboardInterrupt:
+            print('Keyboard interrupt.')
+            retval = 0
         except SystemExit as exc:
             print('Bot exited with code %s.' % exc)
             retval = exc
 
         self.__remove_pidfile(bot_id)
+        if paused:
+            self.bot_start(bot_id)
         return retval
 
     def bot_start(self, bot_id, getstatus=True):
@@ -305,10 +305,12 @@ class IntelMQController():
 
         Outputs are logged to /opt/intelmq/var/log/intelmqctl"""
         EPILOG = '''
-        intelmqctl [start|stop|restart|status|reload|run] bot-id
+        intelmqctl [start|stop|restart|status|reload] bot-id
         intelmqctl [start|stop|restart|status|reload]
         intelmqctl list [bots|queues]
         intelmqctl log bot-id [number-of-lines [log-level]]
+        intelmqctl run bot-id message [get|pop|send --msg]
+        intelmqctl run bot-id process [--msg|--dryrun]
         intelmqctl clear queue-id
         intelmqctl check
 
@@ -321,8 +323,12 @@ Restarting a bot:
 Get status of a bot:
     intelmqctl status bot-id
 
-Run a bot directly (blocking) for debugging purpose:
+Run a bot directly for debugging purpose and temporarily leverage the logging level to DEBUG:
     intelmqctl run bot-id
+See the message that waits in the input queue.
+    intelmqctl run bot-id message get
+See additional help for further explanation.
+    intelmqctl run bot-id --help
 
 Starting the botnet (all bots):
     intelmqctl start
@@ -434,6 +440,19 @@ Outputs are additionally logged to /opt/intelmq/var/log/intelmqctl'''
             parser_run = subparsers.add_parser('run', help='Run a bot interactively')
             parser_run.add_argument('bot_id',
                                     choices=self.runtime_configuration.keys())
+            parser_run_subparsers = parser_run.add_subparsers(title='run-subcommands')            
+            parser_run_message = parser_run_subparsers.add_parser('message', help='Debug bot\'s pipelines. Get the message in the input pipeline, pop it (cut it) and display it, or send the message directly to bot\'s output pipeline.')
+            parser_run_message.add_argument('message_action_kind', choices = ["get","pop","send"])
+            parser_run_message.add_argument('msg', nargs = '?', help='If send was chosen, put here the message in JSON.')
+            parser_run_message.set_defaults(run_subcommand="message")
+            parser_run_process = parser_run_subparsers.add_parser('process', help='Single run of bot\'s process() method.')
+            parser_run_process.add_argument('--dryrun', '-d', action='store_true',
+                                            help='Never really pop the message from the input pipeline '
+                                                 'nor send to output pipeline.')
+            parser_run_process.add_argument('--msg', '-m',
+                                            help='Trick the bot to process this JSON '
+                                                 'instead of the Message in its pipeline.')
+            parser_run_process.set_defaults(run_subcommand="process")
             parser_run.set_defaults(func=self.bot_run)
 
             parser_check = subparsers.add_parser('check',
@@ -518,8 +537,8 @@ Outputs are additionally logged to /opt/intelmq/var/log/intelmqctl'''
         elif results == 'error':
             return 1
 
-    def bot_run(self, bot_id):
-        return self.bot_process_manager.bot_run(bot_id)
+    def bot_run(self, bot_id, run_subcommand=None, message_action_kind=None, dryrun=None, msg=None):
+        return self.bot_process_manager.bot_run(bot_id, run_subcommand, message_action_kind, dryrun, msg)
 
     def bot_start(self, bot_id, getstatus=True):
         if bot_id is None:
@@ -864,7 +883,6 @@ Outputs are additionally logged to /opt/intelmq/var/log/intelmqctl'''
 def main():  # pragma: no cover
     x = IntelMQController(interactive=True)
     return x.run()
-
 
 if __name__ == "__main__":  # pragma: no cover
     exit(main())

--- a/intelmq/lib/bot_debugger.py
+++ b/intelmq/lib/bot_debugger.py
@@ -25,13 +25,15 @@ from intelmq.lib.utils import error_message_from_exc
 
 class BotDebugger:
 
-    EXAMPLE = """\nThe message may look like:  '{"source.network": "178.72.192.0/18", "time.observation": "2017-05-12T05:23:06+00:00"}' """
+    EXAMPLE = """\nThe message may look like:
+    '{"source.network": "178.72.192.0/18", "time.observation": "2017-05-12T05:23:06+00:00"}' """
 
     load_configuration = utils.load_configuration
     logging_level = "DEBUG"
     init_log_level = {"console": logging.DEBUG, "message": logging.WARNING, "process": logging.INFO, None: logging.INFO}
 
-    def __init__(self, runtime_configuration, bot_id, run_subcommand=None, console_type=None, dryrun=None, message_kind=None, msg=None):
+    def __init__(self, runtime_configuration, bot_id, run_subcommand=None, console_type=None,
+                 dryrun=None, message_kind=None, msg=None):
         self.runtime_configuration = runtime_configuration
         self.leverageLogger(level=self.init_log_level[run_subcommand])
         module = import_module(self.runtime_configuration['module'])
@@ -67,7 +69,8 @@ class BotDebugger:
             else:
                 if console_type and console != console_type:
                     print("Console {} not available.".format(console_type))
-                print("*** Using console {}. Please use 'self' to access to the bot instance properties. ***".format(module.__name__))
+                print("*** Using console {}. Please use 'self' to access to the bot instance properties. ***"
+                      .format(module.__name__))
                 break
         else:
             print("Can't run console.")

--- a/intelmq/lib/bot_debugger.py
+++ b/intelmq/lib/bot_debugger.py
@@ -12,96 +12,138 @@ Depending on the subcommand received, the class either
  * processes single message, either injected or from default pipeline (process subcommand)
  * reads the message from input pipeline or send a message to output pipeline (message subcommand)
 """
-import logging
-import json
-from pprint import pprint
-
 from importlib import import_module
-from intelmq.lib.utils import StreamHandler, error_message_from_exc
-from intelmq.lib.message import Event, MessageFactory
-
-
+from intelmq.lib import utils
+from intelmq.lib.message import Event
+from intelmq.lib.message import MessageFactory
+from intelmq.lib.utils import StreamHandler
+from intelmq.lib.utils import error_message_from_exc
+import json
+import logging
 class BotDebugger:
-        def leverageLogger(self, level=logging.DEBUG):
+
+    EXAMPLE = """\nThe message may look like:  '{"source.network": "178.72.192.0/18", "time.observation": "2017-05-12T05:23:06+00:00"}' """
+
+    load_configuration = utils.load_configuration
+    logging_level = "DEBUG"
+    init_log_level = {"console": logging.DEBUG, "message": logging.WARNING, "process": logging.INFO, None: logging.INFO}
+
+    def __init__(self, runtime_configuration, bot_id, run_subcommand=None, console_type=None, dryrun=None, message_kind=None, msg=None):
+        self.runtime_configuration = runtime_configuration
+        self.leverageLogger(level=self.init_log_level[run_subcommand])
+        module = import_module(self.runtime_configuration['module'])
+        bot = getattr(module, 'BOT')
+        if run_subcommand == "message":
+            bot.init = lambda *args: None
+        self.instance = bot(bot_id)
+
+        if not run_subcommand:
+            self.instance.start()
+        else:
+            self.instance._Bot__connect_pipelines()
+            if run_subcommand == "console":
+                self._console(console_type)
+            elif run_subcommand == "message":
+                self.leverageLogger(logging.INFO)
+                self._message(message_kind, msg)
+                return
+            elif run_subcommand == "process":
+                self.leverageLogger(logging.DEBUG)
+                self._process(dryrun, msg)
+            else:
+                print("Subcommand {} not known.".format(run_subcommand))
+
+    def _console(self, console_type):
+        consoles = [console_type, "ipdb", "pudb", "pdb"]
+        for console in consoles:
+            try:
+                module = import_module(console)
+            except Exception as exc:
+                pass
+            else:
+                if console_type and console != console_type:
+                    print("Console {} not available.".format(console_type))
+                print("*** Using console {}. Please use 'self' to access to the bot instance properties. ***".format(module.__name__))
+                break
+        else:
+            print("Can't run console.")
+            return
+
+        self = self.instance
+        module.set_trace()
+
+    def _message(self, message_action_kind, msg):
+        if message_action_kind == "get":
+            self.instance.logger.info("Trying to get the message...")
+            # never pops from source to internal queue, thx to disabling brpoplpush operation
+            if not bool(self.instance._Bot__source_queues):
+                self.instance.logger.warning("Bot has no source queue.")
+                return
+            pl = self.instance._Bot__source_pipeline
+            pl.pipe.brpoplpush = lambda source_q, inter_q, i: pl.pipe.lindex(source_q, -1)
+            self.pprint(self.instance.receive_message())
+        elif message_action_kind == "pop":
+            self.instance.logger.info("Trying to pop the message...")
+            self.pprint(self.instance.receive_message())
+            self.instance.acknowledge_message()
+        elif message_action_kind == "send":
+            if not bool(self.instance._Bot__destination_queues):
+                self.instance.logger.warning("Bot has no destination queues.")
+                return
+            if msg:
+                msg = self.arg2msg(msg)
+                self.instance.send_message(msg)
+                self.instance.logger.info("Message sent to output pipelines.")
+            else:
+                self.messageWizzard("Message missing!")
+
+    def _process(self, dryrun, msg):
+        if msg:
+            self.instance._Bot__source_pipeline.receive = lambda: msg
+            self.instance.logger.info(" * Message from cli will be used when processing.")
+
+        if dryrun:
+            self.instance.send_message = lambda msg: self.instance.logger.info("DRYRUN: Message would be sent now!")
+            self.instance.acknowledge_message = lambda: self.instance.logger.info("DRYRUN: Message would be acknowledged now!")
+            self.instance.logger.info(" * Dryrun only, no message will be really sent through.")
+
+        self.instance.logger.info("Processing...")
+        self.instance.process()
+
+    def arg2msg(self, msg):
+        try:
+            default_type = "Report" if self.runtime_configuration["group"] is "Parser" else "Event"
+            msg = MessageFactory.unserialize(msg, default_type=default_type)
+        except (Exception, KeyError, TypeError, json.JSONDecodeError) as exc:
+            self.messageWizzard("Message can not be parsed from JSON: {}".format(error_message_from_exc(exc)))
+            exit(1)
+        return msg
+
+    def leverageLogger(self, level):
+        utils.load_configuration = BotDebugger.load_configuration_patch
+        BotDebugger.logging_level = level
+        if hasattr(self, "instance"):
             self.instance.logger.setLevel(level)
             for h in self.instance.logger.handlers:
                 if isinstance(h, StreamHandler):
                     h.setLevel(level)
 
-        def __init__(self, module_path, bot_id, run_subcommand=None, console_type=None, dryrun=None, message_kind=None, msg=None):
-            module = import_module(module_path)
-            bot = getattr(module, 'BOT')
-            self.instance = bot(bot_id)
-            self.leverageLogger()
+    @staticmethod
+    def load_configuration_patch(*args, ** kwargs):
+        d = BotDebugger.load_configuration(*args, ** kwargs)
+        if "logging_level" in d:
+            d["logging_level"] = BotDebugger.logging_level
+        return d
 
-            if not run_subcommand:
-                self.instance.start()
-            else:
-                self.instance._Bot__connect_pipelines()
-                if run_subcommand == "process":
-                    self._process(dryrun, msg)
-                elif run_subcommand == "message":
-                    # XXX self.leverageLogger(level=logging.INFO)
-                    self._message(message_kind, msg)
-                elif run_subcommand == "console":
-                    self._console(console_type)
-                else:
-                    print("Subcommand {} not known.".format(run_subcommand))
+    def messageWizzard(self, msg):
+        self.instance.logger.error(msg)
+        print(self.EXAMPLE)
+        if input("Do you want to display current harmonization (available fields)? y/[n]: ") is "y":
+            self.pprint(self.instance.harmonization)
 
-        class PoorBot:
-            pass
 
-        def _console(self,console_type):
-            consoles = [console_type, "ipdb", "pudb", "pdb"]
-            for console in consoles:                
-                try:
-                    module = import_module(console)
-                except Exception as exc:                    
-                    pass
-                else:
-                    if console_type and console != console_type:
-                        print("Console {} not available.".format(console_type))
-                    print("*** Using console {}. Please use 'self' to access to the bot instance properties. ***".format(module.__name__))
-                    break
-            else:
-                print("Can't run console.")
-                return
 
-            self = self.instance
-            module.set_trace()
-
-        def _message(self, message_action_kind, msg):
-            if message_action_kind == "get":
-                self.instance.logger.info("Trying to get the message...")
-                # never pops from source to internal queue, thx to disabling brpoplpush operation
-                pl = self.instance._Bot__source_pipeline                
-                pl.pipe.brpoplpush = lambda source_q, inter_q, i: pl.pipe.lindex(source_q, -1)                
-                pprint(self.instance.receive_message())
-            elif message_action_kind == "pop":
-                self.instance.logger.info("Trying to pop the message...")
-                pprint(self.instance.receive_message())
-                self.instance.acknowledge_message()
-            elif message_action_kind == "send":                
-                if msg:
-                    try:
-                        msg = MessageFactory.unserialize(msg)
-                    except (Exception, KeyError, TypeError, json.JSONDecodeError) as exc:                        
-                        print("Message can not be parsed from JSON: " + error_message_from_exc(exc))
-                        return
-                    self.instance.send_message(msg)
-                    self.instance.logger.info("Message sent to output pipelines.")
-                else:
-                    self.instance.logger.info("Message missing!")
-
-        def _process(self, dryrun, msg):
-            if msg:
-                self.instance._Bot__source_pipeline.receive = lambda: msg
-                self.instance.logger.info("Message from cli will be used when processing.")
-
-            if dryrun:
-                self.instance.send_message = lambda msg: self.instance.logger.info("DRYRUN: Message would be sent now!")
-                self.instance.acknowledge_message = lambda: self.instance.logger.info("DRYRUN: Message would be acknowledged now!")
-                print("Dryrun only, no message will be really sent through.")
-
-            self.instance.logger.info("Processing...")
-            self.instance.process()
+    @staticmethod
+    def pprint(msg):
+        """ We can't use standard pprint as JSON standard asks for double quotes. """
+        print(json.dumps(msg, indent=4, sort_keys=True))

--- a/intelmq/lib/bot_debugger.py
+++ b/intelmq/lib/bot_debugger.py
@@ -70,7 +70,8 @@ class BotDebugger:
             else:
                 if console_type and console != console_type:
                     print("Console {} not available.".format(console_type))
-                print("*** Using console {}. Please use 'self' to access to the bot instance properties. ***"
+                print("*** Using console {}. Please use 'self' to access to the bot instance properties."
+                      "You may exit the console by 'c' command (like continue). ***"
                       .format(module.__name__))
                 break
         else:
@@ -129,7 +130,7 @@ class BotDebugger:
             msg = MessageFactory.unserialize(msg, default_type=default_type)
         except (Exception, KeyError, TypeError, ValueError) as exc:
             if exists(msg):
-                with open(msg,"r") as f:
+                with open(msg, "r") as f:
                     return self.arg2msg(f.read())
             self.messageWizzard("Message can not be parsed from JSON: {}".format(error_message_from_exc(exc)))
             exit(1)

--- a/intelmq/lib/bot_debugger.py
+++ b/intelmq/lib/bot_debugger.py
@@ -1,0 +1,83 @@
+# -*- coding: utf-8 -*-
+"""
+Utilities for debugging intelmq bots.
+
+BotDebugger is called via intelmqctl. It starts a live running bot instance,
+leverages logging to DEBUG level and permits even a non-skilled programmer
+who may find themselves puzzled with Python nuances and server deployment twists
+to see what's happening in the bot and where's the error.
+
+Depending on the subcommand received, the class either
+ * starts the bot as is (default)
+ * processes single message, either injected or from default pipeline (process subcommand)
+ * reads the message from input pipeline or send a message to output pipeline (message subcommand)
+"""
+import logging
+import json
+from pprint import pprint
+
+from importlib import import_module
+from intelmq.lib.utils import StreamHandler, error_message_from_exc
+from intelmq.lib.message import Event, MessageFactory
+
+
+class BotDebugger:
+        def leverageLogger(self, level=logging.DEBUG):
+            self.instance.logger.setLevel(level)
+            for h in self.instance.logger.handlers:
+                if isinstance(h, StreamHandler):
+                    h.setLevel(level)
+
+        def __init__(self, module_path, bot_id, run_subcommand=None, message_kind=None, dryrun=None, msg=None):        
+            module = import_module(module_path)
+            bot = getattr(module, 'BOT')
+            self.instance = bot(bot_id)
+            self.leverageLogger()
+
+            if not run_subcommand:
+                self.instance.start()
+            else:
+                self.instance._Bot__connect_pipelines()
+                if run_subcommand == "process":
+                    self._process(dryrun, msg)
+                elif run_subcommand == "message":
+                    self.leverageLogger(level=logging.INFO)
+                    self._message(message_kind, msg)
+                else:
+                    print("Subcommand {} not known.".format(run_subcommand))
+
+        def _process(self, dryrun, msg):
+            if msg:
+                self.instance._Bot__source_pipeline.receive = lambda: msg
+                self.instance.logger.info("Message from cli will be used when processing.")
+
+            if dryrun:
+                self.instance.send_message = lambda msg: self.instance.logger.info("DRYRUN: Message would be sent now!")
+                self.instance.acknowledge_message = lambda: self.instance.logger.info("DRYRUN: Message would be acknowledged now!")
+                print("Dryrun only, no message will be really sent through.")
+
+            self.instance.logger.info("Processing...")
+            self.instance.process()
+
+        class PoorBot:
+            pass
+
+        def _message(self, message_action_kind, msg):
+            if message_action_kind == "get":
+                self.instance.logger.info("Trying to get the message...")
+                pprint(self.instance.receive_message())
+            elif message_action_kind == "pop":
+                self.instance.logger.info("Trying to pop the message...")
+                pprint(self.instance.receive_message())
+                self.instance.acknowledge_message()
+            elif message_action_kind == "send":                
+                if msg:
+                    try:
+                        msg = MessageFactory.unserialize(msg)
+                    except (Exception, KeyError, TypeError, json.JSONDecodeError) as exc:                        
+                        print("Message can not be parsed from JSON: " + error_message_from_exc(exc))
+                        return
+                    self.instance.send_message(msg)
+                    self.instance.logger.info("Message sent to output pipelines.")
+                else:
+                    self.instance.logger.info("Message missing!")

--- a/intelmq/lib/bot_debugger.py
+++ b/intelmq/lib/bot_debugger.py
@@ -15,6 +15,7 @@ Depending on the subcommand received, the class either
 import time
 import json
 import logging
+from os.path import exists
 from importlib import import_module
 
 from intelmq.lib import utils
@@ -127,6 +128,9 @@ class BotDebugger:
             default_type = "Report" if self.runtime_configuration["group"] is "Parser" else "Event"
             msg = MessageFactory.unserialize(msg, default_type=default_type)
         except (Exception, KeyError, TypeError, ValueError) as exc:
+            if exists(msg):
+                with open(msg,"r") as f:
+                    return self.arg2msg(f.read())
             self.messageWizzard("Message can not be parsed from JSON: {}".format(error_message_from_exc(exc)))
             exit(1)
         return msg

--- a/intelmq/lib/bot_debugger.py
+++ b/intelmq/lib/bot_debugger.py
@@ -28,7 +28,7 @@ class BotDebugger:
                 if isinstance(h, StreamHandler):
                     h.setLevel(level)
 
-        def __init__(self, module_path, bot_id, run_subcommand=None, message_kind=None, dryrun=None, msg=None):
+        def __init__(self, module_path, bot_id, run_subcommand=None, console_type=None, dryrun=None, message_kind=None, msg=None):
             module = import_module(module_path)
             bot = getattr(module, 'BOT')
             self.instance = bot(bot_id)
@@ -41,10 +41,57 @@ class BotDebugger:
                 if run_subcommand == "process":
                     self._process(dryrun, msg)
                 elif run_subcommand == "message":
-                    self.leverageLogger(level=logging.INFO)
+                    # XXX self.leverageLogger(level=logging.INFO)
                     self._message(message_kind, msg)
+                elif run_subcommand == "console":
+                    self._console(console_type)
                 else:
                     print("Subcommand {} not known.".format(run_subcommand))
+
+        class PoorBot:
+            pass
+
+        def _console(self,console_type):
+            consoles = [console_type, "ipdb", "pudb", "pdb"]
+            for console in consoles:                
+                try:
+                    module = import_module(console)
+                except Exception as exc:                    
+                    pass
+                else:
+                    if console_type and console != console_type:
+                        print("Console {} not available.".format(console_type))
+                    print("*** Using console {}. Please use 'self' to access to the bot instance properties. ***".format(module.__name__))
+                    break
+            else:
+                print("Can't run console.")
+                return
+
+            self = self.instance
+            module.set_trace()
+
+        def _message(self, message_action_kind, msg):
+            if message_action_kind == "get":
+                self.instance.logger.info("Trying to get the message...")
+                # never pops from source to internal queue, thx to disabling brpoplpush operation
+                pl = self.instance._Bot__source_pipeline                
+                pl.pipe.brpoplpush = lambda source_q, inter_q, i: pl.pipe.lindex(source_q, -1)                
+                pprint(self.instance.receive_message())
+            elif message_action_kind == "pop":
+                self.instance.logger.info("Trying to pop the message...")
+                pprint(self.instance.receive_message())
+                self.instance.acknowledge_message()
+            elif message_action_kind == "send":                
+                if msg:
+                    try:
+                        msg = MessageFactory.unserialize(msg)
+                    except (Exception, KeyError, TypeError, json.JSONDecodeError) as exc:                        
+                        print("Message can not be parsed from JSON: " + error_message_from_exc(exc))
+                        return
+                    self.instance.send_message(msg)
+                    self.instance.logger.info("Message sent to output pipelines.")
+                else:
+                    self.instance.logger.info("Message missing!")
 
         def _process(self, dryrun, msg):
             if msg:
@@ -58,27 +105,3 @@ class BotDebugger:
 
             self.instance.logger.info("Processing...")
             self.instance.process()
-
-        class PoorBot:
-            pass
-
-        def _message(self, message_action_kind, msg):
-            if message_action_kind == "get":
-                self.instance.logger.info("Trying to get the message...")
-                pprint(self.instance.receive_message())
-            elif message_action_kind == "pop":
-                self.instance.logger.info("Trying to pop the message...")
-                pprint(self.instance.receive_message())
-                self.instance.acknowledge_message()
-            elif message_action_kind == "send":
-                if msg:
-                    try:
-                        msg = MessageFactory.unserialize(msg)
-                    except (Exception, KeyError, TypeError, json.JSONDecodeError) as exc:
-                        print("Message can not be parsed from JSON: " + error_message_from_exc(exc))
-                        return
-                    self.instance.send_message(msg)
-                    self.instance.logger.info("Message sent to output pipelines.")
-                else:
-                    self.instance.logger.info("Message missing!")
-                    

--- a/intelmq/lib/bot_debugger.py
+++ b/intelmq/lib/bot_debugger.py
@@ -90,7 +90,7 @@ class BotDebugger:
             # However, we have to wait manually till there is the message in the queue.
             pl = self.instance._Bot__source_pipeline
             pl.pipe.brpoplpush = lambda source_q, inter_q, i: pl.pipe.lindex(source_q, -1)
-            while not pl.pipe.llen(pl.source_queue):
+            while not (pl.pipe.llen(pl.source_queue) or pl.pipe.llen(pl.internal_queue)):
                 time.sleep(1)
             self.pprint(self.instance.receive_message())
         elif message_action_kind == "pop":

--- a/intelmq/lib/bot_debugger.py
+++ b/intelmq/lib/bot_debugger.py
@@ -18,7 +18,6 @@ import logging
 from importlib import import_module
 
 from intelmq.lib import utils
-from intelmq.lib.message import Event
 from intelmq.lib.message import MessageFactory
 from intelmq.lib.utils import StreamHandler
 from intelmq.lib.utils import error_message_from_exc
@@ -42,6 +41,7 @@ class BotDebugger:
         self.instance = bot(bot_id)
 
         if not run_subcommand:
+            self.leverageLogger(logging.DEBUG)
             self.instance.start()
         else:
             self.instance._Bot__connect_pipelines()
@@ -107,6 +107,7 @@ class BotDebugger:
 
     def _process(self, dryrun, msg):
         if msg:
+            msg = MessageFactory.serialize(self.arg2msg(msg))
             self.instance._Bot__source_pipeline.receive = lambda: msg
             self.instance.logger.info(" * Message from cli will be used when processing.")
 
@@ -122,7 +123,7 @@ class BotDebugger:
         try:
             default_type = "Report" if self.runtime_configuration["group"] is "Parser" else "Event"
             msg = MessageFactory.unserialize(msg, default_type=default_type)
-        except (Exception, KeyError, TypeError, json.JSONDecodeError) as exc:
+        except (Exception, KeyError, TypeError, ValueError) as exc:
             self.messageWizzard("Message can not be parsed from JSON: {}".format(error_message_from_exc(exc)))
             exit(1)
         return msg

--- a/intelmq/lib/bot_debugger.py
+++ b/intelmq/lib/bot_debugger.py
@@ -28,7 +28,7 @@ class BotDebugger:
                 if isinstance(h, StreamHandler):
                     h.setLevel(level)
 
-        def __init__(self, module_path, bot_id, run_subcommand=None, message_kind=None, dryrun=None, msg=None):        
+        def __init__(self, module_path, bot_id, run_subcommand=None, message_kind=None, dryrun=None, msg=None):
             module = import_module(module_path)
             bot = getattr(module, 'BOT')
             self.instance = bot(bot_id)
@@ -70,14 +70,15 @@ class BotDebugger:
                 self.instance.logger.info("Trying to pop the message...")
                 pprint(self.instance.receive_message())
                 self.instance.acknowledge_message()
-            elif message_action_kind == "send":                
+            elif message_action_kind == "send":
                 if msg:
                     try:
                         msg = MessageFactory.unserialize(msg)
-                    except (Exception, KeyError, TypeError, json.JSONDecodeError) as exc:                        
+                    except (Exception, KeyError, TypeError, json.JSONDecodeError) as exc:
                         print("Message can not be parsed from JSON: " + error_message_from_exc(exc))
                         return
                     self.instance.send_message(msg)
                     self.instance.logger.info("Message sent to output pipelines.")
                 else:
                     self.instance.logger.info("Message missing!")
+                    


### PR DESCRIPTION
(This is a continuation of PR #973 , because I completely messed up a git history...)

BotDebugger is called via intelmqctl. It starts a live running bot instance,
leverages logging to DEBUG level and permits even a non-skilled programmer
who may find themselves puzzled with Python nuances and server deployment twists
to see what's happening in the bot and where's the error.

Depending on the subcommand received, the class either
 * starts the bot as is (default)
 * processes single message, either injected or from default pipeline (process subcommand)
 * reads the message from input pipeline or send a message to output pipeline (message subcommand)

Further help was added to argparse help of intelmqctl:
Possible commands:
```
intelmqctl run bot-id (bot.start())
intelmqctl run bot-id message get (read the next message)
intelmqctl run bot-id message pop (read the next message and pop from queue)
intelmqctl run bot-id message send '{a:b}' (create message from string and send to output queue)
intelmqctl run bot-id process (process single message)
intelmqctl run bot-id process --msg '{a:b}' (process single message from string)
intelmqctl run bot-id process --dryrun (process single message from pipeline or --msg, but never really acknowledge nor send it to output pipeline)
intelmqctl run bot-id console (type) (starts ipdb console with self defined as the bot)
```

There were commands I always wanted to have. I missed them when creating/quickly debugging the bots. If you find them useful, too, I'd be very glad to publish it in the main repository. I am open to any discussion concerning the new commands.

Wagner's response: 
> The features are really great. I had something like this in mind too but never had the time to actually do it.
> I am missing a detailed explanation including examples for the users in docs/intelmqctl.md
> Please fix the code style issues: https://travis-ci.org/certtools/intelmq/jobs/231607021#L2790

Dear @wagner-certat , please respond to my 3 little discussions:
* [x] https://github.com/certtools/intelmq/pull/973#discussion_r116441276
* [x] https://github.com/certtools/intelmq/pull/973#discussion_r116573175
* [x] https://github.com/certtools/intelmq/pull/973#discussion_r116555798

Then I have to finish this:
* [x] docs/intelmqctl.md
* [x] https://github.com/certtools/intelmq/pull/973#discussion_r116441276
* [x] https://github.com/certtools/intelmq/pull/973#discussion_r116555798