### PR TITLE
Sieve strictness (allow ip networks with hosts bits set)

### DIFF
--- a/intelmq/bots/experts/sieve/README.md
+++ b/intelmq/bots/experts/sieve/README.md
@@ -46,6 +46,7 @@ if classification.type == ['phishing', 'malware'] && source.fqdn =~ '.*\.(ch|li)
 
 The sieve bot takes only one parameter:
  * `file` - filesystem path of the sieve file
+ * `ip_network_strict` (default true) - throw error if the network has host bits set
 
 
 ## Reference

--- a/intelmq/bots/experts/sieve/README.md
+++ b/intelmq/bots/experts/sieve/README.md
@@ -46,7 +46,6 @@ if classification.type == ['phishing', 'malware'] && source.fqdn =~ '.*\.(ch|li)
 
 The sieve bot takes only one parameter:
  * `file` - filesystem path of the sieve file
- * `ip_network_strict` (default true) - throw error if the network has host bits set
 
 
 ## Reference

--- a/intelmq/bots/experts/sieve/expert.py
+++ b/intelmq/bots/experts/sieve/expert.py
@@ -38,7 +38,6 @@ class SieveExpertBot(Bot):
             SieveExpertBot.harmonization = harmonization_config['event']
 
         self.metamodel = SieveExpertBot.init_metamodel()
-        SieveExpertBot.ip_network_strict = getattr(self.parameters, 'ip_network_strict', True)
         self.sieve = SieveExpertBot.read_sieve_file(self.parameters.file, self.metamodel)
 
     @staticmethod
@@ -215,11 +214,11 @@ class SieveExpertBot(Bot):
             return False
 
         if ip_range.__class__.__name__ == 'SingleIpRange':
-            network = ipaddress.ip_network(ip_range.value, strict=SieveExpertBot.ip_network_strict)
+            network = ipaddress.ip_network(ip_range.value, strict=False)
             return addr in network
         elif ip_range.__class__.__name__ == 'IpRangeList':
             for val in ip_range.values:
-                network = ipaddress.ip_network(val.value, strict=SieveExpertBot.ip_network_strict)
+                network = ipaddress.ip_network(val.value, strict=False)
                 if addr in network:
                     return True
         return False
@@ -246,7 +245,7 @@ class SieveExpertBot(Bot):
     @staticmethod
     def validate_ip_range(ip_range):
         try:
-            ipaddress.ip_network(ip_range.value, strict=SieveExpertBot.ip_network_strict)
+            ipaddress.ip_network(ip_range.value, strict=False)
         except ValueError:
             position = SieveExpertBot.get_linecol(ip_range, as_dict=True)
             raise TextXSemanticError('Invalid ip range: %s.' % ip_range.value, **position)

--- a/intelmq/bots/experts/sieve/expert.py
+++ b/intelmq/bots/experts/sieve/expert.py
@@ -38,6 +38,7 @@ class SieveExpertBot(Bot):
             SieveExpertBot.harmonization = harmonization_config['event']
 
         self.metamodel = SieveExpertBot.init_metamodel()
+        SieveExpertBot.ip_network_strict = getattr(self.parameters, 'ip_network_strict', True)
         self.sieve = SieveExpertBot.read_sieve_file(self.parameters.file, self.metamodel)
 
     @staticmethod
@@ -214,11 +215,11 @@ class SieveExpertBot(Bot):
             return False
 
         if ip_range.__class__.__name__ == 'SingleIpRange':
-            network = ipaddress.ip_network(ip_range.value)
+            network = ipaddress.ip_network(ip_range.value, strict=SieveExpertBot.ip_network_strict)
             return addr in network
         elif ip_range.__class__.__name__ == 'IpRangeList':
             for val in ip_range.values:
-                network = ipaddress.ip_network(val.value)
+                network = ipaddress.ip_network(val.value, strict=SieveExpertBot.ip_network_strict)
                 if addr in network:
                     return True
         return False
@@ -245,7 +246,7 @@ class SieveExpertBot(Bot):
     @staticmethod
     def validate_ip_range(ip_range):
         try:
-            ipaddress.ip_network(ip_range.value)
+            ipaddress.ip_network(ip_range.value, strict=SieveExpertBot.ip_network_strict)
         except ValueError:
             position = SieveExpertBot.get_linecol(ip_range, as_dict=True)
             raise TextXSemanticError('Invalid ip range: %s.' % ip_range.value, **position)

--- a/intelmq/tests/bots/experts/sieve/test_expert.py
+++ b/intelmq/tests/bots/experts/sieve/test_expert.py
@@ -884,6 +884,36 @@ class TestSieveExpertBot(test.BotTestCase, unittest.TestCase):
         self.run_bot()
         self.assertMessageEqual(0, event)
 
+    def test_network_host_bits_list_match(self):
+        """ Test if range list of networks with host bits set match operator. """
+        self.sysconfig['file'] = os.path.join(os.path.dirname(__file__),
+                                              'test_sieve_files/test_ip_range_list_match.sieve')
+
+        # positive test
+        event = EXAMPLE_INPUT.copy()
+        event['source.ip'] = '169.254.2.1'
+        expected = event.copy()
+        expected['comment'] = 'bogon'
+        self.input_message = event
+        self.run_bot()
+        self.assertMessageEqual(0, expected)
+
+        # positive test
+        event = EXAMPLE_INPUT.copy()
+        event['source.ip'] = '169.254.3.1'
+        expected = event.copy()
+        expected['comment'] = 'bogon'
+        self.input_message = event
+        self.run_bot()
+        self.assertMessageEqual(0, expected)
+
+        # negative test
+        event = EXAMPLE_INPUT.copy()
+        event['source.ip'] = '169.255.2.1'
+        self.input_message = event
+        self.run_bot()
+        self.assertMessageEqual(0, event)
+
     def test_comments(self):
         """ Test comments in sieve file."""
         self.sysconfig['file'] = os.path.join(os.path.dirname(__file__), 'test_sieve_files/test_comments.sieve')

--- a/intelmq/tests/bots/experts/sieve/test_sieve_files/test_network_host_bits_list_match.sieve
+++ b/intelmq/tests/bots/experts/sieve/test_sieve_files/test_network_host_bits_list_match.sieve
@@ -1,0 +1,3 @@
+if source.ip << ['192.0.0.5/24', '169.254.2.1/16'] {
+    add comment = 'bogon'
+}


### PR DESCRIPTION
I found it handy to have a parameter for setting strict=False when creating an IP network. If strict=True, we get ValueError: XY has host bits set.