### PR TITLE
add urlpath harmonization type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ CHANGELOG
 
 1.1.0
 -----
+### Harmonization
+- added destination.urlpath and source.urlpath to harmonization.
 
 1.0.0.rc2 Release candidate
 ---------------------------

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,16 @@ See the changelog for a full list of changes.
 
 1.1.0
 -----
+### Harmonization
+- added destination.urlpath and source.urlpath to harmonization.
+
+### Postgres databases
+Use the following statement carefully to upgrade your database.
+```SQL
+ALTER TABLE events
+   ADD COLUMN "destination.urlpath" text,
+   ADD COLUMN "source.urlpath" text;
+```
 
 1.0.0
 -----

--- a/docs/Harmonization-fields.md
+++ b/docs/Harmonization-fields.md
@@ -30,6 +30,7 @@ Harmonization field names
 |Destination|destination.reverse_dns|[FQDN](#fqdn)|Reverse DNS name acquired through a reverse DNS query on an IP address. N.B. Record types other than PTR records may also appear in the reverse DNS tree. Furthermore, unfortunately, there is no rule prohibiting people from writing anything in a PTR record. Even JavaScript will work. A final point is stripped, string is converted to lower case characters.|
 |Destination|destination.tor_node|[Boolean](#boolean)|If the destination IP was a known tor node.|
 |Destination|destination.url|[URL](#url)|A URL denotes on IOC, which refers to a malicious resource, whose interpretation is defined by the abuse type. A URL with the abuse type phishing refers to a phishing resource.|
+|Destination|destination.urlpath|[String](#string)|The path portion of an HTTP or related network request.|
 |Event_Description|event_description.target|[String](#string)|Some sources denominate the target (organization) of a an attack.|
 |Event_Description|event_description.text|[String](#string)|A free-form textual description of an abuse event.|
 |Event_Description|event_description.url|[URL](#url)|A description URL is a link to a further description of the the abuse event in question.|
@@ -78,6 +79,7 @@ Harmonization field names
 |Source|source.reverse_dns|[FQDN](#fqdn)|Reverse DNS name acquired through a reverse DNS query on an IP address. N.B. Record types other than PTR records may also appear in the reverse DNS tree. Furthermore, unfortunately, there is no rule prohibiting people from writing anything in a PTR record. Even JavaScript will work. A final point is stripped, string is converted to lower case characters.|
 |Source|source.tor_node|[Boolean](#boolean)|If the source IP was a known tor node.|
 |Source|source.url|[URL](#url)|A URL denotes an IOC, which refers to a malicious resource, whose interpretation is defined by the abuse type. A URL with the abuse type phishing refers to a phishing resource.|
+|Source|source.urlpath|[String](#string)|The path portion of an HTTP or related network request.|
 | |status|[String](#string)|Status of the malicious resource (phishing, dropzone, etc), e.g. online, offline.|
 |Time|time.observation|[DateTime](#datetime)|The time a source bot saw the event. This timestamp becomes especially important should you perform your own attribution on a host DNS name for example. The mechanism to denote the attributed elements with reference to the source provided is detailed below in Reported Identity IOC.(ISO8660).|
 |Time|time.source|[DateTime](#datetime)|Time reported by a source. Some sources only report a date, which may be used here if there is no better observation.|

--- a/intelmq/bots/parsers/alienvault/parser_otx.py
+++ b/intelmq/bots/parsers/alienvault/parser_otx.py
@@ -61,12 +61,17 @@ class AlienVaultOTXParserBot(Bot):
                 elif indicator["type"] == 'email':
                     event.add('source.account',
                               indicator["indicator"])
-                # URLs
+                # URLs/URIs, OTX URIs can contail both full url or only path
                 elif indicator["type"] in ['URL', 'URI']:
                     resource = indicator["indicator"] \
                         if '://' in indicator["indicator"] \
                         else 'http://' + indicator["indicator"]
-                    event.add('source.url', resource)
+                    uri_added = event.add('source.url', resource, raise_failure=False)
+                    if not uri_added:
+                        if indicator["type"] == 'URI':
+                            event.add('source.urlpath', indicator["indicator"])
+                        else:
+                            raise ValueError("Invalid value %r for URL hamonization type." % indicator["indicator"])
                 # CIDR
                 elif indicator["type"] in ['CIDR']:
                     event.add('source.network',

--- a/intelmq/bots/parsers/alienvault/parser_otx.py
+++ b/intelmq/bots/parsers/alienvault/parser_otx.py
@@ -61,7 +61,7 @@ class AlienVaultOTXParserBot(Bot):
                 elif indicator["type"] == 'email':
                     event.add('source.account',
                               indicator["indicator"])
-                # URLs/URIs, OTX URIs can contail both full url or only path
+                # URLs/URIs, OTX URIs can contain both full url or only path
                 elif indicator["type"] in ['URL', 'URI']:
                     resource = indicator["indicator"] \
                         if '://' in indicator["indicator"] \

--- a/intelmq/etc/harmonization.conf
+++ b/intelmq/etc/harmonization.conf
@@ -110,6 +110,10 @@
             "description": "A URL denotes on IOC, which refers to a malicious resource, whose interpretation is defined by the abuse type. A URL with the abuse type phishing refers to a phishing resource.",
             "type": "URL"
         },
+        "destination.urlpath": {
+            "description": "The path portion of an HTTP or related network request.",
+            "type": "String"
+        },
         "event_description.target": {
             "description": "Some sources denominate the target (organization) of a an attack.",
             "type": "String"
@@ -330,6 +334,10 @@
         "source.url": {
             "description": "A URL denotes an IOC, which refers to a malicious resource, whose interpretation is defined by the abuse type. A URL with the abuse type phishing refers to a phishing resource.",
             "type": "URL"
+        },
+        "source.urlpath": {
+            "description": "The path portion of an HTTP or related network request.",
+            "type": "String"
         },
         "status": {
             "description": "Status of the malicious resource (phishing, dropzone, etc), e.g. online, offline.",

--- a/intelmq/tests/bin/initdb.sql
+++ b/intelmq/tests/bin/initdb.sql
@@ -26,6 +26,7 @@ CREATE TABLE events (
     "destination.reverse_dns" text,
     "destination.tor_node" boolean,
     "destination.url" text,
+    "destination.urlpath" text,
     "event_description.target" text,
     "event_description.text" text,
     "event_description.url" text,
@@ -74,6 +75,7 @@ CREATE TABLE events (
     "source.reverse_dns" text,
     "source.tor_node" boolean,
     "source.url" text,
+    "source.urlpath" text,
     "status" text,
     "time.observation" timestamp with time zone,
     "time.source" timestamp with time zone

--- a/intelmq/tests/bots/experts/ripencc_abuse_contact/test_expert.py
+++ b/intelmq/tests/bots/experts/ripencc_abuse_contact/test_expert.py
@@ -91,7 +91,7 @@ class TestRIPENCCExpertBot(test.BotTestCase, unittest.TestCase):
         self.bot.URL_STAT = 'http://localhost/{}'
         self.run_bot(prepare=False)
         self.bot.URL_STAT = old
-        self.assertLogMatches(pattern='HTTP status code was 404',
+        self.assertLogMatches(pattern='.*HTTP status code was 404.*',
                               levelname='ERROR')
 
     @test.skip_local_web()
@@ -108,7 +108,7 @@ class TestRIPENCCExpertBot(test.BotTestCase, unittest.TestCase):
         self.bot.URL_DB_AS = 'http://localhost/{}'
         self.run_bot(prepare=False)
         self.bot.URL_DB_AS = old
-        self.assertLogMatches(pattern='HTTP status code was 404',
+        self.assertLogMatches(pattern='.*HTTP status code was 404.*',
                               levelname='ERROR')
 
     @test.skip_local_web()
@@ -125,7 +125,7 @@ class TestRIPENCCExpertBot(test.BotTestCase, unittest.TestCase):
         self.bot.URL_DB_IP = 'http://localhost/{}'
         self.run_bot(prepare=False)
         self.bot.URL_DB_IP = old
-        self.assertLogMatches(pattern='HTTP status code was 404',
+        self.assertLogMatches(pattern='.*HTTP status code was 404.*',
                               levelname='ERROR')
 
     def test_replace(self):

--- a/intelmq/tests/bots/parsers/alienvault/test_parser_otx.data
+++ b/intelmq/tests/bots/parsers/alienvault/test_parser_otx.data
@@ -1322,8 +1322,22 @@
 			"type": "FileHash-MD5",
 			"id": 234158,
 			"observations": 11
-		  }
-		],
+          },
+          {
+            "indicator": "http://107.6.172.54/woolen/",
+            "_id": "55e6bfb14637f22cb6057466",
+            "type": "URI",
+            "description": "",
+            "created": "2015-09-02T09:21:53.093"
+          },
+          {
+            "indicator": "/woolen/",
+            "_id": "55e6bfb14637f22cb6057466",
+            "type": "URI",
+            "description": "",
+            "created": "2015-09-02T09:21:53.093"
+          }
+     ],
 		"revision": 1,
 		"adversary": "",
 		"id": "5942175dd78f563d01abc79c",

--- a/intelmq/tests/bots/parsers/alienvault/test_parser_otx.py
+++ b/intelmq/tests/bots/parsers/alienvault/test_parser_otx.py
@@ -115,6 +115,43 @@ EXAMPLE_EVENT_4 = {
   'time.source': '2017-06-15T05:01:00+00:00'
   }
 
+EXAMPLE_EVENT_URI_1 = {
+    "__type": "Event",
+    "extra": '{"adversary": "", "author": "bschlaps", "industries": [], '
+             '"pulse": "Alert (TA17-164A)", "pulse_key": '
+             '"5942175dd78f563d01abc79c", "tags": [], "time_updated": '
+             '"2017-06-15T05:17:12.18+00:00"}',
+    "comment": "HIDDEN COBRA – North Korean Malicious Cyber Activity",
+    "feed.name": "AlienVault OTX",
+    "classification.type": "blacklist",
+    "source.url": "http://107.6.172.54/woolen/",
+    "raw": "eyJfaWQiOiAiNTVlNmJmYjE0NjM3ZjIyY2I2"
+           "MDU3NDY2IiwgImNyZWF0ZWQiOiAiMjAxNS0wO"
+           "S0wMlQwOToyMTo1My4wOTMiLCAiZGVzY3JpcH"
+           "Rpb24iOiAiIiwgImluZGljYXRvciI6ICJodHR"
+           "wOi8vMTA3LjYuMTcyLjU0L3dvb2xlbi8iLCAidHlwZSI6ICJVUkkifQ==",
+    "time.source": "2015-09-02T09:21:53+00:00",
+    "time.observation": "2015-09-02T14:17:58+00:00"
+}
+
+EXAMPLE_EVENT_URI_2 = {
+    "__type": "Event",
+    "extra": '{"adversary": "", "author": "bschlaps", "industries": [], '
+             '"pulse": "Alert (TA17-164A)", "pulse_key": '
+             '"5942175dd78f563d01abc79c", "tags": [], "time_updated": '
+             '"2017-06-15T05:17:12.18+00:00"}',
+    "comment": "HIDDEN COBRA – North Korean Malicious Cyber Activity",
+    "feed.name": "AlienVault OTX",
+    "classification.type": "blacklist",
+    "source.urlpath": "/woolen/",
+    "raw": "eyJfaWQiOiAiNTVlNmJmYjE0NjM3ZjIyY2I2MDU3NDY2IiwgImNyZWF0ZWQiOiAiMjAxNS"
+           "0wOS0wMlQwOToyMTo1My4wOTMiLCAiZGVzY3JpcHRpb24iOiAiIiwgImluZGljYXRvciI6"
+           "ICIvd29vbGVuLyIsICJ0eXBlIjogIlVSSSJ9",
+    "time.source": "2015-09-02T09:21:53+00:00",
+    "time.observation": "2015-09-02T14:17:58+00:00"
+}
+
+
 class TestAlienVaultOTXParserBot(test.BotTestCase, unittest.TestCase):
     """
     A TestCase for AlienVaultOTXParserBot.
@@ -132,6 +169,8 @@ class TestAlienVaultOTXParserBot(test.BotTestCase, unittest.TestCase):
         self.assertMessageEqual(11, EXAMPLE_EVENT_2)
         self.assertMessageEqual(70, EXAMPLE_EVENT_3)
         self.assertMessageEqual(91, EXAMPLE_EVENT_4)
+        self.assertMessageEqual(93, EXAMPLE_EVENT_URI_1)
+        self.assertMessageEqual(94, EXAMPLE_EVENT_URI_2)
 
 if __name__ == '__main__':  # pragma: no cover
     unittest.main()


### PR DESCRIPTION
Bringing this from #1037 

This PR 

- adds hamonization type for urlpath as `source.urlpath` and `destination.urlpath`. A use case for this is to consume IoCs for HTTP/Web accessible shells and backdoors.
- fixes issues with URI handling in OTX feed where a URI can contain both a url like `http://test.com/x/y/z` or just path eg `/x/y/z`.
- test cases for above.
- adds `source.urlpath` and `destination.urlpath` in initdb.sq
- add information to changelog and news
- add information to upgrade db.