### PR TITLE
[Fix] Two minor fixes

### DIFF
--- a/intelmq/bots/experts/cymru_whois/expert.py
+++ b/intelmq/bots/experts/cymru_whois/expert.py
@@ -59,6 +59,8 @@ class CymruExpertBot(Bot):
                 self.cache.set(cache_key, result_json)
 
             for result_key, result_value in result.items():
+                if result_key == 'registry' and result_value == 'other':
+                    continue
                 event.add(key % result_key, result_value, overwrite=True)
 
         self.send_message(event)

--- a/intelmq/bots/parsers/alienvault/parser_otx.py
+++ b/intelmq/bots/parsers/alienvault/parser_otx.py
@@ -82,8 +82,12 @@ class AlienVaultOTXParserBot(Bot):
                 if 'tags' in pulse:
                     additional_indicator['tags'] = pulse['tags']
                 if 'modified' in pulse:
-                    additional_indicator['time_updated'] = \
-                        pulse["modified"][:-4] + "+00:00"
+                    if '.' in pulse["modified"]:
+                        additional_indicator['time_updated'] = \
+                            pulse["modified"][:-4] + "+00:00"
+                    else:
+                        additional_indicator['time_updated'] = \
+                            pulse["modified"] + ".00+00:00"
                 if 'industries' in pulse:
                     additional_indicator['industries'] = pulse["industries"]
                 if 'adversary' in pulse:

--- a/intelmq/tests/bots/experts/cymru_whois/test_expert.py
+++ b/intelmq/tests/bots/experts/cymru_whois/test_expert.py
@@ -64,7 +64,17 @@ NO_ASN_OUTPUT = {"__type": "Event",
                  "source.network": '212.92.127.0/24',
                  "source.registry": 'RIPE',
                  }
-
+EXAMPLE_6TO4_INPUT = {"__type": "Event",
+                 "source.ip": "2002:3ee0:3972:0001::1",
+                 "time.observation": "2015-01-01T00:00:00+00:00",
+                 }
+EXAMPLE_6TO4_OUTPUT = {"__type": "Event",
+                  "source.ip": "2002:3ee0:3972:0001::1",
+                  "source.network": "2002::/16",
+                  "source.asn": 6939,
+                  "source.as_name": "HURRICANE - Hurricane Electric, Inc., US",
+                  "time.observation": "2015-01-01T00:00:00+00:00",
+                  }
 
 @test.skip_redis()
 @test.skip_internet()
@@ -97,6 +107,11 @@ class TestCymruExpertBot(test.BotTestCase, unittest.TestCase):
         self.input_message = EMPTY_INPUT
         self.run_bot()
         self.assertMessageEqual(0, EMPTY_INPUT)
+
+    def test_6to4_result(self):
+        self.input_message = EXAMPLE_6TO4_INPUT
+        self.run_bot()
+        self.assertMessageEqual(0, EXAMPLE_6TO4_OUTPUT)
 
     @unittest.expectedFailure
     def test_missing_asn(self):

--- a/intelmq/tests/bots/parsers/alienvault/test_parser_otx.data
+++ b/intelmq/tests/bots/parsers/alienvault/test_parser_otx.data
@@ -1117,7 +1117,7 @@
             "rat", 
             "Strategic\tWeb\tCompromise"
         ], 
