### PR TITLE
Extra log line during dumping message process

### DIFF
--- a/intelmq/lib/bot.py
+++ b/intelmq/lib/bot.py
@@ -604,7 +604,10 @@ class ParserBot(Bot):
             self.acknowledge_message()
             return
 
-        for line in self.parse(report):
+        lines = self.parse(report)
+
+        for line in lines:
+
             if not line:
                 continue
             try:
@@ -620,6 +623,8 @@ class ParserBot(Bot):
             report_dump = report.copy()
             report_dump.change('raw', self.recover_line(line))
             self._dump_message(exc, report_dump)
+
+        self.logger.info('Processed %d lines and %d error(s) found.' % (len(lines), len(self.__failed)))
 
         self.acknowledge_message()
 

--- a/intelmq/lib/bot.py
+++ b/intelmq/lib/bot.py
@@ -604,9 +604,9 @@ class ParserBot(Bot):
             self.acknowledge_message()
             return
 
-        lines = self.parse(report)
+        events_count = 0
 
-        for line in lines:
+        for line in self.parse(report):
 
             if not line:
                 continue
@@ -617,6 +617,7 @@ class ParserBot(Bot):
                 self.logger.exception('Failed to parse line.')
                 self.__failed.append((traceback.format_exc(), line))
             else:
+                events_count += len(events)
                 self.send_message(*events)
 
         for exc, line in self.__failed:
@@ -624,7 +625,7 @@ class ParserBot(Bot):
             report_dump.change('raw', self.recover_line(line))
             self._dump_message(exc, report_dump)
 
-        self.logger.info('Processed %d lines and %d error(s) found.' % (len(lines), len(self.__failed)))
+        self.logger.info('Sent %d events and found %d error(s).' % (len(events_count), len(self.__failed)))
 
         self.acknowledge_message()
 


### PR DESCRIPTION
The only "small" reason for the additional line is just to help users on the same problem as I had which is:

A parser bot is processing thousands of lines and in the middle of the process, parser found one line with an error and automatically wrote a log message about it but continued. In the end, after all thousand lines processed, the log file is full of messages saying `INFO - Processed 500 messages since last logging.` and in the end has an additional log message saying `INFO - Dumping message from pipeline to dump file.`. 

In my perspective, before the log line `INFO - Dumping message from pipeline to dump file.`, bot should write another log line mentioning the issue with the specific message that is about to dump in order to alert the user that need to check all log file looking for that error. Otherwise the user may have difficulties to understand where the dump message came from after all processed lines.