### PR TITLE
Fixes #1207 Sieve bot named queues ( #1088 ) usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ CHANGELOG
 
 #### Experts
 - Added sieve expert for filtering and modifying events (#1083)
+ * capable of distributing the event to appropriate named queues
 - `bots.experts.modify`
  * default ruleset: added avalanche rule.
  * new parameter `case_sensitive` (default: True)

--- a/intelmq/bots/experts/sieve/README.md
+++ b/intelmq/bots/experts/sieve/README.md
@@ -120,7 +120,7 @@ in the sieve file will be forwarded to the next bot in the pipeline, unless the
 already defined. If the key is not defined in the event, this action is ignored.
 Example:
 
-   ```modify feed.accuary = 50```
+   ```modify feed.accuracy = 50```
 
  * `remove` removes a key/value from the event. Action is ignored if the key is
  not defined in the event. Example:
@@ -130,6 +130,9 @@ Example:
  * `keep` marks the event to be forwarded to the next bot in the pipeline
  (same as the default behaviour), but in addition the sieve file processing is
  interrupted upon reaching this action.
+ It can have an optional parameter that specifies the path to appropriate named queue.
+
+   ```keep``` or  ```keep 'named-queue'```
 
  * `drop` marks the event to be dropped. The event will not be forwarded to the
  next bot in the pipeline. The sieve file processing is interrupted upon

--- a/intelmq/bots/experts/sieve/expert.py
+++ b/intelmq/bots/experts/sieve/expert.py
@@ -93,7 +93,8 @@ class SieveExpertBot(Bot):
 
         # forwarding decision
         if procedure != Procedure.DROP:
-            self.send_message(event)
+            path = getattr(event, "path", "_default")
+            self.send_message(event, path=path)
 
         self.acknowledge_message()
 
@@ -227,7 +228,9 @@ class SieveExpertBot(Bot):
     def process_action(action, event):
         if action == 'drop':
             return Procedure.DROP
-        elif action == 'keep':
+        elif action.__class__.__name__ == 'KeepAction':
+            if action.path:
+                event.path = action.path
             return Procedure.KEEP
         elif action.__class__.__name__ == 'AddAction':
             if action.key not in event:

--- a/intelmq/bots/experts/sieve/expert.py
+++ b/intelmq/bots/experts/sieve/expert.py
@@ -10,9 +10,9 @@ import os
 import re
 
 import intelmq.lib.exceptions as exceptions
-from intelmq.lib.bot import Bot
 from intelmq import HARMONIZATION_CONF_FILE
 from intelmq.lib import utils
+from intelmq.lib.bot import Bot
 
 try:
     import textx.model
@@ -228,10 +228,10 @@ class SieveExpertBot(Bot):
     def process_action(action, event):
         if action == 'drop':
             return Procedure.DROP
-        elif action.__class__.__name__ == 'KeepAction':
-            if action.path:
-                event.path = action.path
+        elif action == 'keep':
             return Procedure.KEEP
+        elif action.__class__.__name__ == 'PathAction':
+            event.path = action.path
         elif action.__class__.__name__ == 'AddAction':
             if action.key not in event:
                 event.add(action.key, action.value)

--- a/intelmq/bots/experts/sieve/sieve.tx
+++ b/intelmq/bots/experts/sieve/sieve.tx
@@ -68,7 +68,7 @@ Action: action=DropAction
         | action=RemoveAction
       );
 DropAction: 'drop';
-KeepAction: 'keep';
+KeepAction: 'keep' path=STRING?;
 AddAction: 'add' key=Key '=' value=STRING;              // add key/value without overwriting existing key
 AddForceAction: 'add!' key=Key '=' value=STRING;        // add key/value, overwriting existing key
 UpdateAction: 'update' key=Key '=' value=STRING;        // update key/value, do not create if not exists

--- a/intelmq/bots/experts/sieve/sieve.tx
+++ b/intelmq/bots/experts/sieve/sieve.tx
@@ -62,13 +62,15 @@ NumericValueList: '[' values+=SingleNumericValue[','] ']' ;
 
 Action: action=DropAction
     | ( action=KeepAction
+        | action=PathAction
         | action=AddAction
         | action=AddForceAction
         | action=UpdateAction
         | action=RemoveAction
       );
 DropAction: 'drop';
-KeepAction: 'keep' path=STRING?;
+KeepAction: 'keep';
+PathAction: 'path' path=STRING;
 AddAction: 'add' key=Key '=' value=STRING;              // add key/value without overwriting existing key
 AddForceAction: 'add!' key=Key '=' value=STRING;        // add key/value, overwriting existing key
 UpdateAction: 'update' key=Key '=' value=STRING;        // update key/value, do not create if not exists

--- a/intelmq/tests/bots/experts/sieve/test_expert.py
+++ b/intelmq/tests/bots/experts/sieve/test_expert.py
@@ -925,6 +925,40 @@ class TestSieveExpertBot(test.BotTestCase, unittest.TestCase):
         self.run_bot()
         self.assertMessageEqual(0, expected)
 
+    def test_named_queues(self):
+        """ Test == numeric match """
+        self.sysconfig['file'] = os.path.join(os.path.dirname(__file__),
+                                              'test_sieve_files/test_named_queues.sieve')
+
+        # if match drop
+        numeric_match_true = EXAMPLE_INPUT.copy()
+        numeric_match_true['comment'] = "drop"
+        self.input_message = numeric_match_true
+        self.run_bot()
+        self.assertOutputQueueLen(0)
+
+
+        # if doesn't match keep
+        numeric_match_false = EXAMPLE_INPUT.copy()
+        numeric_match_false['comment'] = "keep without path"
+        self.input_message = numeric_match_false
+        self.run_bot()
+        self.assertMessageEqual(0, numeric_match_false)
+
+        # if doesn't match keep
+        numeric_match_false = EXAMPLE_INPUT.copy()
+        numeric_match_false['comment'] = "keep with path"
+        self.input_message = numeric_match_false
+        self.run_bot()
+        self.assertMessageEqual(0, numeric_match_false, path="other-way")
+
+        # if doesn't match keep
+        numeric_match_false = EXAMPLE_INPUT.copy()
+        numeric_match_false['comment'] = "default path"
+        self.input_message = numeric_match_false
+        self.run_bot()
+        self.assertMessageEqual(0, numeric_match_false, path="_default")
+
 
 
 if __name__ == '__main__':  # pragma: no cover

--- a/intelmq/tests/bots/experts/sieve/test_sieve_files/test_named_queues.sieve
+++ b/intelmq/tests/bots/experts/sieve/test_sieve_files/test_named_queues.sieve
@@ -1,0 +1,11 @@
+if comment == "keep without path" {
+    keep
+}
+
+if comment == "keep with path" {
+    keep "other-way"
+}
+
+if comment == "drop" {
+    drop
+}

--- a/intelmq/tests/bots/experts/sieve/test_sieve_files/test_named_queues.sieve
+++ b/intelmq/tests/bots/experts/sieve/test_sieve_files/test_named_queues.sieve
@@ -3,7 +3,8 @@ if comment == "keep without path" {
 }
 
 if comment == "keep with path" {
-    keep "other-way"
+    path "other-way"
+    keep
 }
 
 if comment == "drop" {


### PR DESCRIPTION
Sieve bot now can distribute events to appropriate named queue by an optional parameter next to word 'keep'

@antoinet @wagner-certat 

PS: Note that the error in travis-ci/pr seems to have nothing common with my changes.