### PR TITLE
lib/Message: overwrite parameter enhancement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ CHANGELOG
   event['extra'] # gives '{"foo": "bar"}'
   "Old" bots and configurations compatible with 1.0.x do still work.
   Also, the extra field is now properly exploded when exporting events, analogous to all other fields.
+- intelmq.lib.message.Message.add: The parameter overwrite accepts now three different values: True, False and None (new).
+  True: An existing value will be overwritten
+  False: An existing value will not be overwritten (previously and exception has been raised when the value was raised).
+  None (default): If the value exists an KeyExists Exception is thrown (previously the same as False).
+  This allows shorter code in the bots, as an 'overwrite' configuration parameter can be directly passed to the function.
 
 ### Bots
 #### Collectors

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ CHANGELOG
 ### Bots
 #### Collectors
 - Mail: New parameters; `sent_from`: filter messages by sender, `sent_to`: filter messages by recipient
+- bots.experts.maxmind_geoip: New (optional) parameter `overwrite`, by default false. The current default was to overwrite!
 
 ### Harmonization
 - Renamed `JSON` to `JSONDict` and added a new type `JSON`. `JSONDict` saves data internally as JSON, but acts like a dictionary. `JSON` accepts any valid JSON.

--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,9 @@ The feed names in the shadowserver parser have been adapted to the current subje
 * `Ssl-Freak-Scan` to `SSL-FREAK-Vulnerable-Servers`
 * `Ssl-Scan` to `SSL-POODLE-Vulnerable-Servers`
 
+The Maxmind GeoIP expert did previously always overwrite existing data. A new parameter `overwrite` has been added,
+which is by default set to `false` to be consistent with other bots.
+
 ### Postgres databases
 The following statements optionally update existing data.
 Please check if you did use these feed names and eventually adapt them for your setup!

--- a/intelmq/bots/BOTS
+++ b/intelmq/bots/BOTS
@@ -523,7 +523,8 @@
             "description": "MaxMind GeoIP is the bot responsible for adding geolocation information to events (Country, City, Longitude, Latitude, etc..)",
             "module": "intelmq.bots.experts.maxmind_geoip.expert",
             "parameters": {
-                "database": "/opt/intelmq/var/lib/bots/maxmind_geoip/GeoLite2-City.mmdb"
+                "database": "/opt/intelmq/var/lib/bots/maxmind_geoip/GeoLite2-City.mmdb",
+                "overwrite": false
             }
         },
         "Modify": {

--- a/intelmq/bots/experts/maxmind_geoip/expert.py
+++ b/intelmq/bots/experts/maxmind_geoip/expert.py
@@ -24,6 +24,7 @@ class GeoIPExpertBot(Bot):
             self.logger.error("Read 'bots/experts/geoip/README' and follow the"
                               " procedure.")
             self.stop()
+        self.overwrite = getattr(self.parameters, 'overwrite', False)
 
     def process(self):
         event = self.receive_message()
@@ -41,18 +42,19 @@ class GeoIPExpertBot(Bot):
 
                 if info.country.iso_code:
                     event.add(geo_key % "cc", info.country.iso_code,
-                              overwrite=True)
+                              overwrite=self.parameters)
 
                 if info.location.latitude:
                     event.add(geo_key % "latitude", info.location.latitude,
-                              overwrite=True)
+                              overwrite=self.parameters)
 
                 if info.location.longitude:
                     event.add(geo_key % "longitude", info.location.longitude,
-                              overwrite=True)
+                              overwrite=self.parameters)
 
                 if info.city.name:
-                    event.add(geo_key % "city", info.city.name, overwrite=True)
+                    event.add(geo_key % "city", info.city.name,
+                              overwrite=self.parameters)
 
             except geoip2.errors.AddressNotFoundError:
                 pass

--- a/intelmq/tests/lib/test_message.py
+++ b/intelmq/tests/lib/test_message.py
@@ -222,14 +222,6 @@ class TestMessageFactory(unittest.TestCase):
         with self.assertRaises(exceptions.KeyExists):
             report.add('raw', LOREM_BASE64)
 
-    def test_report_add_duplicate_force(self):
-        """ Test if report can add raw value. """
-        report = self.new_report(auto=True)
-        report.add('raw', LOREM_BASE64, sanitize=False)
-        report.add('raw', DOLOR_BASE64, overwrite=True, sanitize=False)
-        self.assertDictContainsSubset({'raw': DOLOR_BASE64},
-                                      report)
-
     def test_report_del_(self):
         """ Test if report can del a value. """
         report = self.new_report()
@@ -656,6 +648,32 @@ class TestMessageFactory(unittest.TestCase):
         with self.assertRaises(KeyError):
             event['extra.foo']
 
+    def test_overwrite_true(self):
+        """
+        Test if values can be overwritten.
+        """
+        event = self.new_event()
+        event.add('comment', 'foo')
+        event.add('comment', 'bar', overwrite=True)
+        self.assertEqual(event['comment'], 'bar')
+
+    def test_overwrite_none(self):
+        """
+        Test if exception is raised when values exist and can't be overwritten.
+        """
+        event = self.new_event()
+        event.add('comment', 'foo')
+        with self.assertRaises(exceptions.KeyExists):
+            event['comment'] = 'bar'
+
+    def test_overwrite_false(self):
+        """
+        Test if values are not overwritten.
+        """
+        event = self.new_event()
+        event.add('comment', 'foo')
+        event.add('comment', 'bar', overwrite=False)
+        self.assertEqual(event['comment'], 'foo')
 
 
 if __name__ == '__main__':  # pragma: no cover


### PR DESCRIPTION
Description from the changelog:
> - intelmq.lib.message.Message.add: The parameter overwrite accepts now three different values: True, False and None (new).
>   True: An existing value will be overwritten
>  False: An existing value will not be overwritten (previously and exception has been raised when the value was raised).
>   None (default): If the value exists an KeyExists Exception is thrown (previously the same as False).
>   This allows shorter code in the bots, as an 'overwrite' configuration parameter can be directly passed to the function.

You can then pass a given configuration parameter directly to the `add()` function, for example here shown for the maxmind expert.