### PR TITLE
Call bot check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ CHANGELOG
   event['extra'] # gives '{"foo": "bar"}'
   "Old" bots and configurations compatible with 1.0.x do still work.
   Also, the extra field is now properly exploded when exporting events, analogous to all other fields.
+- Bots can specify a static method `check(parameters)` which can perform individual checks specific to the bot.
+  These functions will be called by `intelmqctl check` if the bot is configured with the given parameters
 
 ### Bots
 #### Collectors

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ CHANGELOG
 - changed feednames in `bots.parsers.shadowserver`. Please refer to it's README for the exact changes.
 
 ### Requirements
-- Requests is no longer a listed as dependency of the core. For depending bots the requirement is noted in their REQUIREMENTS.txt file
+- Requests is no longer listed as dependency of the core. For depending bots the requirement is noted in their REQUIREMENTS.txt file
 
 1.0.1 Bugfix release
 --------------------
@@ -44,7 +44,7 @@ CHANGELOG
 - lib/bot: Bots will now log the used intelmq version at startup
 
 ### Tools
-- intelmqctl: To check the status of a bot, the comandline of the running process is compared to the actual executable of the bot. Otherwise unrelated programs with the same PID are detected as running bot.
+- intelmqctl: To check the status of a bot, the command line of the running process is compared to the actual executable of the bot. Otherwise unrelated programs with the same PID are detected as running bot.
 - intelmqctl: enable, disable, check, clear now support the JSON output
 
 1.0.0 Stable release

--- a/docs/Developers-Guide.md
+++ b/docs/Developers-Guide.md
@@ -37,6 +37,7 @@
     * [How to Log](#how-to-log)
   * [Error handling](#error-handling)
   * [Initialization](#initialization)
+  * [Custom configuration checks](#custom-configuration-checks)
   * [Examples](#examples)
   * [Parsers](#parsers)
   * [Tests](#tests)
@@ -479,6 +480,22 @@ class ExampleParserBot(Bot):
             self.logger.error("Read 'bots/experts/asn_lookup/README.md' and "
                               "follow the procedure.")
             self.stop()
+```
+
+## Custom configuration checks
+
+Every bot can define a static method `check(parameters)` which will be called by `intelmqctl check`.
+For example the check function of the ASNLookupExpert:
+
+```python
+    @staticmethod
+    def check(parameters):
+        if not os.path.exists(parameters.get('database', '')):
+            return [["error", "File given as parameter 'database' does not exist."]]
+        try:
+            pyasn.pyasn(parameters['database'])
+        except Exception as exc:
+            return [["error", "Error reading database: %r." % exc]]
 ```
 
 ## Examples

--- a/intelmq/bots/experts/asn_lookup/expert.py
+++ b/intelmq/bots/experts/asn_lookup/expert.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-"""
-"""
+import os
+
 from intelmq.lib.bot import Bot
 
 try:
@@ -46,6 +46,15 @@ class ASNLookupExpertBot(Bot):
 
         self.send_message(event)
         self.acknowledge_message()
+
+    @staticmethod
+    def check(parameters):
+        if not os.path.exists(parameters.get('database', '')):
+            return [["error", "File given as parameter 'database' does not exist."]]
+        try:
+            pyasn.pyasn(parameters['database'])
+        except Exception as exc:
+            return [["error", "Error reading database: %r." % exc]]
 
 
 BOT = ASNLookupExpertBot

--- a/intelmq/bots/outputs/file/output.py
+++ b/intelmq/bots/outputs/file/output.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import io
+import os
 
 from intelmq.lib.bot import Bot
 
@@ -26,6 +27,14 @@ class FileOutputBot(Bot):
 
     def shutdown(self):
         self.file.close()
+
+    @staticmethod
+    def check(parameters):
+        if 'file' not in parameters:
+            return [["error", "Parameter 'file' not given."]]
+        dirname = os.path.dirname(parameters['file'])
+        if not os.path.exists(dirname):
+            return [["error", "Directory (%r) of parameter 'file' does not exist." % dirname]]
 
 
 BOT = FileOutputBot

--- a/intelmq/lib/bot.py
+++ b/intelmq/lib/bot.py
@@ -21,7 +21,7 @@ from intelmq import (DEFAULT_LOGGING_PATH, DEFAULTS_CONF_FILE,
 from intelmq.lib import exceptions, utils
 import intelmq.lib.message as libmessage
 from intelmq.lib.pipeline import PipelineFactory
-from typing import Any, Optional
+from typing import Any, Optional, List
 
 __all__ = ['Bot', 'CollectorBot', 'ParserBot']
 
@@ -540,6 +540,23 @@ class Bot(object):
         self.http_timeout_max_tries = self.http_timeout_max_tries if self.http_timeout_max_tries >= 1 else 1
 
         self.http_header['User-agent'] = self.parameters.http_user_agent
+
+    @staticmethod
+    def check(parameters: dict) -> Optional[List[List[str]]]:
+        """
+        The bot's own check function can perform individual checks on it's
+        parameters.
+        `init()` is *not* called before, this is a staticmethod which does not
+        require class initialization.
+
+        Parameters:
+            parameters: Bot's parameters, defaults and runtime merged together
+
+        Returns:
+            output: None or a list of [log_level, log_message] pairs, both
+                strings. log_level must be a valid log level.
+        """
+        pass
 
 
 class ParserBot(Bot):


### PR DESCRIPTION
Bots can specify a static method `check(parameters)` which can perform individual checks specific to the bot. These functions will be called by `intelmqctl check` if the bot is configured with the given parameters.

Needed for antoinet/intelmq#20 / https://github.com/certtools/intelmq/pull/1083#discussion-diff-136086094R146