### PR TITLE
bots: ignore NULL bytes in all csv parsers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
 
 ### Bots
 #### Parsers
+- All CSV parsers ignore NULL-bytes now, because the csv-library cannot handle it (#967)
 - Modify Bot default ruleset: changed conficker rule to catch more spellings
 
 ### Documentation

--- a/intelmq/bots/parsers/abusech/parser_ransomware.py
+++ b/intelmq/bots/parsers/abusech/parser_ransomware.py
@@ -23,6 +23,7 @@ class AbuseCHRansomwaretrackerParserBot(Bot):
 
         report = self.receive_message()
         raw_report = utils.base64_decode(report.get("raw"))
+        raw_report = raw_report.translate({0: None})
 
         for row in csv.reader(io.StringIO(raw_report)):
             if row[0].startswith('#'):

--- a/intelmq/bots/parsers/generic/parser_csv.py
+++ b/intelmq/bots/parsers/generic/parser_csv.py
@@ -50,6 +50,7 @@ class GenericCsvParserBot(ParserBot):
 
     def parse(self, report):
         raw_report = utils.base64_decode(report.get("raw"))
+        raw_report = raw_report.translate({0: None})
         # ignore lines starting with #
         raw_report = re.sub(r'(?m)^#.*\n?', '', raw_report)
         # ignore null bytes

--- a/intelmq/bots/parsers/phishtank/parser.py
+++ b/intelmq/bots/parsers/phishtank/parser.py
@@ -22,6 +22,7 @@ class PhishTankParserBot(Bot):
                    ]
 
         raw_report = utils.base64_decode(report.get("raw"))
+        raw_report = raw_report.translate({0: None})
         for row in csv.reader(io.StringIO(raw_report)):
 
             if not len(row):  # csv module can give empty lists

--- a/intelmq/bots/parsers/shadowserver/parser.py
+++ b/intelmq/bots/parsers/shadowserver/parser.py
@@ -49,7 +49,6 @@ class ShadowserverParserBot(ParserBot):
 
     def parse(self, report):
         raw_report = utils.base64_decode(report["raw"])
-        # Temporary fix for https://github.com/certtools/intelmq/issues/967
         raw_report = raw_report.translate({0: None})
         csvr = csv.DictReader(io.StringIO(raw_report))
 

--- a/intelmq/bots/parsers/turris/parser.py
+++ b/intelmq/bots/parsers/turris/parser.py
@@ -20,6 +20,7 @@ class TurrisGreylistParserBot(Bot):
 
         headers = True
         raw_report = utils.base64_decode(report.get("raw"))
+        raw_report = raw_report.translate({0: None})
         for row in csv.reader(io.StringIO(raw_report)):
             # ignore headers
             if headers:

--- a/intelmq/lib/bot.py
+++ b/intelmq/lib/bot.py
@@ -545,6 +545,7 @@ class ParserBot(Bot):
         A basic CSV parser.
         """
         raw_report = utils.base64_decode(report.get("raw")).strip()
+        raw_report = raw_report.translate({0: None})
         if self.ignore_lines_starting:
             raw_report = '\n'.join([line for line in raw_report.splitlines()
                                     if not any([line.startswith(prefix) for prefix
@@ -558,6 +559,7 @@ class ParserBot(Bot):
         A basic CSV Dictionary parser.
         """
         raw_report = utils.base64_decode(report.get("raw")).strip()
+        raw_report = raw_report.translate({0: None})
         if self.ignore_lines_starting:
             raw_report = '\n'.join([line for line in raw_report.splitlines()
                                     if not any([line.startswith(prefix) for prefix


### PR DESCRIPTION
fixes certtools/intelmq#967