### PR TITLE
FIX: adapt cymru whois expert tests

### DIFF
--- a/intelmq/tests/bots/experts/cymru_whois/test_expert.py
+++ b/intelmq/tests/bots/experts/cymru_whois/test_expert.py
@@ -71,8 +71,8 @@ EXAMPLE_6TO4_INPUT = {"__type": "Event",
 EXAMPLE_6TO4_OUTPUT = {"__type": "Event",
                   "source.ip": "2002:3ee0:3972:0001::1",
                   "source.network": "2002::/16",
-                  "source.asn": 1103,
-                  "source.as_name": "SURFNET-NL SURFnet, The Netherlands, NL",
+                  "source.asn": 6939,
+                  "source.as_name": "HURRICANE - Hurricane Electric, Inc., US",
                   "time.observation": "2015-01-01T00:00:00+00:00",
                   }
 


### PR DESCRIPTION
```
# whois -h whois.cymru.com '-v 2002:3ee0:3972:0001::1'
AS      | IP                                       | BGP Prefix          | CC | Registry | Allocated  | AS Name
6939    | 2002:3ee0:3972:0001::1                   | 2002::/16           |    | other    |            | HURRICANE - Hurricane Electric, Inc., US
```