### PR TITLE
MISP Parser to recognize attribtes nested in objects

### DIFF
--- a/intelmq/bots/parsers/misp/parser.py
+++ b/intelmq/bots/parsers/misp/parser.py
@@ -70,6 +70,11 @@ class MISPParserBot(Bot):
         # get the attributes from the event
         event_attributes = misp_event['Attribute']
 
+        # add object attributes to the list
+        if 'Object' in misp_event:
+            for obj in misp_event['Object']:
+                event_attributes += obj['Attribute']
+
         # payload type - get malware variant for the event
         malware_variant = None
         for attribute in event_attributes:


### PR DESCRIPTION
Hi,

just recognized the current parser simply ignores MISP Attributes if they are nested into an MISP Object.

Would like to see this minor code change go upstream since many misp sharing instances are using objects to group attributes together.

Regards,
Hendrik