### PR TITLE
stop for redis "OOM command not allowed when used memory > 'maxmemory'."

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ CHANGELOG
 
 ### Core
 - warnings of bots are catched by the logger (#1074)
+- Bots stop when redis gives the error "OOM command not allowed when used memory > 'maxmemory'.".
 
 ### Bots
 #### Collectors

--- a/intelmq/lib/bot.py
+++ b/intelmq/lib/bot.py
@@ -160,7 +160,7 @@ class Bot(object):
             except Exception as exc:
                 # in case of serious system issues, exit immediately
                 if isinstance(exc, MemoryError):
-                    self.logger.exception('Out of memory. Exit immediately.')
+                    self.logger.exception('Out of memory. Exit immediately. Reason: %r.' % exc.args[0])
                     self.stop()
                 elif isinstance(exc, (IOError, OSError)) and exc.errno == 28:
                     self.logger.exception('Out of disk space. Exit immediately.')

--- a/intelmq/lib/pipeline.py
+++ b/intelmq/lib/pipeline.py
@@ -109,8 +109,9 @@ class Redis(Pipeline):
             try:
                 self.pipe.lpush(destination_queue, message)
             except Exception as exc:
-                if 'Cannot assign requested address' in exc.args[0]:
-                    raise MemoryError
+                if 'Cannot assign requested address' in exc.args[0] or\
+                   "OOM command not allowed when used memory > 'maxmemory'." in exc.args[0]:
+                    raise MemoryError(exc.args[0])
                 elif 'Redis is configured to save RDB snapshots, but is currently not able to persist on disk' in exc.args[0]:
                     raise IOError(28, 'No space left on device. Redis can\'t save its snapshots.')
                 raise exceptions.PipelineError(exc)
@@ -124,8 +125,9 @@ class Redis(Pipeline):
                 try:
                     self.pipe.lpush(destination_queue, message)
                 except Exception as exc:
-                    if 'Cannot assign requested address' in exc.args[0]:
-                        raise MemoryError
+                    if 'Cannot assign requested address' in exc.args[0] or\
+                       "OOM command not allowed when used memory > 'maxmemory'." in exc.args[0]:
+                        raise MemoryError(exc.args[0])
                     elif 'Redis is configured to save RDB snapshots, but is currently not able to persist on disk' in exc.args[0]:
                         raise IOError(28, 'No space left on device. Redis can\'t save its snapshots.')
                     raise exceptions.PipelineError(exc)


### PR DESCRIPTION
reported as https://lists.cert.at/pipermail/intelmq-users/2017-December/000022.html