### PR TITLE
intelmqctl start botnet --type json fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ CHANGELOG
 ### Tools
 - `intelmqctl start` prints bot's error messages if it failed to start
 - `intelmqctl start` message "is running" is printed every time. (Until now, it wasn't said when a bot was just starting.)
+- `intelmqctl start` botnet. When using `--type json`, no non-json information about wrong bots are output because that would confuse eg. intelmq-manager
 - `intelmqctl check` checks for defaults.conf completeness
 - `intelmqctl check` shows errors for non-importable bots.
 - `intelmqctl list bots -q` only prints the IDs of enabled bots

--- a/intelmq/bin/intelmqctl.py
+++ b/intelmq/bin/intelmqctl.py
@@ -650,7 +650,8 @@ Outputs are additionally logged to /opt/intelmq/var/log/intelmqctl'''
                 botnet_status[bot_id] = self.bot_status(bot_id)[1]
                 if botnet_status[bot_id] not in ['running', 'disabled']:
                     retval = 1
-                    print(bot_id, botnet_status[bot_id])
+                    if RETURN_TYPE == 'text':
+                        print(bot_id, botnet_status[bot_id])
 
         log_botnet_message('running')
         return retval, botnet_status


### PR DESCRIPTION
no non-json information about wrong bots are output because that would confuse eg. intelmq-manager
For example, if there was defined a bot that didnt exist in BOTS, a superfluous line was printed:

```bash
IntelMQ-Collector stopped <-- superfluous line!
{"restapi-output": "disabled", "IntelMQ-Collector": "stopped", "JSON-Parser": "running", "TCP-Output": "stopped", "abuse-ch-feodo-tracker-domains-collector": "running", "abuse-ch-feodo-tracker-domains-parser": "running", "abuse-ch-feodo-tracker-ips-collector": "running", "abuse-ch-feodo-tracker-ips-parser": "running", "abuse-ch-zeus-tracker-domains-collector": "running", "abuse-ch-zeus-tracker-domains-parser": "running", "abuse-ch-zeus-tracker-ips-collector": "running", "abuse-ch-zeus-tracker-ips-parser": "running", "abusix-expert-cz": "running", "alienvault-collector": "running", "alienvault-otx-collector": "stopped", "alienvault-otx-parser": "running", "alienvault-parser": "running", "asn-lookup-expert": "stopped", "autoshun-collector": "running", "autoshun-parser": "running", "blocklist-de-apache-collector": "running", "blocklist-de-apache-parser": "r...
```