### PR TITLE
ENH: Blueliv collector accepts arbitrary API URL

### DIFF
--- a/intelmq/bots/BOTS
+++ b/intelmq/bots/BOTS
@@ -193,6 +193,7 @@
             "description": "Blueliv Crimeserver Collector is the bot responsible to get the report through the API.",
             "module": "intelmq.bots.collectors.blueliv.collector_crimeserver",
             "parameters": {
+                "api_url": "https://freeapi.blueliv.com",
                 "api_key": "<insert your api key>",
                 "name": "Blueliv Crimeserver",
                 "provider": "Blueliv",

--- a/intelmq/bots/collectors/blueliv/collector_crimeserver.py
+++ b/intelmq/bots/collectors/blueliv/collector_crimeserver.py
@@ -21,7 +21,7 @@ class BluelivCrimeserverCollectorBot(CollectorBot):
         if self.parameters.http_proxy and self.parameters.https_proxy:
             proxy = {'http': self.parameters.http_proxy,
                      'https': self.parameters.https_proxy}
-        api = BluelivAPI(base_url='https://freeapi.blueliv.com',
+        api = BluelivAPI(base_url=self.parameters.api_url,
                          token=self.parameters.api_key,
                          log_level=logging.INFO,
                          proxy=proxy)


### PR DESCRIPTION
Non-free Blueliv crimeserver API uses a different API URL which the original Blueliv collector was not able to receive as an input.