### PR TITLE
Debug logging of response text for restapi bot

### DIFF
--- a/intelmq/bots/outputs/restapi/output.py
+++ b/intelmq/bots/outputs/restapi/output.py
@@ -34,7 +34,10 @@ class RestAPIOutputBot(Bot):
                               cert=self.ssl_client_cert,
                               timeout=self.http_timeout_sec,
                               **kwargs)
-        r.raise_for_status()
+        if self.parameters.logging_level in ["DEBUG", 10] and r.status_code != 200:
+            self.logger.debug("Something failed during message sending with response body {}".format(r.text))
+        else:
+            r.raise_for_status()
         self.logger.debug('Sent message.')
         self.acknowledge_message()
 

--- a/intelmq/bots/outputs/restapi/output.py
+++ b/intelmq/bots/outputs/restapi/output.py
@@ -34,13 +34,9 @@ class RestAPIOutputBot(Bot):
                               cert=self.ssl_client_cert,
                               timeout=self.http_timeout_sec,
                               **kwargs)
-        if self.parameters.logging_level in ["DEBUG", 10] and r.status_code != 200:
-            try:
-                self.logger.debug("Something failed during message sending with response body {}".format(r.text))
-            except Exception as e:
-                self.logger.debug("There was an error in your message, but there was no response text {}".format(e))
-        else:
-            r.raise_for_status()
+        if not r.ok:
+            self.logger.debug("Error during message sending with response body: %r.", r.text)
+        r.raise_for_status()
         self.logger.debug('Sent message.')
         self.acknowledge_message()
 

--- a/intelmq/bots/outputs/restapi/output.py
+++ b/intelmq/bots/outputs/restapi/output.py
@@ -35,7 +35,10 @@ class RestAPIOutputBot(Bot):
                               timeout=self.http_timeout_sec,
                               **kwargs)
         if self.parameters.logging_level in ["DEBUG", 10] and r.status_code != 200:
-            self.logger.debug("Something failed during message sending with response body {}".format(r.text))
+            try:
+                self.logger.debug("Something failed during message sending with response body {}".format(r.text))
+            except Exception as e:
+                self.logger.debug("There was an error in your message, but there was no response text {}".format(e))
         else:
             r.raise_for_status()
         self.logger.debug('Sent message.')


### PR DESCRIPTION
This PR ads the option to log response texts while the bot runs in debug mode. This option might be helpful while debugging the interaction between intelmq and intelmq "consumer". 
Description: If the logging level of bot/intelmq is set to debug and response is not success (HTTP 200), the bot tries to log the response text.