### PR TITLE
CleanMX Fix

### DIFF
--- a/intelmq/bots/parsers/cleanmx/parser.py
+++ b/intelmq/bots/parsers/cleanmx/parser.py
@@ -158,7 +158,7 @@ class CleanMXParserBot(ParserBot):
 
             event.add('classification.type', ctype)
             event.add("raw", entry_str)
-            return event
+            yield event
 
 
 BOT = CleanMXParserBot


### PR DESCRIPTION
I added self.logger.info to check the content of `events` variable and found this:
```
2018-01-18 17:32:58,916 - cleanmx-phishing-parser - INFO - Bot is starting.
2018-01-18 17:32:58,918 - cleanmx-phishing-parser - INFO - Pipeline ready.
2018-01-18 17:33:05,354 - cleanmx-phishing-parser - INFO - ['source.abuse_contact', 'extra', 'raw', 'feed.url', 'time.observation', 'source.url', 'source.geolocation.cc', 'source.registry', 'source.ip', 'source.fqdn', 'classification.type', 'feed.provider', 'status', 'feed.name', 'feed.accuracy']
2018-01-18 17:33:05,581 - cleanmx-phishing-parser - ERROR - Bot has found a problem.
Traceback (most recent call last):
  File "/intelmq/intelmq/lib/bot.py", line 144, in start
    self.process()
  File "/intelmq/intelmq/lib/bot.py", line 622, in process
    self.send_message(*events)
  File "/intelmq/intelmq/lib/bot.py", line 343, in send_message
    raw_message = libmessage.MessageFactory.serialize(message)
  File "/intelmq/intelmq/lib/message.py", line 82, in serialize
    raw_message = Message.serialize(message)
  File "/intelmq/intelmq/lib/message.py", line 243, in serialize
    self['__type'] = self.__class__.__name__
TypeError: 'str' object does not support item assignment
2018-01-18 17:33:05,602 - cleanmx-phishing-parser - INFO - Bot will continue in 3 seconds.
```

my bad.