### PR TITLE
BUG: fix saving extra.* as string for postgres

### DIFF
--- a/docs/Bots.md
+++ b/docs/Bots.md
@@ -854,10 +854,11 @@ for the versions you are using.
 * `connect_timeout`: PostgreSQL connect_timeout, optional, default 5 seconds
 * `database`: PostgreSQL database
 * `host`: PostgreSQL host
+* `jsondict_as_string`: save JSONDict fields as JSON string, boolean. Default: true (like in versions before 1.1)
 * `port`: PostgreSQL port
 * `user`: PostgreSQL user
 * `password`: PostgreSQL password
-* `sslmode`: PostgreSQL sslmode
+* `sslmode`: PostgreSQL sslmode, can be `'disable'`, `'allow'`, `'prefer'` (default), `'require'`, `'verify-ca'` or `'verify-full'`. See postgresql docs: https://www.postgresql.org/docs/current/static/libpq-connect.html#libpq-connect-sslmode
 * `table`: name of the database table into which events are to be inserted
 
 #### Installation Requirements

--- a/intelmq/bots/BOTS
+++ b/intelmq/bots/BOTS
@@ -665,6 +665,7 @@
                 "autocommit": true,
                 "database": "intelmq-events",
                 "host": "localhost",
+                "jsondict_as_string": true,
                 "password": "<password>",
                 "port": "5432",
                 "sslmode": "require",

--- a/intelmq/tests/bots/outputs/postgresql/test_output.py
+++ b/intelmq/tests/bots/outputs/postgresql/test_output.py
@@ -18,6 +18,11 @@ INPUT1 = {"__type": "Event",
           "source.ip": "192.0.2.1",
           "feed.name": "Example Feed",
           }
+INPUT_EXTRA = {"__type": "Event",
+               "classification.type": "vulnerable service",
+               "extra.asn": 64496,
+               "extra.ip": "192.0.2.1",
+               }
 
 
 @test.skip_database()
@@ -32,7 +37,7 @@ class TestPostgreSQLOutputBot(test.BotTestCase, unittest.TestCase):
                          "database": "intelmq",
                          "user": "intelmq",
                          "password": "intelmq",
-                         "sslmode": "require",
+                         "sslmode": "allow",
                          "table": "tests"}
         if not os.environ.get('INTELMQ_TEST_DATABASES'):
             return
@@ -49,11 +54,23 @@ class TestPostgreSQLOutputBot(test.BotTestCase, unittest.TestCase):
     def test_event(self):
         self.run_bot()
         self.cur.execute('SELECT "classification.identifier", "classification.type", "source.asn",'
-                         ' "source.ip", "feed.name" FROM tests')
+                         ' "source.ip", "feed.name" FROM tests WHERE "source.asn" = 64496')
         self.assertEqual(self.cur.rowcount, 1)
         del INPUT1['__type']
         from_db = {k: v for k, v in self.cur.fetchone().items() if v is not None}
         self.assertDictEqual(from_db, INPUT1)
+
+    def test_extra(self):
+        """
+        Test if extra.* fields are saved as one column according to jsondict_as_string parameter.
+        jsondict_as_string is True by default.
+        """
+        self.input_message = INPUT_EXTRA
+        self.run_bot()
+        self.cur.execute('SELECT "extra" FROM tests WHERE "classification.type" = \'vulnerable service\'')
+        self.assertEqual(self.cur.rowcount, 1)
+        from_db = {k: v for k, v in self.cur.fetchone().items() if v is not None}
+        self.assertEqual(from_db['extra'], {"asn": 64496, "ip": "192.0.2.1"})
 
     @classmethod
     def tearDownClass(cls):

--- a/intelmq/tests/lib/test_message.py
+++ b/intelmq/tests/lib/test_message.py
@@ -675,6 +675,14 @@ class TestMessageFactory(unittest.TestCase):
         event.add('comment', 'bar', overwrite=False)
         self.assertEqual(event['comment'], 'foo')
 
+    def test_to_dict_jsondict_as_string(self):
+        """
+        Test if to_dict(jsondict_as_string) works correctly.
+        """
+        event = self.new_event()
+        event.add('extra.foo', 'bar')
+        self.assertDictEqual(event.to_dict(hierarchical=False, jsondict_as_string=True),
+                             {'extra': '{"foo": "bar"}'})
 
 if __name__ == '__main__':  # pragma: no cover
     unittest.main()


### PR DESCRIPTION
* fixes certools/intelmq#1107
* introduced a new parameter jsondict_as_string for the postgresql output bot with a useful default
* new parameter jsondict_as_string for `Message.to_dict`