### PR TITLE
Shadowserver config.py netbios, poodle, freak

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -71,7 +71,7 @@ UPDATE events
    SET "classification.identifier" = 'open-mongodb'
    WHERE "classification.identifier" = 'openmongodb' AND "feed.name" = 'Open-MongoDB';
 UPDATE events
-   SET "classification.identifier" = 'open-netbios', "feed.name" = 'Open-NetBIOS-Nameservice'
+   SET "classification.identifier" = 'open-netbios-nameservice', "feed.name" = 'Open-NetBIOS-Nameservice'
    WHERE "classification.identifier" = 'opennetbios' AND "feed.name" = 'Open-NetBIOS';
 UPDATE events
    SET "classification.identifier" = 'openelasticsearch'
@@ -83,11 +83,11 @@ UPDATE events
    SET "classification.identifier" = 'ntp-monitor'
    WHERE "classification.identifier" = 'openntp' AND "feed.name" = 'NTP-Monitor';
 UPDATE events
-   SET "classification.identifier" = 'SSL-POODLE', "feed.name" = 'SSL-POODLE-Vulnerable-Servers'
+   SET "classification.identifier" = 'ssl-poodle', "feed.name" = 'SSL-POODLE-Vulnerable-Servers'
    WHERE "classification.identifier" = 'SSL-Poodle' AND "feed.name" = 'SSL-Scan';
 UPDATE events
-   SET "feed.name" = 'SSL-FREAK-Vulnerable-Servers'
-   WHERE "feed.name" = 'SSL-Freak-Scan';
+   SET "classification.identifier" = 'ssl-freak', "feed.name" = 'SSL-FREAK-Vulnerable-Servers'
+   WHERE "classification.identifier" = 'SSL-FREAK' AND "feed.name" = 'SSL-Freak-Scan';
 UPDATE events
    SET "classification.identifier" = 'open-memcached'
    WHERE "classification.identifier" = 'openmemcached' AND "feed.name" = 'Open-Memcached';

--- a/NEWS.md
+++ b/NEWS.md
@@ -84,10 +84,10 @@ UPDATE events
    WHERE "classification.identifier" = 'openntp' AND "feed.name" = 'NTP-Monitor';
 UPDATE events
    SET "classification.identifier" = 'ssl-poodle', "feed.name" = 'SSL-POODLE-Vulnerable-Servers'
-   WHERE "classification.identifier" = 'SSL-Poodle' AND "feed.name" = 'SSL-Scan';
+   WHERE "classification.identifier" = 'SSL-Poodle' AND "feed.name" = 'Ssl-Scan';
 UPDATE events
    SET "classification.identifier" = 'ssl-freak', "feed.name" = 'SSL-FREAK-Vulnerable-Servers'
-   WHERE "classification.identifier" = 'SSL-FREAK' AND "feed.name" = 'SSL-Freak-Scan';
+   WHERE "classification.identifier" = 'SSL-FREAK' AND "feed.name" = 'Ssl-Freak-Scan';
 UPDATE events
    SET "classification.identifier" = 'open-memcached'
    WHERE "classification.identifier" = 'openmemcached' AND "feed.name" = 'Open-Memcached';

--- a/intelmq/bots/parsers/shadowserver/config.py
+++ b/intelmq/bots/parsers/shadowserver/config.py
@@ -682,7 +682,7 @@ open_netbios_nameservice = {
     'constant_fields': {
         'classification.type': 'vulnerable service',
         'classification.taxonomy': 'vulnerable',
-        'classification.identifier': 'open-netbios',
+        'classification.identifier': 'open-netbios-nameservice',
         'protocol.application': 'netbios',
     },
 }
@@ -793,7 +793,7 @@ ssl_freak_vulnerable_servers = {
     'constant_fields': {
         'classification.type': 'vulnerable service',
         'classification.taxonomy': 'vulnerable',
-        'classification.identifier': 'SSL-FREAK',
+        'classification.identifier': 'ssl-freak',
         'protocol.application': 'https',
     },
 }
@@ -816,7 +816,7 @@ ssl_poodle_vulnerable_servers = {
     'constant_fields': {
         'classification.type': 'vulnerable service',
         'classification.taxonomy': 'vulnerable',
-        'classification.identifier': 'SSL-POODLE',
+        'classification.identifier': 'ssl-poodle',
         'protocol.application': 'https',
     },
 }


### PR DESCRIPTION
Rename identifiers:
Make SSL-POODLE/SSL-FREAK lowercase like all other identifiers.
Rename open-netbios to open-netbios-nameservice as this report only deals with 137/udp, not netbios in general.
