### PR TITLE
Revised RIPE abuse contact expert, fix behavior of overwriting an event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ development
 ### Development
 - We are now testing with and without optional libraries/lowest recommended versions and most current versions of required libraries
 
+### Bots
+- `bots.experts.ripencc_abuse_contact` now has the two additional parameters `query_ripe_stat_asn` and `query_ripe_stat_ip`.
+  Deprecated parameter `query_ripe_stat`. New parameter `mode`.
+
 v1.0.0.dev8
 -----------
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,8 @@ See the changelog for a full list of changes.
 
 development
 -----------
+### Configuration
+- `bots.experts.ripencc_abuse_contact` now has the two additional parameters `query_ripe_stat_asn` and `query_ripe_stat_ip` instead of `query_ripe_stat`. The old parameter will be supported until version 1.1. An additional parameter `mode` has been introduced. See the bot's documentation for more details.
 
 1.0.0.dev8
 ----------

--- a/docs/Bots.md
+++ b/docs/Bots.md
@@ -710,7 +710,11 @@ Sources:
 
 #### Configuration Parameters:
 
-FIXME
+* `query_ripe_db_asn`: Query for IPs at `http://rest.db.ripe.net/abuse-contact/%s.json`, default `true`
+* `query_ripe_db_ip`: Query for ASNs at `http://rest.db.ripe.net/abuse-contact/as%s.json`, default `true`
+* `query_ripe_stat_asn`: Query for ASNs at `https://stat.ripe.net/data/abuse-contact-finder/data.json?resource=%s`, default `true`
+* `query_ripe_stat_ip`: Query for IPs at `https://stat.ripe.net/data/abuse-contact-finder/data.json?resource=%s`, default `true`
+* `mode`: either `append` (default) or `replace`
 
 * * *
 

--- a/intelmq/lib/message.py
+++ b/intelmq/lib/message.py
@@ -180,6 +180,8 @@ class Message(dict):
             raise exceptions.KeyExists(key)
 
         if value is None or value in ["", "-", "N/A"]:
+            if overwrite and key in self:
+                del self[key]
             return
 
         if not self.__is_valid_key(key):

--- a/intelmq/lib/test.py
+++ b/intelmq/lib/test.py
@@ -394,7 +394,11 @@ class BotTestCase(object):
         for logline in self.loglines:
             fields = utils.parse_logline(logline)
 
-            if levelname == fields["log_level"] and re.match(pattern, fields["message"]):
+            #  Exception tracebacks
+            if isinstance(fields, str):
+                if levelname == "ERROR" and re.match(pattern, fields):
+                    break
+            elif levelname == fields["log_level"] and re.match(pattern, fields["message"]):
                 break
         else:
             raise ValueError('No matching logline found.')

--- a/intelmq/lib/test.py
+++ b/intelmq/lib/test.py
@@ -210,14 +210,15 @@ class BotTestCase(object):
             if self.default_input_message:  # None for collectors
                 self.input_queue = [self.default_input_message]
 
-    def run_bot(self, iterations: int=1, error_on_pipeline: bool=False):
+    def run_bot(self, iterations: int=1, error_on_pipeline: bool=False, prepare=True):
         """
         Call this method for actually doing a test run for the specified bot.
 
         Parameters:
             iterations: Bot instance will be run the given times, defaults to 1.
         """
-        self.prepare_bot()
+        if prepare:
+            self.prepare_bot()
         with mock.patch('intelmq.lib.utils.load_configuration',
                         new=self.mocked_config):
             with mock.patch('intelmq.lib.utils.log', self.mocked_log):

--- a/intelmq/tests/bots/experts/ripencc_abuse_contact/test_expert.py
+++ b/intelmq/tests/bots/experts/ripencc_abuse_contact/test_expert.py
@@ -28,6 +28,15 @@ EXAMPLE_OUTPUT6 = {"__type": "Event",
                    "source.abuse_contact": "security.zid@univie.ac.at",
                    "time.observation": "2015-01-01T00:00:00+00:00",
                    }
+EMPTY_INPUT = {"__type": "Event",
+               "source.ip": "127.0.0.1",
+               "source.abuse_contact": "bla@example.com",
+               "time.observation": "2015-01-01T00:00:00+00:00",
+               }
+EMPTY_REPLACED = {"__type": "Event",
+                  "source.ip": "127.0.0.1",
+                  "time.observation": "2015-01-01T00:00:00+00:00",
+                  }
 
 
 @test.skip_internet()
@@ -47,12 +56,83 @@ class TestRIPENCCExpertBot(test.BotTestCase, unittest.TestCase):
     def test_ipv4_lookup(self):
         self.input_message = EXAMPLE_INPUT
         self.run_bot()
+        self.assertLogMatches(pattern="^The parameter 'query_ripe_stat' is deprecated and will be r",
+                              levelname="WARNING")
         self.assertMessageEqual(0, EXAMPLE_OUTPUT)
 
     def test_ipv6_lookup(self):
         self.input_message = EXAMPLE_INPUT6
         self.run_bot()
         self.assertMessageEqual(0, EXAMPLE_OUTPUT6)
