### PR TITLE
Fix #1329, CleanMX parser support for 'first' source timestamp field

### DIFF
--- a/intelmq/bots/parsers/cleanmx/parser.py
+++ b/intelmq/bots/parsers/cleanmx/parser.py
@@ -1,6 +1,7 @@
 from xml.etree import ElementTree
 
 from collections import OrderedDict
+from datetime import datetime
 
 from intelmq.lib import utils
 from intelmq.lib.bot import ParserBot
@@ -9,8 +10,8 @@ from intelmq.lib.exceptions import ConfigurationError
 PHISHING = OrderedDict([
     ("line", "__IGNORE__"),
     ("id", "extra"),
-    ("first", "__IGNORE__"),
-    ("firsttime", "time.source"),
+    ("first", "time.source"),
+    ("firsttime", "__IGNORE__"),
     ("last", "__IGNORE__"),
     ("lasttime", "__IGNORE__"),
     ("phishtank", "extra"),
@@ -37,8 +38,8 @@ VIRUS = OrderedDict([
     ("line", "__IGNORE__"),
     ("id", "extra"),
     ("sub", "extra"),
-    ("first", "__IGNORE__"),
-    ("firsttime", "time.source"),
+    ("first", "time.source"),
+    ("firsttime", "__IGNORE__"),
     ("last", "__IGNORE__"),
     ("lasttime", "__IGNORE__"),
     ("scanner", "extra"),
@@ -134,7 +135,15 @@ class CleanMXParserBot(ParserBot):
                     continue
 
                 if key == "time.source":
-                    value = value + " UTC"
+                    try:
+                        value = (
+                            datetime.utcfromtimestamp(int(value)).isoformat()
+                            + " UTC")
+                    except TypeError as e:
+                        self.logger.warning(
+                            'No valid "first" field epoch time found, skipping '
+                            'timestamp. Got {} {}'.format(value, e))
+                        continue
 
                 if key == "source.asn":
                     if value.upper().startswith("ASNA"):

--- a/intelmq/tests/bots/parsers/cleanmx/test_parser.py
+++ b/intelmq/tests/bots/parsers/cleanmx/test_parser.py
@@ -41,7 +41,8 @@ PHISHING_EVENTS = [{
                         'feed.url': 'http://support.clean-mx.de/clean-mx/xmlphishing?response=alive&domain=',
                         'source.registry': 'ARIN',
                         'extra.inetnum': '104.16.0.0 - 104.31.255.255',
-                        'source.geolocation.cc': 'US'
+                        'source.geolocation.cc': 'US',
+                        'time.source': '2017-08-06T14:59:50+00:00'
                     },
                     {
                         'source.abuse_contact': 'abuse@mochahost.com',
@@ -66,7 +67,8 @@ PHISHING_EVENTS = [{
                         'feed.url': 'http://support.clean-mx.de/clean-mx/xmlphishing?response=alive&domain=',
                         'source.registry': 'ARIN',
                         'extra.inetnum': '198.38.80.0 - 198.38.95.255',
-                        'source.geolocation.cc': 'US'
+                        'source.geolocation.cc': 'US',
+                        'time.source': '2017-08-23T17:04:43+00:00'
                     },
                     {
                         'classification.type': 'phishing',
@@ -83,6 +85,7 @@ PHISHING_EVENTS = [{
                         'source.registry': 'ARIN',
                         'status': 'toggle',
                         'time.observation': '2015-11-02T13:11:43+00:00',
+                        'time.source': '2017-10-18T17:48:09+00:00',
                         '__type': 'Event',
                     },
                     ]
@@ -119,7 +122,8 @@ VIRUSES_EVENTS = [{
                     'malware.hash.md5': '14404b4610a945706d802a54eed2429b',
                     'source.abuse_contact': 'abuse@cloudflare.com',
                     'extra.ns1': 'noah.ns.cloudflare.com',
-                    'extra.id': '112588349'
+                    'extra.id': '112588349',
+                    'time.source': '2017-12-12T22:30:10+00:00'
                 },
                 {
                     'malware.name': 'phishing.html.doc',
@@ -148,7 +152,8 @@ VIRUSES_EVENTS = [{
                     'malware.hash.md5': 'a862d6f2238585042948ed1f720ce1f3',
                     'source.abuse_contact': 'abuse@netregistry.com.au',
                     'extra.ns1': 'ns-2.ezyreg.com',
-                    'extra.id': '112588346'
+                    'extra.id': '112588346',
+                    'time.source': '2017-12-12T22:30:09+00:00'
                 }]
 
 


### PR DESCRIPTION
Previously time.source was appearing empty. That caused
issues for upstream parsing via Logstash.

Patch reads the epoch time from the CleanMX 'first' field then
assigns to time.source. Also adds field tests to the existing
parser tests.