### PR TITLE
Fix: don't display named paths amongst standard queues.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ CHANGELOG
 
 ### Tests
 
+### Tools
+- intelmqctl Fix: don't display named paths amongst standard queues.
+
 ### Contrib
 
 ### Known issues

--- a/intelmq/lib/pipeline.py
+++ b/intelmq/lib/pipeline.py
@@ -2,10 +2,11 @@
 import time
 from itertools import chain
 
+import redis
+
 import intelmq.lib.exceptions as exceptions
 import intelmq.lib.pipeline
 import intelmq.lib.utils as utils
-import redis
 
 __all__ = ['Pipeline', 'PipelineFactory', 'Redis', 'Pythonlist']
 
@@ -41,7 +42,8 @@ class Pipeline(object):
     def set_queues(self, queues, queues_type):
         """
         :param queues: For source queue, it's just string.
-                    For destination queue, it can be one of the following: None or list or dict (of strings or lists, one of the key should be '_default')
+                    For destination queue, it can be one of the following:
+                    None or list or dict (of strings or lists, one of the key should be '_default')
 
         :param queues_type: "source" or "destination"
 


### PR DESCRIPTION
Queue path names were incorrectly listed amongst standard queue names. Named queue got displayed twice – as a standard queue and as a named path. Note that this information didn't serve anything because multiple queues may have the same name, ex: _default. Plus, manager got confused, having no way to distinguinsh path names from standard queue names.

> intelmqctl list queues
intelmqctl: _default - 0
intelmqctl: abuse-ch-feodo-tracker-domains-parser-queue - 0