### PR TITLE
Return value of restart command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ CHANGELOG
 - `intelmq_gen_feeds_docs` add to bin directory, allows generating the Feeds.md documentation file from feeds.yaml
 - `intelmqctl run` parameter for showing a sent message
 - `intelmqctl run` if message is sent to a non-default path, it is printed out
+- `intelmqctl restart` bug fix; returned some half-nonsense, now returns return state of start and stop operation in a list, see #1226
 
 
 ### Contrib

--- a/intelmq/bin/intelmqctl.py
+++ b/intelmq/bin/intelmqctl.py
@@ -608,7 +608,7 @@ Outputs are additionally logged to /opt/intelmq/var/log/intelmqctl'''
         else:
             status_stop = self.bot_stop(bot_id)
             status_start = self.bot_start(bot_id)
-            return (status_stop, status_start)
+            return status_stop[0] + status_start[0], [status_stop[1], status_start[1]]
 
     def bot_status(self, bot_id):
         if bot_id is None:


### PR DESCRIPTION
Both start and stop command returned tuple (exit-status, string). Restart command returned ((exit-status-of-stop, string-of-stop), (exit-status-of-start, string-of-start)). Since exit-status was a tuple instead of a number, in the terminal error pipe received that tuple. Since intelmq-manager read only output-pipe, it wasn't aware of this incorrect behaviour. With my another pull request, intelmq-manager now handles error-pipe too, so that restart command stopped working.

Old wrong behaviour:

```bash
www-data@jezevec:~$ PATH=~/.local/bin intelmqctl restart abuse-ch-feodo-tracker-domains-parser
intelmqctl: abuse-ch-feodo-tracker-domains-parser was NOT RUNNING.
intelmqctl: Starting abuse-ch-feodo-tracker-domains-parser...
intelmqctl: abuse-ch-feodo-tracker-domains-parser is running.
(0, 'stopped')
www-data@jezevec:~$ PATH=~/.local/bin intelmqctl --type json restart abuse-ch-feodo-tracker-domains-parser
[0, "running"]
(0, 'stopped')
```

New correct behaviour:

```bash
www-data@jezevec:~$ PATH=~/.local/bin intelmqctl restart abuse-ch-feodo-tracker-domains-parser
intelmqctl: Stopping abuse-ch-feodo-tracker-domains-parser...
intelmqctl: abuse-ch-feodo-tracker-domains-parser is stopped.
intelmqctl: Starting abuse-ch-feodo-tracker-domains-parser...
intelmqctl: abuse-ch-feodo-tracker-domains-parser is running.
www-data@jezevec:~$ PATH=~/.local/bin intelmqctl --type json restart abuse-ch-feodo-tracker-domains-parser
["stopped", "running"]
```

Note that the return value reflects both operations, `bot_start` and `bot_stop` as seems intended by previous programmer.