### PR TITLE
error in the bot shouldnt affect whole botnet

### DIFF
--- a/intelmq/bin/intelmqctl.py
+++ b/intelmq/bin/intelmqctl.py
@@ -158,10 +158,15 @@ class IntelMQProcessManager:
         module = self.__runtime_configuration[bot_id]['module']
         cmdargs = [module, bot_id]
         with open('/dev/null', 'w') as devnull:
-            proc = psutil.Popen(cmdargs, stdout=devnull, stderr=devnull)
-            filename = self.PIDFILE.format(bot_id)
-            with open(filename, 'w') as fp:
-                fp.write(str(proc.pid))
+            try:
+                proc = psutil.Popen(cmdargs, stdout=devnull, stderr=devnull)
+            except FileNotFoundError:
+                log_bot_error("starting", bot_id)
+                return 'stopped'
+            else:            
+                filename = self.PIDFILE.format(bot_id)
+                with open(filename, 'w') as fp:
+                    fp.write(str(proc.pid))
 
         if getstatus:
             time.sleep(0.5)

--- a/intelmq/bin/intelmqctl.py
+++ b/intelmq/bin/intelmqctl.py
@@ -44,6 +44,7 @@ ERROR_MESSAGES = {
     'running': '%s is still running.',
     'stopped': '%s was NOT RUNNING.',
     'stopping': '%s failed to STOP.',
+    'not found': '%s failed to START because the file cannot be found.',
 }
 
 LOG_LEVEL = {
@@ -161,9 +162,9 @@ class IntelMQProcessManager:
             try:
                 proc = psutil.Popen(cmdargs, stdout=devnull, stderr=devnull)
             except FileNotFoundError:
-                log_bot_error("starting", bot_id)
+                log_bot_error("not found", bot_id)
                 return 'stopped'
-            else:            
+            else:
                 filename = self.PIDFILE.format(bot_id)
                 with open(filename, 'w') as fp:
                     fp.write(str(proc.pid))


### PR DESCRIPTION
We had an error – our proprietary bot wasn't listed in BOTS file. Thus, no launcher in bin was created. When launching whole botnet only bots that preceded this bot in the alphabet were launched, the rest stayed stopped.  
With this change, when an error occurs, the rest of the botnet will stay unaffected → only erroneous bots won't get launched → it will be easier to detect the bug for the administrator.