### PR TITLE
Log bot's errors if failed to start and check for defaults.conf completeness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ CHANGELOG
 
 1.1.0
 -----
+### Tools
+- `intelmqctl start` prints bot's error messages if it failed to start
 
 1.0.0.rc2 Release candidate
 ---------------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 -----
 ### Tools
 - `intelmqctl start` prints bot's error messages if it failed to start
+- `intelmqctl check` checks for defaults.conf completeness
 
 1.0.0.rc2 Release candidate
 ---------------------------

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,8 @@ See the changelog for a full list of changes.
 
 1.1.0
 -----
+### Tools
+- `intelmqctl start` prints bot's error messages in stderr if it failed to start.
 
 1.0.0
 -----

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@ See the changelog for a full list of changes.
 -----
 ### Tools
 - `intelmqctl start` prints bot's error messages in stderr if it failed to start.
+- `intelmqctl check` checks if all keys in the packaged defaults.conf are present in the current configuration.
 
 1.0.0
 -----

--- a/intelmq/bin/intelmqctl.py
+++ b/intelmq/bin/intelmqctl.py
@@ -838,6 +838,12 @@ Outputs are additionally logged to /opt/intelmq/var/log/intelmqctl'''
             self.logger.error('Fatal errors occurred.')
             return retval
 
+        self.logger.info('Checking defaults configuration.')
+        with open(pkg_resources.resource_filename('intelmq', 'etc/defaults.conf')) as fh:
+            defaults = json.load(fh)
+        keys = set(defaults.keys()) - set(files[DEFAULTS_CONF_FILE].keys())
+        self.logger.error("Keys missing in your 'defaults.conf' file: %r", keys)
+
         self.logger.info('Checking runtime configuration.')
         http_proxy = files[DEFAULTS_CONF_FILE].get('http_proxy')
         https_proxy = files[DEFAULTS_CONF_FILE].get('https_proxy')

--- a/intelmq/bin/intelmqctl.py
+++ b/intelmq/bin/intelmqctl.py
@@ -249,7 +249,7 @@ class IntelMQProcessManager:
 
         if self.controller._is_enabled(bot_id):
             log_bot_message('stopped', bot_id)
-            if proc:
+            if proc and RETURN_TYPE == 'text':
                 log = proc.stderr.read().decode()
                 if not log:  # if nothing in stderr, print stdout
                     log = proc.stdout.read().decode()

--- a/intelmq/lib/bot.py
+++ b/intelmq/lib/bot.py
@@ -279,7 +279,10 @@ class Bot(object):
         for level, message in self.__log_buffer:
             if self.logger:
                 getattr(self.logger, level)(message)
-            print(level.upper(), '-', message)
+            if level in ['WARNING', 'ERROR', 'critical']:
+                print(level.upper(), '-', message, file=sys.stderr)
+            else:
+                print(level.upper(), '-', message)
         self.__log_buffer = []
 
     def __check_bot_id(self, name: str):


### PR DESCRIPTION
fixes certtools/intelmq#1021

I am using `proc.status()` in `IntelMQProcessManager.bot_status` if possible to get a more accurate result. But that's only implemented for the start of a single bot now.
Looks like this now:
```
> intelmqctl start abusech-domain-parser 
intelmqctl: Starting abusech-domain-parser...
intelmqctl: abusech-domain-parser is stopped.
CRITICAL - Traceback (most recent call last):
  File "/home/sebastian/dev/intelmq/intelmq/lib/bot.py", line 57, in __init__
    self.__load_defaults_configuration()
  File "/home/sebastian/dev/intelmq/intelmq/lib/bot.py", line 420, in __load_defaults_configuration
    self.parameters.log_processed_messages_seconds = datetime.timedelta(seconds=self.parameters.log_processed_messages_seconds)
AttributeError: 'Parameters' object has no attribute 'log_processed_messages_seconds'
```

And:
```
> intelmqctl check
intelmqctl: Reading configuration files.
intelmqctl: Checking defaults configuration.
intelmqctl: Keys missing in your 'defaults.conf' file: {'http_timeout_max_tries', 'log_processed_messages_count', 'http_timeout_sec', 'log_processed_messages_seconds'}
intelmqctl: Checking runtime configuration.
intelmqctl: Checking pipeline configuration.
intelmqctl: Checking for bots.
intelmqctl: No issues found.
```