### PR TITLE
BUG: lib/bot: enhance pipeline error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ CHANGELOG
 - Bots stop when redis gives the error "OOM command not allowed when used memory > 'maxmemory'.".
 - lib/bot: Fixed exitcodes 0 for graceful shutdowns.
 - lib/harmonization: Handle idna encoding error in FQDN sanitation (#1175).
+- lib/bot: better handling of problems with pipeline and especially it's initialization
 
 ### Harmonization
 - Rule for harmonization keys is enforced (#1104)

--- a/intelmq/lib/bot.py
+++ b/intelmq/lib/bot.py
@@ -134,8 +134,12 @@ class Bot(object):
                     error_on_message = False
 
                 if error_on_pipeline:
-                    self.__connect_pipelines()
-                    error_on_pipeline = False
+                    try:
+                        self.__connect_pipelines()
+                    except Exception as exc:
+                        raise exceptions.PipelineError(exc)
+                    else:
+                        error_on_pipeline = False
 
                 if starting:
                     starting = False
@@ -226,8 +230,11 @@ class Bot(object):
                             self.stop()
 
                         # error_procedure: pass
-                        else:
+                        elif not error_on_pipeline:
                             self.__error_retries_counter = 0  # reset counter
+                        # error_procedure: pass and pipeline problem
+                        else:
+                            self.stop()
 
                 # no errors, check for run mode: scheduled
                 elif self.run_mode == 'scheduled':
@@ -290,11 +297,12 @@ class Bot(object):
             self.stop()
 
     def __connect_pipelines(self):
-        self.logger.debug("Loading source pipeline and queue %r.", self.__source_queues)
-        self.__source_pipeline = PipelineFactory.create(self.parameters)
-        self.__source_pipeline.set_queues(self.__source_queues, "source")
-        self.__source_pipeline.connect()
-        self.logger.debug("Connected to source queue.")
+        if self.__source_queues:
+            self.logger.debug("Loading source pipeline and queue %r.", self.__source_queues)
+            self.__source_pipeline = PipelineFactory.create(self.parameters)
+            self.__source_pipeline.set_queues(self.__source_queues, "source")
+            self.__source_pipeline.connect()
+            self.logger.debug("Connected to source queue.")
 
         if self.__destination_queues:
             self.logger.debug("Loading destination pipeline and queues %r.",


### PR DESCRIPTION
don't initialize source pipeline if not necessary
always raise PipelineError in case of connection issues
always stop in these cases, do never pass, would only result in loops