### PR TITLE
erroneous date line

### DIFF
--- a/intelmq/bots/parsers/dyn/parser.py
+++ b/intelmq/bots/parsers/dyn/parser.py
@@ -32,7 +32,6 @@ class DynParserBot(Bot):
                 continue
             if row.startswith("date started"):
                 continue
-            
 
             row_split = row.split()
 

--- a/intelmq/bots/parsers/dyn/parser.py
+++ b/intelmq/bots/parsers/dyn/parser.py
@@ -23,15 +23,13 @@ class DynParserBot(Bot):
         source_time = None
 
         for row in raw_report.splitlines():
-            if row.startswith("# last updated:"):
+            if row.startswith("date started:"):
                 source_time = dateutil.parser.parse(row[row.find(':') + 1:],
                                                     tzinfos=self.TZOFFSETS)
                 source_time = source_time.isoformat()
                 continue
             if row.startswith('#'):
-                continue
-            if row.startswith("date started"):
-                continue
+                continue            
 
             row_split = row.split()
 

--- a/intelmq/bots/parsers/dyn/parser.py
+++ b/intelmq/bots/parsers/dyn/parser.py
@@ -30,6 +30,9 @@ class DynParserBot(Bot):
                 continue
             if row.startswith('#'):
                 continue
+            if row.startswith("date started"):
+                continue
+            
 
             row_split = row.split()
 


### PR DESCRIPTION
The report starts with a date line.

```
# this list of ponmocup malware redirection domains and infected web-servers is maintained by 
# (...)
date started: Mon Jun  5 00:00:01 PDT 2017
checking domain: beplants.be --> seems to be INFECTED: http://yasonia.vehicleexchangeprogram.com/gadgets/ifr --> DNS: yasonia.vehicleexchangeprogram.com 
```
This is so done by purpose (we wrote to the developer):
> Yes, the date start/stop lines are not preceeded with "#" to mark as comment.

However, intelmq ends like that with:
```
"traceback": [
            "Traceback (most recent call last):\n",
            "  File \"/usr/local/lib/python3.5/dist-packages/intelmq/lib/bot.py\", line 150, in start\n    self.process()\n",
            "  File \"/usr/local/lib/python3.5/dist-packages/intelmq/bots/parsers/dyn/parser.py\", line 40, in process\n    event_infected.add('source.ip', row_split[0])\n",
            "  File \"/usr/local/lib/python3.5/dist-packages/intelmq/lib/message.py\", line 205, in add\n    raise exceptions.InvalidValue(key, old_value)\n",
            "intelmq.lib.exceptions.InvalidValue: invalid value 'date' (<class 'str'>) for key 'source.ip' : \n"
        ]
```

So that no dyn date came in further the botnet.