### PR TITLE
Modify INSTALL.md remove Ubuntu 16 install instructions

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -50,7 +50,7 @@ python3.4 /tmp/get-pip.py
 ## Ubuntu 16.04
 
 ```bash
-apt install python3-pip python3-typing python3-dnspython python3-psutil python3-redis python3-requests python3-termstyle python3-tz
+apt install python3-pip python3-dnspython python3-psutil python3-redis python3-requests python3-termstyle python3-tz
 apt install git redis-server
 ```
 Optional dependencies:


### PR DESCRIPTION
Removing the python3-typing as this is now installed as part of the standard library as of python 3.5, per:

https://docs.python.org/3/library/typing.html

Confirmed on system:
# uname -a
Linux ubuntu14-generic-template-01 4.4.0-57-generic #78-Ubuntu SMP Fri Dec 9 23:50:32 UTC 2016 x86_64 x86_64 x86_64 GNU/Linux
# python3
Python 3.5.2 (default, Nov 17 2016, 17:05:23) 
[GCC 5.4.0 20160609] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import typing
>>> dir(typing)
['AbstractSet', 'Any', 'AnyMeta', 'AnyStr', 'AsyncIterable', 'AsyncIterator', 'Awaitable', 'BinaryIO', 'ByteString', 'CT', 'Callable', 'CallableMeta', 'Container', 'DefaultDict', 'Dict', 'Final', 'FrozenSet', 'Generator', 'Generic', 'GenericMeta', 'Hashable', 'IO', 'ItemsView', 'Iterable', 'Iterator', 'KT', 'KeysView', 'List', 'Mapping', 'MappingView', 'Match', 'MutableMapping', 'MutableSequence', 'MutableSet', 'NamedTuple', 'NewType', 'Optional', 'OptionalMeta', 'Pattern', 'Reversible', 'Sequence', 'Set', 'Sized', 'SupportsAbs', 'SupportsBytes', 'SupportsComplex', 'SupportsFloat', 'SupportsInt', 'SupportsRound', 'T', 'TYPE_CHECKING', 'T_co', 'T_contra', 'Text', 'TextIO', 'Tuple', 'TupleMeta', 'Type', 'TypeVar', 'TypingMeta', 'Union', 'UnionMeta', 'VT', 'VT_co', 'V_co', 'ValuesView', '_ForwardRef', '_FrozenSetMeta', '_G_base', '_Protocol', '_ProtocolMeta', '_TypeAlias', '__all__', '__builtins__', '__cached__', '__doc__', '__file__', '__loader__', '__name__', '__package__', '__spec__', '_eval_type', '_geqv', '_get_defaults', '_get_type_vars', '_gorg', '_next_in_mro', '_overload_dummy', '_qualname', '_type_check', '_type_repr', '_type_vars', 'abc', 'abstractmethod', 'abstractproperty', 'cast', 'collections', 'collections_abc', 'contextlib', 'functools', 'get_type_hints', 'io', 'no_type_check', 'no_type_check_decorator', 'overload', 're', 'stdlib_re', 'sys', 'types']
>>> 
