### PR TITLE
named queues displayed when querying intelmqctl for queues in JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ CHANGELOG
 ### Harmonization
 
 ### Bots
+- named queues displayed when querying intelmqctl for queues in JSON
+
 #### Collectors
 - added `intelmq.bots.parsers.opendxl.collector` (#1265).
 

--- a/intelmq/bin/intelmqctl.py
+++ b/intelmq/bin/intelmqctl.py
@@ -835,9 +835,14 @@ Outputs are additionally logged to /opt/intelmq/var/log/intelmqctl'''
 
             if 'destination-queues' in info:
                 return_dict[bot_id]['destination_queues'] = []
-                for dest_queue in info['destination-queues']:
-                    return_dict[bot_id]['destination_queues'].append(
-                        (dest_queue, counters[dest_queue]))
+                if type(info['destination-queues']) is list:
+                    for dest_queue in info['destination-queues']:
+                        return_dict[bot_id]['destination_queues'].append(
+                            (dest_queue, counters[dest_queue]))
+                else:  # named queues comes in dict of {"named-path": "named-queue"}
+                    for path, dest_queue in info['destination-queues'].items():
+                        return_dict[bot_id]['destination_queues'].append(
+                            (dest_queue, counters[dest_queue], path))
 
         return 0, return_dict
 


### PR DESCRIPTION
Intelmq manager will be able to work with named queues thanks to this commit.