### PR TITLE
Added modify rule for ramnit

### DIFF
--- a/intelmq/bots/experts/modify/examples/morefeeds.conf
+++ b/intelmq/bots/experts/modify/examples/morefeeds.conf
@@ -226,6 +226,15 @@
         }
     },
     {
+        "rulename": "ramnit",
+        "if": {
+            "malware.name": "^ramnit-0x.*$"
+        },
+        "then": {
+            "classification.identifier": "ramnit"
+        }
+    },
+    {
         "rulename": "default",
         "if": {
             "malware.name": ".*",


### PR DESCRIPTION
Added modify expert rule for different "ramnit" malware names (like "ramnit-0xe371bf19") in Shadowserver Botnet Drone feed.