### PR TITLE
[enh] bypss mechanism for deduplicator

### DIFF
--- a/intelmq/bots/experts/deduplicator/README.md
+++ b/intelmq/bots/experts/deduplicator/README.md
@@ -9,6 +9,7 @@ Bot responsible for ignore duplicated messages. The bot can be configured to per
 * `redis_cache_db` - redis db to connect (e.g. `6`)
 * `redis_cache_ttl` - ttl (in seconds) for each entry inserted on cache (e.g. `86400`)
 * `redis_cache_password` - password to access redis (by default is None)
+* `bypass` - true or false value to bypass the eduplicator. When set to true, messages will not be deduplicated.
 
 ### Parameters for "fine-grained" deduplication
 

--- a/intelmq/bots/experts/deduplicator/expert.py
+++ b/intelmq/bots/experts/deduplicator/expert.py
@@ -45,17 +45,17 @@ class DeduplicatorExpertBot(Bot):
 
         if self.bypass:
             self.send_message(message)
-
-        message_hash = message.hash(filter_keys=self.filter_keys,
-                                    filter_type=self.parameters.filter_type)
-
-        if not self.cache.exists(message_hash):
-            self.cache.set(message_hash, 'hash')
-            self.send_message(message)
         else:
-            self.logger.debug('Dropped message.')
+            message_hash = message.hash(filter_keys=self.filter_keys,
+                                        filter_type=self.parameters.filter_type)
 
-        self.acknowledge_message()
+            if not self.cache.exists(message_hash):
+                self.cache.set(message_hash, 'hash')
+                self.send_message(message)
+            else:
+                self.logger.debug('Dropped message.')
+
+            self.acknowledge_message()
 
 
 BOT = DeduplicatorExpertBot

--- a/intelmq/bots/experts/deduplicator/expert.py
+++ b/intelmq/bots/experts/deduplicator/expert.py
@@ -15,7 +15,7 @@ Parameters:
 
     filter_type: string ["blacklist", "whitelist"]
 
-    bypass: boolean
+    bypass: boolean  default: {False}
 
     filter_keys: string with multiple keys separated by comma. Please
                  note that time.observation key is never consider by the
@@ -55,7 +55,7 @@ class DeduplicatorExpertBot(Bot):
             else:
                 self.logger.debug('Dropped message.')
 
-            self.acknowledge_message()
+        self.acknowledge_message()
 
 
 BOT = DeduplicatorExpertBot

--- a/intelmq/bots/experts/deduplicator/expert.py
+++ b/intelmq/bots/experts/deduplicator/expert.py
@@ -15,6 +15,8 @@ Parameters:
 
     filter_type: string ["blacklist", "whitelist"]
 
+    bypass: boolean
+
     filter_keys: string with multiple keys separated by comma. Please
                  note that time.observation key is never consider by the
                  system because system will always ignore this key.
@@ -36,9 +38,13 @@ class DeduplicatorExpertBot(Bot):
                            )
         self.filter_keys = set(k.strip() for k in
                                self.parameters.filter_keys.split(','))
+        self.bypass = getattr(self.parameters, "bypass", False)
 
     def process(self):
         message = self.receive_message()
+
+        if self.bypass:
+            self.send_message(message)
 
         message_hash = message.hash(filter_keys=self.filter_keys,
                                     filter_type=self.parameters.filter_type)

--- a/intelmq/tests/bots/experts/deduplicator/test_expert.py
+++ b/intelmq/tests/bots/experts/deduplicator/test_expert.py
@@ -68,6 +68,22 @@ class TestDeduplicatorExpertBot(test.BotTestCase, unittest.TestCase):
         self.run_bot()
         self.assertMessageEqual(0, msg)
 
+    def test_bypass(self):
+        self.sysconfig = {"redis_cache_ttl": "86400",
+                          "filter_type": "whitelist",
+                          "filter_keys": "source.ip",
+                          "bypass": True}
+        msg = self.new_event()
+        msg.add('source.ip', '127.0.0.8')
+        msg_hash = msg.hash()
+        self.cache.set(msg_hash, 'hash')
+        self.cache.expire(msg_hash, 3600)
+
+        self.input_message = msg
+        self.run_bot()
+        self.assertMessageEqual(0, msg)
+
+
 
 if __name__ == '__main__':  # pragma: no cover
     unittest.main()


### PR DESCRIPTION
Add boolean parameter `bypass`. If set the deduplicator will simply pass along the msgs bypassing deduplication mechanism. Useful in case you dont want to change the configuration but still want to bypass deduplicator temporarily. 