### PR TITLE
Malware family names download & convert script

### DIFF
--- a/contrib/malware_name_mapping/README.md
+++ b/contrib/malware_name_mapping/README.md
@@ -1,0 +1,10 @@
+Malware Name Mapping
+====================
+
+This script fetches the current mapping file from the [Malware Name Mapping repository](https://github.com/certtools/malware_name_mapping/raw/master/mapping.txt) and converts it to the syntax needed by the modify expert.
+It expects a tab-separated file and uses the first column as regular expression and the second one as family name. Other URLs can be given as parameter.
+The resulting configuration sets the field `classification.identifier` to the malware family name corresponding to the given `malware.name`.
+
+By default, the result is printed to stdout, a filename can be given as parameter.
+
+For more information about the mapping project, have a look at the [Malware Name Mapping repository](https://github.com/certtools/malware_name_mapping).

--- a/contrib/malware_name_mapping/README.md
+++ b/contrib/malware_name_mapping/README.md
@@ -1,8 +1,8 @@
 Malware Name Mapping
 ====================
 
-This script fetches the current mapping file from the [Malware Name Mapping repository](https://github.com/certtools/malware_name_mapping/raw/master/mapping.txt) and converts it to the syntax needed by the modify expert.
-It expects a tab-separated file and uses the first column as regular expression and the second one as family name. Other URLs can be given as parameter.
+This script fetches the current mapping file from the [Malware Name Mapping repository](https://github.com/certtools/malware_name_mapping/raw/master/mapping.csv) and converts it to the syntax needed by the modify expert.
+It expects a comma-separated file and uses the first column as regular expression and the second one as family name. Other URLs can be given as parameter.
 The resulting configuration sets the field `classification.identifier` to the malware family name corresponding to the given `malware.name`.
 
 By default, the result is printed to stdout, a filename can be given as parameter.

--- a/contrib/malware_name_mapping/README.md
+++ b/contrib/malware_name_mapping/README.md
@@ -17,3 +17,8 @@ Default rule
 A default rule can optionally be added the the end of the rules with the `-d` flag.
 With this rule, the field `classification.identifier` is set to `malware.name` if the first is empty and the latter is not.
 As this is the last rule, it is kind of "last resort" to fill the identifier field.
+
+Modify Bot
+----------
+
+Use the Modify bot to apply the ruleset by using the generated file as configuration. Also, deactivate the case sensitivity of the bot.

--- a/contrib/malware_name_mapping/README.md
+++ b/contrib/malware_name_mapping/README.md
@@ -8,3 +8,12 @@ The resulting configuration sets the field `classification.identifier` to the ma
 By default, the result is printed to stdout, a filename can be given as parameter.
 
 For more information about the mapping project, have a look at the [Malware Name Mapping repository](https://github.com/certtools/malware_name_mapping).
+
+See also the built-in help of the script by calling it with `-h`.
+
+Default rule
+------------
+
+A default rule can optionally be added the the end of the rules with the `-d` flag.
+With this rule, the field `classification.identifier` is set to `malware.name` if the first is empty and the latter is not.
+As this is the last rule, it is kind of "last resort" to fill the identifier field.

--- a/contrib/malware_name_mapping/download_mapping.py
+++ b/contrib/malware_name_mapping/download_mapping.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """
-
+TODO: Fix ordering of dicts
 """
 import argparse
 import csv

--- a/contrib/malware_name_mapping/download_mapping.py
+++ b/contrib/malware_name_mapping/download_mapping.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+
+"""
+import argparse
+import json
+import requests
+
+
+URL = 'https://raw.githubusercontent.com/certtools/malware_name_mapping/master/mapping.txt'
+
+
+def main(url: str=URL):
+    download = requests.get(url)
+    download.raise_for_status()
+    rules = [{"rulename": "%s-%s" % (line[1], abs(hash(line[0]))),
+              "if": {"malware.name": line[0]},
+              "then": {"classification.identifier": line[1], }}
+             for line in [line.split() for line in download.text.strip().splitlines()]]
+    return json.dumps(rules, indent=4, separators=(',', ': '))
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        prog='download_mapping',
+        description='Downloads malware family mapping and converts it to modify syntax.',
+    )
+
+    parser.add_argument('filename', nargs='?',
+                        help='The filename to write the converted mapping to. If not given, printed to stdout.')
+    parser.add_argument('--url', '-u',
+                        default=URL,
+                        help='The URL to download the mapping from.')
+    args = parser.parse_args()
+
+    if args.filename:
+        try:
+            with open(args.filename, 'wt') as output:
+                output.write(main(url=args.url))
+        except PermissionError:
+            print('Could not write to file %r.' % args.filename, file=sys.stderr)
+            exit(1)
+    else:
+        print(main(url=args.url))

--- a/contrib/malware_name_mapping/download_mapping.py
+++ b/contrib/malware_name_mapping/download_mapping.py
@@ -4,11 +4,13 @@
 
 """
 import argparse
+import csv
+import io
 import json
 import requests
 
 
-URL = 'https://raw.githubusercontent.com/certtools/malware_name_mapping/master/mapping.txt'
+URL = 'https://raw.githubusercontent.com/certtools/malware_name_mapping/master/mapping.csv'
 
 
 def main(url: str=URL):
@@ -17,7 +19,7 @@ def main(url: str=URL):
     rules = [{"rulename": "%s-%s" % (line[1], abs(hash(line[0]))),
               "if": {"malware.name": line[0]},
               "then": {"classification.identifier": line[1], }}
-             for line in [line.split() for line in download.text.strip().splitlines()]]
+             for line in csv.reader(io.StringIO(download.text))]
     return json.dumps(rules, indent=4, separators=(',', ': '))
 
 

--- a/contrib/malware_name_mapping/download_mapping.py
+++ b/contrib/malware_name_mapping/download_mapping.py
@@ -8,18 +8,26 @@ import csv
 import io
 import json
 import requests
+import sys
 
 
 URL = 'https://raw.githubusercontent.com/certtools/malware_name_mapping/master/mapping.csv'
 
 
-def main(url: str=URL):
+def main(url: str=URL, add_default=False):
     download = requests.get(url)
     download.raise_for_status()
     rules = [{"rulename": "%s-%s" % (line[1], abs(hash(line[0]))),
               "if": {"malware.name": line[0]},
               "then": {"classification.identifier": line[1], }}
              for line in csv.reader(io.StringIO(download.text))]
+
+    if add_default:
+        rules.append(
+            {"rulename": "default",
+             "if": {"malware.name": ".*",
+                    "classification.identifier": ""},
+             "then": {"classification.identifier": "{msg[malware.name]}", }})
     return json.dumps(rules, indent=4, separators=(',', ': '))
 
 
@@ -34,14 +42,18 @@ if __name__ == '__main__':
     parser.add_argument('--url', '-u',
                         default=URL,
                         help='The URL to download the mapping from.')
+    parser.add_argument('--add-default', '-d',
+                        help='Add a default rule to use the malware name as identifier.',
+                        const=True, action='store_const')
     args = parser.parse_args()
 
+    rules = main(url=args.url, add_default=args.add_default)
     if args.filename:
         try:
             with open(args.filename, 'wt') as output:
-                output.write(main(url=args.url))
+                output.write(rules)
         except PermissionError:
             print('Could not write to file %r.' % args.filename, file=sys.stderr)
             exit(1)
     else:
-        print(main(url=args.url))
+        print(rules)

--- a/contrib/malware_name_mapping/download_mapping.py
+++ b/contrib/malware_name_mapping/download_mapping.py
@@ -5,6 +5,7 @@
 """
 import argparse
 import csv
+import hashlib
 import io
 import json
 import requests
@@ -17,7 +18,7 @@ URL = 'https://raw.githubusercontent.com/certtools/malware_name_mapping/master/m
 def main(url: str=URL, add_default=False):
     download = requests.get(url)
     download.raise_for_status()
-    rules = [{"rulename": "%s-%s" % (line[1], abs(hash(line[0]))),
+    rules = [{"rulename": "%s-%s" % (line[1], hashlib.sha1(line[0].encode()).hexdigest()[:10]),
               "if": {"malware.name": line[0]},
               "then": {"classification.identifier": line[1], }}
              for line in csv.reader(io.StringIO(download.text))]


### PR DESCRIPTION
Downloads the current mapping from https://github.com/certtools/malware_name_mapping/ and converts it to the syntax applicable for the modify bot.