### PR TITLE
BUG: ctl: handle already removed PID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ CHANGELOG
 
 1.0.0.rc2 Release candidate
 ---------------------------
+### Core
+- Fixes a thrown FileNotFound exception when stopping bots started with `intelmqctl run ...`
+
 ### Harmonization
 - leading dots in FQDNs are rejected and removed in sanitation (#1022, #1030)
 

--- a/intelmq/bin/intelmqctl.py
+++ b/intelmq/bin/intelmqctl.py
@@ -204,7 +204,10 @@ class IntelMQProcessManager:
                 if self.__status_process(pid):
                     log_bot_error('running', bot_id)
                     return 'running'
-                self.__remove_pidfile(bot_id)
+                try:
+                    self.__remove_pidfile(bot_id)
+                except FileNotFoundError:  # Bot was running interactively and file has been removed already
+                    pass
                 log_bot_message('stopped', bot_id)
                 return 'stopped'
 


### PR DESCRIPTION
When running `intelmqctl run bot-id` and stopping/killing bot-id in parallel, this threw a FileNotFound exception. As we can't handle this in `bot_run` (It does not know who killed it), we need to implement this check in `bot_stop`.