### PR TITLE
add http-basic authentication support to elasticsearch bot

### DIFF
--- a/intelmq/bots/BOTS
+++ b/intelmq/bots/BOTS
@@ -626,6 +626,8 @@
                 "elastic_port": 9200,
                 "elastic_index": "intelmq",
                 "elastic_doctype": "events",
+                "http_username": "",
+                "http_password": "",
                 "flatten_fields": "extra",
                 "replacement_char": "_"
             }

--- a/intelmq/bots/outputs/elasticsearch/README.md
+++ b/intelmq/bots/outputs/elasticsearch/README.md
@@ -9,6 +9,8 @@ Bot parameters:
 * elastic_port       : Port for the ElasticSearch server, defaults to 9200
 * elastic_index      : Index for the ElasticSearch output, defaults to intelmq
 * elastic_doctype    : docname to put the event data, defaults to events
+* http_username      : http_auth basic username
+* http_password      : http_auth basic password
 * replacement_char   : ES forbids '.' in field names since v2.0, this parameters specifies which character should be used as replacement for '.', defaults to '_'
 * flatten_fields     : In ES, some query and aggregations work better if the fields are flat and not JSON. Here you can provide a list of fields to convert.
                        Can be a list of strings (fieldnames) or a string with field names separated by a comma (,). eg `extra,field2` or `['extra', 'field2']`

--- a/intelmq/bots/outputs/elasticsearch/output.py
+++ b/intelmq/bots/outputs/elasticsearch/output.py
@@ -36,6 +36,10 @@ class ElasticsearchOutputBot(Bot):
                                     'elastic_port', '9200')
         self.elastic_index = getattr(self.parameters,
                                      'elastic_index', 'intelmq')
+        self.http_username = getattr(self.parameters,
+                                     'http_username', '')
+        self.http_password = getattr(self.parameters,
+                                     'http_password', '')
         self.elastic_doctype = getattr(self.parameters,
                                        'elastic_doctype', 'events')
         self.replacement_char = getattr(self.parameters,
@@ -45,8 +49,13 @@ class ElasticsearchOutputBot(Bot):
         if isinstance(self.flatten_fields, str):
             self.flatten_fields = self.flatten_fields.split(',')
 
-        self.es = Elasticsearch([{'host': self.elastic_host,
-                                  'port': self.elastic_port}])
+        if self.http_username and self.http_password:
+            self.es = Elasticsearch([{'host': self.elastic_host,
+                                      'port': self.elastic_port}],
+                                    http_auth=(self.http_username, self.http_password))
+        else:
+            self.es = Elasticsearch([{'host': self.elastic_host, 'port': self.elastic_port}])
+
         if not self.es.indices.exists(self.elastic_index):
             self.es.indices.create(index=self.elastic_index, ignore=400)
 


### PR DESCRIPTION
Elasticsearch doesn't provide authentication out of the box, the most common solution adopted during deployments is to publishing the service behind a reverse proxy.
This patch adds the option to authenticate to it using http basic authentication.