### PR TITLE
Use SIGTERM to stop bots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ CHANGELOG
 
 1.0.0.rc2 Release candidate
 ---------------------------
+### Core
+- use SIGTERM instead of SIGINT to stop bots (#981)
+
 ### Harmonization
 - leading dots in FQDNs are rejected and removed in sanitation (#1022, #1030)
 

--- a/intelmq/bin/intelmqctl.py
+++ b/intelmq/bin/intelmqctl.py
@@ -194,7 +194,7 @@ class IntelMQProcessManager:
         log_bot_message('stopping', bot_id)
         proc = psutil.Process(int(pid))
         try:
-            proc.send_signal(signal.SIGINT)
+            proc.send_signal(signal.SIGTERM)
         except psutil.AccessDenied:
             log_bot_error('access denied', bot_id, 'STOP')
             return 'running'

--- a/intelmq/lib/bot.py
+++ b/intelmq/lib/bot.py
@@ -79,6 +79,7 @@ class Bot(object):
             signal.signal(signal.SIGHUP, self.__handle_sighup_signal)
             # system calls should not be interrupted, but restarted
             signal.siginterrupt(signal.SIGHUP, False)
+            signal.signal(signal.SIGTERM, self.__handle_sigterm_signal)
         except Exception as exc:
             if self.parameters.error_log_exception:
                 self.logger.exception('Bot initialization failed.')
@@ -88,6 +89,14 @@ class Bot(object):
 
             self.stop()
             raise
+
+    def __handle_sigterm_signal(self, signum: int, stack: Optional[object]):
+        """
+        Calles when a SIGTERM is received. Stops the bot.
+        """
+        self.logger.info("Received SIGTERM.")
+        self.stop(exitcode=0)
+        del self
 
     def __handle_sighup_signal(self, signum: int, stack: Optional[object]):
         """


### PR DESCRIPTION
Sigint can be captured by parent processes

fixes certtools/intelmq#981
fixes certtools/intelmq-manager#103

See also https://unix.stackexchange.com/questions/149741/why-is-sigint-not-propagated-to-child-process-when-sent-to-its-parent-process