-        "modified": "2015-09-01T07:47:06.073000", 
+        "modified": "2015-09-01T07:47:06", 
         "author_name": "AlienVault", 
         "references": [
             "http://pages.arbornetworks.com/rs/082-KNA-087/images/ASERT%20Threat%20Intelligence%20Brief%202015-05%20PlugX%20Threat%20Activity%20in%20Myanmar.pdf"

--- a/intelmq/tests/bots/parsers/alienvault/test_parser_otx.py
+++ b/intelmq/tests/bots/parsers/alienvault/test_parser_otx.py
@@ -46,8 +46,8 @@ attacks.""".replace('\n', ' '),
 
 EXAMPLE_EVENT_2 = {
   '__type': 'Event',
-   'classification.type': 'blacklist',
-      'comment': 'Active users of mobile banking apps should be aware of a new '
+  'classification.type': 'blacklist',
+  'comment': 'Active users of mobile banking apps should be aware of a new '
                  'Android banking malware campaign targeting customers of large '
                  'banks in the United States, Germany, France, Australia, Turkey, '
                  'Poland, and Austria. This banking malware can steal login '
@@ -62,7 +62,7 @@ EXAMPLE_EVENT_2 = {
            '"banker"], "targeted_countries": ["United States", "Germany", '
            '"France", "Australia", "Turkey", "Poland", "Austria"], '
            '"time_updated": "2016-11-03T20:15:43.26+00:00"}',
-   'feed.name': 'AlienVault OTX',
+  'feed.name': 'AlienVault OTX',
   'malware.hash.sha256': 'e5df30b41b0c50594c2b77c1d5d6916a9ce925f792c563f692426c2d50aa2524',
   'raw': 'eyJhY2Nlc3NfZ3JvdXBzIjogW10sICJhY2Nlc3NfcmVhc29uIjogIiIsICJhY2Nlc3NfdHlwZSI6ICJwdWJsaWMiLCAiY29udGVudCI6ICIiLCAiY3JlYXRlZCI6ICIyMDE2LTExLTAzVDIwOjE1OjQ0IiwgImRlc2NyaXB0aW9uIjogIiIsICJleHBpcmF0aW9uIjogbnVsbCwgImlkIjogMTI2NTM1NCwgImluZGljYXRvciI6ICJlNWRmMzBiNDFiMGM1MDU5NGMyYjc3YzFkNWQ2OTE2YTljZTkyNWY3OTJjNTYzZjY5MjQyNmMyZDUwYWEyNTI0IiwgImlzX2FjdGl2ZSI6IDEsICJvYnNlcnZhdGlvbnMiOiAzLCAicm9sZSI6IG51bGwsICJ0aXRsZSI6ICIiLCAidHlwZSI6ICJGaWxlSGFzaC1TSEEyNTYifQ==',
   'time.source': '2016-11-03T20:01:00+00:00'
@@ -71,7 +71,7 @@ EXAMPLE_EVENT_2 = {
 EXAMPLE_EVENT_3 = {
   '__type': 'Event',
    'classification.type': 'blacklist',
-      'comment': 'Myanmar is a country currently engaged in an important '
+   'comment': 'Myanmar is a country currently engaged in an important '
                  'political process. A pro-democracy reform took place \n'
                  'in 2011 which has helped the government create an atmopshere '
                  'conducive to investor interest. The country is \n'
@@ -89,13 +89,13 @@ EXAMPLE_EVENT_3 = {
                  'countries - including China - have been known to target '
                  'organizations of strategic interest with aggressive '
                  'malware-based espionage campaigns.',
-    'extra': '{"author": "AlienVault", "pulse": "PlugX Threat\\tActivity in '
+  'extra': '{"author": "AlienVault", "pulse": "PlugX Threat\\tActivity in '
              'Myanmar", "tags": ["plugx", "Myanmar", "rat", '
              '"Strategic\\tWeb\\tCompromise"], "time_updated": '
              '"2015-09-01T07:47:06.00+00:00"}',
-   'feed.name': 'AlienVault OTX',
+  'feed.name': 'AlienVault OTX',
   'raw': 'eyJfaWQiOiAiNTVlNTU3ZmE0NjM3ZjIxYzU0YzFiYWY4IiwgImNyZWF0ZWQiOiAiMjAxNS0wOS0wMVQwNzo0NzowNi4wNzMiLCAiZGVzY3JpcHRpb24iOiAiIiwgImluZGljYXRvciI6ICJodHRwOi8vd3d3LnVlY215YW5tYXIub3JnL2RtZG9jdW1lbnRzL2ludml0YXRpb25zLnJhciIsICJ0eXBlIjogIlVSTCJ9',
-    'source.url': 'http://www.uecmyanmar.org/dmdocuments/invitations.rar',
+  'source.url': 'http://www.uecmyanmar.org/dmdocuments/invitations.rar',
   'time.source': '2015-09-01T07:47:06+00:00'
   }
 

--- a/intelmq/tests/bots/parsers/alienvault/test_parser_otx.py
+++ b/intelmq/tests/bots/parsers/alienvault/test_parser_otx.py
@@ -47,15 +47,15 @@ attacks.""".replace('\n', ' '),
 EXAMPLE_EVENT_2 = {
   '__type': 'Event',
    'classification.type': 'blacklist',
-  'comment': 'Active users of mobile banking apps should be aware of a new '
-             'Android banking malware campaign targeting customers of large '
-             'banks in the United States, Germany, France, Australia, Turkey, '
-             'Poland, and Austria. This banking malware can steal login '
-             'credentials from 94 different mobile banking apps. Due to its '
-             'ability to intercept SMS communications, the malware is also '
-             'able to bypass SMS-based two-factor authentication. '
-             'Additionally, it also contains modules to target some popular '
-             'social media apps.',
+      'comment': 'Active users of mobile banking apps should be aware of a new '
+                 'Android banking malware campaign targeting customers of large '
+                 'banks in the United States, Germany, France, Australia, Turkey, '
+                 'Poland, and Austria. This banking malware can steal login '
+                 'credentials from 94 different mobile banking apps. Due to its '
+                 'ability to intercept SMS communications, the malware is also '
+                 'able to bypass SMS-based two-factor authentication. '
+                 'Additionally, it also contains modules to target some popular '
+                 'social media apps.',
   'extra': '{"adversary": "", "author": "AlienVault", "industries": '
            '["banking"], "pulse": "Android banking malware masquerades as '
            'Flash Player", "tags": ["skype", "flash player", "android", '
@@ -66,6 +66,37 @@ EXAMPLE_EVENT_2 = {
   'malware.hash.sha256': 'e5df30b41b0c50594c2b77c1d5d6916a9ce925f792c563f692426c2d50aa2524',
   'raw': 'eyJhY2Nlc3NfZ3JvdXBzIjogW10sICJhY2Nlc3NfcmVhc29uIjogIiIsICJhY2Nlc3NfdHlwZSI6ICJwdWJsaWMiLCAiY29udGVudCI6ICIiLCAiY3JlYXRlZCI6ICIyMDE2LTExLTAzVDIwOjE1OjQ0IiwgImRlc2NyaXB0aW9uIjogIiIsICJleHBpcmF0aW9uIjogbnVsbCwgImlkIjogMTI2NTM1NCwgImluZGljYXRvciI6ICJlNWRmMzBiNDFiMGM1MDU5NGMyYjc3YzFkNWQ2OTE2YTljZTkyNWY3OTJjNTYzZjY5MjQyNmMyZDUwYWEyNTI0IiwgImlzX2FjdGl2ZSI6IDEsICJvYnNlcnZhdGlvbnMiOiAzLCAicm9sZSI6IG51bGwsICJ0aXRsZSI6ICIiLCAidHlwZSI6ICJGaWxlSGFzaC1TSEEyNTYifQ==',
   'time.source': '2016-11-03T20:01:00+00:00'
+  }
+
+EXAMPLE_EVENT_3 = {
+  '__type': 'Event',
+   'classification.type': 'blacklist',
+      'comment': 'Myanmar is a country currently engaged in an important '
+                 'political process. A pro-democracy reform took place \n'
+                 'in 2011 which has helped the government create an atmopshere '
+                 'conducive to investor interest. The country is \n'
+                 'resource rich, with a variety of natural resources and a steady '
+                 'labor supply. Despite recent progress, the \n'
+                 'country is subject to ongoing conflict with ethnic rebels and '
+                 'an ongoing civil war. Analysts suggest that both \n'
+                 'China and the United States are vying for greater influence in '
+                 'Myanmar, with China in particular having \n'
+                 'geopolitical interest due to sea passages, port deals, and fuel '
+                 'pipelines that are important to its goals. \n'
+                 'Geopolitical analysts have suggested that the United States may '
+                 'have its own interests that involve thwarting \n'
+                 'Chinese ambitions in the region. APT groups from multiple '
+                 'countries - including China - have been known to target '
+                 'organizations of strategic interest with aggressive '
+                 'malware-based espionage campaigns.',
+    'extra': '{"author": "AlienVault", "pulse": "PlugX Threat\\tActivity in '
+             'Myanmar", "tags": ["plugx", "Myanmar", "rat", '
+             '"Strategic\\tWeb\\tCompromise"], "time_updated": '
+             '"2015-09-01T07:47:06.00+00:00"}',
+   'feed.name': 'AlienVault OTX',
+  'raw': 'eyJfaWQiOiAiNTVlNTU3ZmE0NjM3ZjIxYzU0YzFiYWY4IiwgImNyZWF0ZWQiOiAiMjAxNS0wOS0wMVQwNzo0NzowNi4wNzMiLCAiZGVzY3JpcHRpb24iOiAiIiwgImluZGljYXRvciI6ICJodHRwOi8vd3d3LnVlY215YW5tYXIub3JnL2RtZG9jdW1lbnRzL2ludml0YXRpb25zLnJhciIsICJ0eXBlIjogIlVSTCJ9',
+    'source.url': 'http://www.uecmyanmar.org/dmdocuments/invitations.rar',
+  'time.source': '2015-09-01T07:47:06+00:00'
   }
 
 class TestAlienVaultOTXParserBot(test.BotTestCase, unittest.TestCase):
@@ -83,6 +114,7 @@ class TestAlienVaultOTXParserBot(test.BotTestCase, unittest.TestCase):
         self.run_bot()
         self.assertMessageEqual(0, EXAMPLE_EVENT)
         self.assertMessageEqual(11, EXAMPLE_EVENT_2)
+        self.assertMessageEqual(70, EXAMPLE_EVENT_3)
 
 if __name__ == '__main__':  # pragma: no cover
     unittest.main()


### PR DESCRIPTION
1. Ignore registry value "Other" from cymru. Provides a workaround #996 
2. Came across two types of timestamp for OTX feed
```
"modified": "2017-05-20T13:43:54"
"modified": "2017-05-20T13:43:28.563000"
```
I am not sure if this was one time system error or their lib strips sub-seconds part if it is perfect 0?
The check here fixes it only for modified time entry and other timestamps are left unchanged.  Test case for this is added as well.