+
+    def test_empty_lookup(self):
+        """ No email is returned, event should be untouched. """
+        self.input_message = EMPTY_INPUT
+        self.run_bot()
+        self.assertMessageEqual(0, EMPTY_INPUT)
+
+    @test.skip_local_web()
+    def test_ripe_stat_errors(self):
+        """ Test RIPE stat for errors. """
+        self.sysconfig = {'query_ripe_db_asn': False,
+                          'query_ripe_db_ip': False,
+                          'query_ripe_stat_asn': True,
+                          'query_ripe_stat_ip': True,
+                          }
+        self.input_message = EMPTY_INPUT
+        self.allowed_error_count = 1
+        self.prepare_bot()
+        old = self.bot.URL_STAT
+        self.bot.URL_STAT = 'http://localhost/index.html?{}'
+        self.run_bot(prepare=False)
+        self.assertLogMatches(pattern='.*JSONDecodeError.*',
+                              levelname='ERROR')
+
+        self.bot.URL_STAT = 'http://localhost/{}'
+        self.run_bot(prepare=False)
+        self.bot.URL_STAT = old
+        self.assertLogMatches(pattern='ValueError: HTTP status code was 404',
+                              levelname='ERROR')
+
+    @test.skip_local_web()
+    def test_ripe_db_as_errors(self):
+        """ Test RIPE DB AS for errors. """
+        self.sysconfig = {'query_ripe_db_asn': True,
+                          'query_ripe_db_ip': False,
+                          'query_ripe_stat': False,
+                          }
+        self.input_message = EXAMPLE_INPUT
+        self.allowed_error_count = 1
+        self.prepare_bot()
+        old = self.bot.URL_DB_AS
+        self.bot.URL_DB_AS = 'http://localhost/{}'
+        self.run_bot(prepare=False)
+        self.bot.URL_DB_AS = old
+        self.assertLogMatches(pattern='ValueError: HTTP status code was 404',
+                              levelname='ERROR')
+
+    @test.skip_local_web()
+    def test_ripe_db_ip_errors(self):
+        """ Test RIPE DB IP for errors. """
+        self.sysconfig = {'query_ripe_db_asn': False,
+                          'query_ripe_db_ip': True,
+                          'query_ripe_stat': False,
+                          }
+        self.input_message = EXAMPLE_INPUT
+        self.allowed_error_count = 1
+        self.prepare_bot()
+        old = self.bot.URL_DB_IP
+        self.bot.URL_DB_IP = 'http://localhost/{}'
+        self.run_bot(prepare=False)
+        self.bot.URL_DB_IP = old
+        self.assertLogMatches(pattern='ValueError: HTTP status code was 404',
+                              levelname='ERROR')
+
+    def test_replace(self):
+        self.sysconfig = {'mode': 'replace'}
+        self.input_message = EMPTY_INPUT
+        self.run_bot()
+        self.assertMessageEqual(0, EMPTY_REPLACED)
 
 
 if __name__ == '__main__':  # pragma: no cover

--- a/intelmq/tests/bots/experts/ripencc_abuse_contact/test_expert.py
+++ b/intelmq/tests/bots/experts/ripencc_abuse_contact/test_expert.py
@@ -83,7 +83,7 @@ class TestRIPENCCExpertBot(test.BotTestCase, unittest.TestCase):
         self.allowed_error_count = 1
         self.prepare_bot()
         old = self.bot.URL_STAT
-        self.bot.URL_STAT = 'http://localhost/index.html?{}'
+        self.bot.URL_STAT = 'https://example.com/index.html?{}'
         self.run_bot(prepare=False)
         self.assertLogMatches(pattern='.*JSONDecodeError.*',
                               levelname='ERROR')

--- a/intelmq/tests/bots/experts/ripencc_abuse_contact/test_expert.py
+++ b/intelmq/tests/bots/experts/ripencc_abuse_contact/test_expert.py
@@ -85,7 +85,7 @@ class TestRIPENCCExpertBot(test.BotTestCase, unittest.TestCase):
         old = self.bot.URL_STAT
         self.bot.URL_STAT = 'https://example.com/index.html?{}'
         self.run_bot(prepare=False)
-        self.assertLogMatches(pattern='.*JSONDecodeError.*',
+        self.assertLogMatches(pattern='.*(JSONDecodeError|ValueError).*',
                               levelname='ERROR')
 
         self.bot.URL_STAT = 'http://localhost/{}'

--- a/intelmq/tests/lib/test_message.py
+++ b/intelmq/tests/lib/test_message.py
@@ -167,6 +167,13 @@ class TestMessageFactory(unittest.TestCase):
         report.add('feed.name', None)
         self.assertNotIn('feed.name', report)
 
+    def test_report_change_delete_none(self):
+        """ Test if report ignores None. """
+        report = self.new_report()
+        report.add('feed.name', 'foo')
+        report.change('feed.name', None)
+        self.assertNotIn('feed.name', report)
+
     def test_report_ignore_empty(self):
         """ Test if report ignores empty string. """
         report = self.new_report()


### PR DESCRIPTION
* can now optionally replace existing abuse contact
* split parameter `query_ripe_stat` into `query_ripe_stat_asn` and `query_ripe_stat_ip`
* better error handling
* lib/message: overwriting something with None now has the same behavior as adding sth with None:
  if you overwrite an existing value with None/empty string, it will be deleted. Previously this did nothing.
* small fixes/additions in the tests library

and the test coverage of this bot is now 100% incl. all branches :)