### PR TITLE
dump silently failed

### DIFF
--- a/intelmq/lib/bot.py
+++ b/intelmq/lib/bot.py
@@ -395,7 +395,7 @@ class Bot(object):
             with open(dump_file, 'r') as fp:
                 dump_data = json.load(fp)
                 dump_data.update(new_dump_data)
-        except ValueError:
+        except (ValueError, FileNotFoundError):
             dump_data = new_dump_data
 
         with open(dump_file, 'w') as fp:


### PR DESCRIPTION
When dumping to a file due to processing error, if the dump didnt exist yet, we got on stderr FileNotFound and that was all – nothing in logs, nothing nowhere.  
The correct behaviour is to create new file.