### PR TITLE
Fix Shadowserver parser convert_http_host_and_url

### DIFF
--- a/intelmq/bots/parsers/shadowserver/config.py
+++ b/intelmq/bots/parsers/shadowserver/config.py
@@ -378,7 +378,7 @@ ipv6_sinkhole_http_drone = {
         ('source.reverse_dns', 'hostname'),
         ('extra.', 'sysdesc', validate_to_none),
         ('extra.', 'sysname', validate_to_none),
-        ('destination.url', 'url', convert_http_host_and_url, True),
+        ('destination.url', 'http_url', convert_http_host_and_url, True),
         ('extra.', 'http_agent', validate_to_none),
         ('destination.fqdn', 'http_host'),
         ('extra.', 'http_referer', validate_to_none),

--- a/intelmq/bots/parsers/shadowserver/config.py
+++ b/intelmq/bots/parsers/shadowserver/config.py
@@ -171,7 +171,7 @@ def convert_http_host_and_url(value, row):
 
         application = "http"
         if "application" in row:
-            if row['application']:
+            if row['application'] in ['http', 'https']:
                 application = row['application']
 
         return application + "://" + hostname + path

--- a/intelmq/bots/parsers/shadowserver/config.py
+++ b/intelmq/bots/parsers/shadowserver/config.py
@@ -138,37 +138,44 @@ def convert_float(value):
         return float(value)
 
 
-def convert_hostname_and_url(value, row):
+def convert_http_host_and_url(value, row):
     """
-    URLs are split into hostname and path, we can also guess the protocol here.
-    but only guess if the protocol is in a set of known good values.
-    """
-    if row['application'] in ['http', 'https', 'irc']:
-        if row['hostname'] and row['url']:
-            url = row['url'] if row['url'].startswith('/') else '/' + row['url']
-            return row['application'] + '://' + row['hostname'] + url
-
-        elif row['hostname'] and not row['url']:
-            return row['application'] + '://' + row['hostname']
-
-    return value
-
-
-def convert_httphost_and_url(value, row):
-    """
-    URLs are split into hostname and path, we can also guess the protocol here.
+    URLs are split into hostname and path. The column names differ in reports.
+    Compromised-Website: http_host, url
+    Drone: cc_dns, url
+    IPv6-Sinkhole-HTTP-Drone: http_host, http_url
+    Microsoft-Sinkhole: http_host, url
+    Sinkhole-HTTP-Drone: http_host, url
     With some reports, url/http_url holds only the path, with others the full HTTP request.
     """
+    hostname = ""
+    if "cc_dns" in row:
+        if row['cc_dns']:
+            hostname = row['cc_dns']
+    elif "http_host" in row:
+        if row['http_host']:
+            hostname = row['http_host']
+
+    path = ""
     if "url" in row:
-        if row['http_host'] and row['url']:
-            path = re.sub(r'^[^/]*', '', row['url'])
-            path = re.sub(r'\s.*$', '', path)
-            return 'http://' + row['http_host'] + path
+        if row['url']:
+            path = row['url']
     elif "http_url" in row:
-        if row['http_host'] and row['http_url']:
-            path = re.sub(r'^[^/]*', '', row['http_url'])
-            path = re.sub(r'\s.*$', '', path)
-            return 'http://' + row['http_host'] + path
+        if row['http_url']:
+            path = row['http_url']
+
+    if hostname and path:
+        # remove potential leading/trailing HTTP request information
+        path = re.sub(r'^[^/]*', '', path)
+        path = re.sub(r'\s.*$', '', path)
+
+        application = "http"
+        if "application" in row:
+            if row['application']:
+                application = row['application']
+
+        return application + "://" + hostname + path
+
     return value
 
 
@@ -315,6 +322,7 @@ sinkhole_http_drone = {
     'optional_fields': [
         ('source.asn', 'asn'),
         ('source.geolocation.cc', 'geo'),
+        ('destination.url', 'url', convert_http_host_and_url, True),
         ('malware.name', 'type'),
         ('user_agent', 'http_agent'),
         ('source.tor_node', 'tor', set_tor_node),
@@ -370,7 +378,7 @@ ipv6_sinkhole_http_drone = {
         ('source.reverse_dns', 'hostname'),
         ('extra.', 'sysdesc', validate_to_none),
         ('extra.', 'sysname', validate_to_none),
-        ('destination.url', 'http_url'),
+        ('destination.url', 'url', convert_http_host_and_url, True),
         ('extra.', 'http_agent', validate_to_none),
         ('destination.fqdn', 'http_host'),
         ('extra.', 'http_referer', validate_to_none),
@@ -400,7 +408,7 @@ microsoft_sinkhole = {
     'optional_fields': [
         ('source.asn', 'asn'),
         ('source.geolocation.cc', 'geo'),
-        ('destination.url', 'url', convert_httphost_and_url, True),
+        ('destination.url', 'url', convert_http_host_and_url, True),
         ('malware.name', 'type'),
         ('user_agent', 'http_agent'),
         ('source.tor_node', 'tor', set_tor_node),
@@ -1056,7 +1064,7 @@ drone = {
         ('source.reverse_dns', 'hostname'),
         ('protocol.transport', 'type'),
         ('malware.name', 'infection'),
-        ('destination.url', 'url', convert_hostname_and_url, True),
+        ('destination.url', 'url', convert_http_host_and_url, True),
         ('user_agent', 'agent'),
         ('destination.ip', 'cc_ip', validate_ip),
         ('destination.port', 'cc_port'),
@@ -1133,7 +1141,7 @@ compromised_website = {
         ('source.geolocation.cc', 'geo'),
         ('source.geolocation.region', 'region'),
         ('source.geolocation.city', 'city'),
-        ('source.url', 'url', convert_hostname_and_url, True),
+        ('source.url', 'url', convert_http_host_and_url, True),
         ('source.fqdn', 'http_host', validate_fqdn),
         ('event_description.text', 'category'),
         ('extra.', 'system', validate_to_none),


### PR DESCRIPTION
Both functions convert_hostname_and_url() and convert_httphost_and_url() were broken or incomplete. Replaced by new function convert_http_host_and_url().
