### PR TITLE
deduplication bypass default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,7 +66,7 @@ CHANGELOG
 - `bots.parsers.alienvault.parser_otx`: handle timestamps without floating point seconds
 
 ### Experts
-- bots.experts.deduplicator: New parameter `bypass` to deactivate deduplication, default: true
+- bots.experts.deduplicator: New parameter `bypass` to deactivate deduplication, default: False
 
 v1.0.0.dev8
 -----------


### PR DESCRIPTION
I think, the default value should be False (as seen in the code at https://github.com/certtools/intelmq/blob/master/intelmq/bots/experts/deduplicator/expert.py line 41)