### PR TITLE
[ENH] bambenek parser: add malware name from the url available in the feed

### DIFF
--- a/intelmq/bots/parsers/bambenek/parser.py
+++ b/intelmq/bots/parsers/bambenek/parser.py
@@ -11,6 +11,13 @@ class BambenekParserBot(ParserBot):
     DOMMASTERLIST = {'http://osint.bambenekconsulting.com/feeds/c2-dommasterlist.txt'}
     DGA_FEED = {'http://osint.bambenekconsulting.com/feeds/dga-feed.txt'}
 
+    MALWARE_NAME_MAP = {
+        "cryptolocker": "cl",
+        "p2p goz": "p2pgoz",
+        "pt goz": "ptgoz",
+        "volatile cedar": "volatile"
+    }
+
     def parse_line(self, line, report):
         if line.startswith('#') or len(line) == 0:
             self.tempdata.append(line)
@@ -22,6 +29,12 @@ class BambenekParserBot(ParserBot):
             event.add('event_description.text', value[1])
             event.add('event_description.url', value[3])
             event.add('raw', line)
+
+            # last row is a url with malware named txt file link
+            malware_name = value[-1].split('/')[-1].split('.')[0]
+            if malware_name in BambenekParserBot.MALWARE_NAME_MAP:
+                malware_name = BambenekParserBot.MALWARE_NAME_MAP[malware_name]
+            event.add('malware.name', malware_name)
 
             if report['feed.url'] in BambenekParserBot.IPMASTERLIST:
                 event.add('source.ip', value[0])

--- a/intelmq/bots/parsers/bambenek/parser.py
+++ b/intelmq/bots/parsers/bambenek/parser.py
@@ -7,15 +7,17 @@ from intelmq.lib.bot import ParserBot
 class BambenekParserBot(ParserBot):
     """ Single parser for Bambenek feeds """
 
-    IPMASTERLIST = {'http://osint.bambenekconsulting.com/feeds/c2-ipmasterlist.txt'}
-    DOMMASTERLIST = {'http://osint.bambenekconsulting.com/feeds/c2-dommasterlist.txt'}
+    IPMASTERLIST = {
+        'http://osint.bambenekconsulting.com/feeds/c2-ipmasterlist.txt'}
+    DOMMASTERLIST = {
+        'http://osint.bambenekconsulting.com/feeds/c2-dommasterlist.txt'}
     DGA_FEED = {'http://osint.bambenekconsulting.com/feeds/dga-feed.txt'}
 
     MALWARE_NAME_MAP = {
-        "cryptolocker": "cl",
-        "p2p goz": "p2pgoz",
-        "pt goz": "ptgoz",
-        "volatile cedar": "volatile"
+        "cl": "cryptolocker",
+        "p2pgoz": "p2p goz",
+        "ptgoz": "pt goz",
+        "volatile": "volatile cedar",
     }
 
     def parse_line(self, line, report):
@@ -30,7 +32,7 @@ class BambenekParserBot(ParserBot):
             event.add('event_description.url', value[3])
             event.add('raw', line)
 
-            # last row is a url with malware named txt file link
+            # last column is a url with malware named txt file link
             malware_name = value[-1].split('/')[-1].split('.')[0]
             if malware_name in BambenekParserBot.MALWARE_NAME_MAP:
                 malware_name = BambenekParserBot.MALWARE_NAME_MAP[malware_name]

--- a/intelmq/tests/bots/parsers/bambenek/test_parser.py
+++ b/intelmq/tests/bots/parsers/bambenek/test_parser.py
@@ -74,7 +74,7 @@ DGA_EVENTS = {'feed.url': 'http://osint.bambenekconsulting.com/feeds/dga-feed.tx
               'time.source': '2016-11-10T00:00:00+00:00',
               'source.fqdn': 'xqmclnusaswvof.com',
               'classification.type': 'dga domain',
-              'malware.name': 'cl',
+              'malware.name': 'cryptolocker',
               'event_description.text': 'Domain used by Cryptolocker - Flashback DGA for 10 Nov 2016',
               'event_description.url': 'http://osint.bambenekconsulting.com/manual/cl.txt'
              }

--- a/intelmq/tests/bots/parsers/bambenek/test_parser.py
+++ b/intelmq/tests/bots/parsers/bambenek/test_parser.py
@@ -31,6 +31,7 @@ DOMAIN_EVENTS = {'feed.url': 'http://osint.bambenekconsulting.com/feeds/c2-domma
                  'raw': 'c2ZraDIxb2tycm5sdS5jb20sRG9tYWluIHVzZWQgYnkgc2hpb3RvYi91cmx6b25lL2JlYmxvaCwyMDE2LTExLTEyIDE1OjAyLGh0dHA6Ly9vc2ludC5iYW1iZW5la2NvbnN1bHRpbmcuY29tL21hbnVhbC9iZWJsb2gudHh0',
                  'time.source': '2016-11-12T15:02:00+00:00',
                  'source.fqdn': 'sfkh21okrrnlu.com',
+                 'malware.name': 'bebloh',
                  'classification.type': 'c&c',
                  'status': 'online',
                  'event_description.text': 'Domain used by shiotob/urlzone/bebloh',
@@ -50,6 +51,7 @@ IP_EVENTS = {'feed.url': 'http://osint.bambenekconsulting.com/feeds/c2-ipmasterl
              'time.observation': '2016-01-01T00:00:00+00:00',
              'raw': 'MjEzLjI0Ny40Ny4xOTAsSVAgdXNlZCBieSBzaGlvdG9iL3VybHpvbmUvYmVibG9oIEMmQywyMDE2LTExLTEyIDE4OjAyLGh0dHA6Ly9vc2ludC5iYW1iZW5la2NvbnN1bHRpbmcuY29tL21hbnVhbC9iZWJsb2gudHh0',
              'source.ip': '213.247.47.190',
+             'malware.name': 'bebloh',
              'classification.type': 'c&c',
              'status': 'online',
              'time.source': '2016-11-12T18:02:00+00:00',
@@ -72,6 +74,7 @@ DGA_EVENTS = {'feed.url': 'http://osint.bambenekconsulting.com/feeds/dga-feed.tx
               'time.source': '2016-11-10T00:00:00+00:00',
               'source.fqdn': 'xqmclnusaswvof.com',
               'classification.type': 'dga domain',
+              'malware.name': 'cl',
               'event_description.text': 'Domain used by Cryptolocker - Flashback DGA for 10 Nov 2016',
               'event_description.url': 'http://osint.bambenekconsulting.com/manual/cl.txt'
              }


### PR DESCRIPTION
Adds malware name from the last column (url with file named after malware) in the csv.