### PR TITLE
BUG: Update taxonomy mapping to enisa version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,39 @@ CHANGELOG
 - `bin/rewrite_config_files.py`: Fix ordering of BOTS file (#1327).
 
 ### Harmonization
+Update to 2018-09-26 version. New values are per taxonomy:
+- Taxonomy 'intrusions':
+  - "application-compromise"
+  - "burglary"
+  - "privileged-account-compromise"
+  - "unprivileged-account-compromise"
+- Taxonomy 'fraud':
+  - "copyright"
+  - "masquerade"
+  - "unauthorized-use-of-resources"
+- Taxonomy 'information content security':
+  - "data-loss"
+- Taxonomy 'vulnerable':
+  - "ddos-amplifier"
+  - "information-disclosure"
+  - "potentially-unwanted-accessible"
+  - "vulnerable-system"
+  - "weak-crypto"
+- Taxonomy 'availability':
+  - "dos"
+  - "outage"
+  - "sabotage"
+- Taxonomy 'abusive-content':
+  - "harmful-speech"
+  - "violence"
+- Taxonomy 'malicious code':
+  - "malware-distribution"
+- Taxonomy 'information-gathering':
+  - "social-engineering"
+  - "sniffing"
+- Taxonomy 'information content security':
+  - "Unauthorised-information-access"
+  - "Unauthorised-information-modification"
 
 ### Bots
 #### Collectors

--- a/docs/Harmonization-fields.md
+++ b/docs/Harmonization-fields.md
@@ -123,36 +123,66 @@ Sanitation accepts string 'true' and 'false' and integers 0 and 1.
 
 ### ClassificationType
 
-classification.type type. Allowed values are:
+`classification.type` type.
+
+The mapping follows
+Reference Security Incident Taxonomy Working Group – RSIT WG
+https://github.com/enisaeu/Reference-Security-Incident-Taxonomy-Task-Force/
+with extensions.
+
+Allowed values are:
+ * application-compromise
  * backdoor
  * blacklist
  * botnet drone
  * brute-force
+ * burglary
  * c&c
  * compromised
+ * copyright
+ * data-loss
  * ddos
+ * ddos-amplifier
  * defacement
  * dga domain
+ * dos
  * dropzone
  * exploit
+ * harmful-speech
  * ids alert
  * infected system
+ * information-disclosure
  * leak
  * malware
  * malware configuration
+ * malware-distribution
+ * masquerade
  * other
+ * outage
  * phishing
+ * potentially-unwanted-accessible
+ * privileged-account-compromise
  * proxy
  * ransomware
+ * sabotage
  * scanner
+ * sniffing
+ * social-engineering
  * spam
  * test
  * tor
- * unauthorized-login
+ * Unauthorised-information-access
+ * Unauthorised-information-modification
  * unauthorized-command
+ * unauthorized-login
+ * unauthorized-use-of-resources
  * unknown
+ * unprivileged-account-compromise
+ * violence
  * vulnerable client
  * vulnerable service
+ * vulnerable-system
+ * weak-crypto
 
 ### DateTime
 

--- a/intelmq/bots/experts/taxonomy/expert.py
+++ b/intelmq/bots/experts/taxonomy/expert.py
@@ -1,4 +1,10 @@
 # -*- coding: utf-8 -*-
+"""
+The mapping follows
+Reference Security Incident Taxonomy Working Group – RSIT WG
+https://github.com/enisaeu/Reference-Security-Incident-Taxonomy-Task-Force/
+with extensions.
+"""
 
 from intelmq.lib.bot import Bot
 
@@ -6,35 +12,59 @@ from intelmq.lib.bot import Bot
 
 TAXONOMY = {
     # type       # taxonomy
-    "phishing": "fraud",
-    "proxy": "Other",
-    "ddos": "availability",
+    # sorted!
     "spam": "abusive content",
+    "harmful-speech": "abusive-content",
+    "violence": "abusive-content",
+    "ddos": "availability",
+    "dos": "availability",
+    "outage": "availability",
+    "sabotage": "availability",
+    "copyright": "fraud",
+    "masquerade": "fraud",
+    "phishing": "fraud",
+    "unauthorized-use-of-resources": "fraud",
+    "Unauthorised-information-access": "information content security",
+    "Unauthorised-information-modification": "information content security",
+    "data-loss": "information content security",
+    "dropzone": "information content security",  # not in ENISA eCSIRT-II taxonomy
+    "leak": "information content security",  # not in ENISA eCSIRT-II taxonomy
     "scanner": "information gathering",
-    "dropzone": "information content security",
-    "malware": "malicious code",
-    "botnet drone": "malicious code",
-    "ransomware": "malicious code",
-    "dga domain": "malicious code",
-    "malware configuration": "malicious code",
-    "c&c": "malicious code",
-    "exploit": "intrusion attempts",
+    "sniffing": "information-gathering",
+    "social-engineering": "information-gathering",
     "brute-force": "intrusion attempts",
-    "ids alert": "intrusion attempts",
-    "defacement": "intrusions",
-    "compromised": "intrusions",
-    "backdoor": "intrusions",
-    "vulnerable service": "vulnerable",
-    "vulnerable client": "vulnerable",
+    "exploit": "intrusion attempts",
+    "ids alert": "intrusion attempts",  # ENISA eCSIRT-II taxonomy: 'ids-alert'
+    "application-compromise": "intrusions",
+    "backdoor": "intrusions",  # not in ENISA eCSIRT-II taxonomy
+    "burglary": "intrusions",
+    "compromised": "intrusions",  # not in ENISA eCSIRT-II taxonomy,
+    "defacement": "intrusions",  # not in ENISA eCSIRT-II taxonomy
+    "privileged-account-compromise": "intrusions",
+    "unauthorized-command": "intrusions",  # not in ENISA eCSIRT-II taxonomy
+    "unauthorized-login": "intrusions",  # not in ENISA eCSIRT-II taxonomy
+    "unprivileged-account-compromise": "intrusions",
+    "botnet drone": "malicious code",
+    "c&c": "malicious code",  # ENISA eCSIRT-II taxonomy: 'c2server'
+    "dga domain": "malicious code",
+    "infected system": "malicious code",  # ENISA eCSIRT-II taxonomy: 'infected-system'
+    "malware": "malicious code",
+    "malware configuration": "malicious code",  # ENISA eCSIRT-II taxonomy: 'malware-configuration'
+    "malware-distribution": "malicious code",
+    "ransomware": "malicious code",
     "blacklist": "other",
+    "other": "other",
+    "proxy": "other",
+    "tor": "other",
     "unknown": "other",
     "test": "test",
-    "other": "other",
-    "tor": "other",
-    "leak": "information content security",
-    "infected system": "malicious code",
-    'unauthorized-login': 'intrusions',
-    'unauthorized-command': 'intrusions',
+    "ddos-amplifier": "vulnerable",
+    "information-disclosure": "vulnerable",
+    "potentially-unwanted-accessible": "vulnerable",
+    "vulnerable client": "vulnerable",  # not in ENISA eCSIRT-II taxonomy
+    "vulnerable service": "vulnerable",  # not in ENISA eCSIRT-II taxonomy
+    "vulnerable-system": "vulnerable",
+    "weak-crypto": "vulnerable",
 }
 
 

--- a/intelmq/lib/harmonization.py
+++ b/intelmq/lib/harmonization.py
@@ -137,38 +137,68 @@ class Boolean(GenericType):
 
 class ClassificationType(GenericType):
     """
-    classification.type type. Allowed values are:
+    `classification.type` type.
+
+    The mapping follows
+    Reference Security Incident Taxonomy Working Group – RSIT WG
+    https://github.com/enisaeu/Reference-Security-Incident-Taxonomy-Task-Force/
+    with extensions.
+
+    Allowed values are:
      * """
 
-    allowed_values = ['backdoor',
+    allowed_values = ["application-compromise",
+                      'backdoor',
                       'blacklist',
                       'botnet drone',
                       'brute-force',
+                      "burglary",
                       'c&c',
                       'compromised',
+                      "copyright",
+                      "data-loss",
                       'ddos',
+                      "ddos-amplifier",
                       'defacement',
                       'dga domain',
+                      "dos",
                       'dropzone',
                       'exploit',
+                      'harmful-speech',
                       'ids alert',
                       'infected system',
+                      "information-disclosure",
                       'leak',
                       'malware',
                       'malware configuration',
+                      'malware-distribution',
+                      "masquerade",
                       'other',
+                      'outage',
                       'phishing',
+                      "potentially-unwanted-accessible",
+                      "privileged-account-compromise",
                       'proxy',
                       'ransomware',
+                      'sabotage',
                       'scanner',
+                      'sniffing',
+                      'social-engineering',
                       'spam',
                       'test',
                       'tor',
-                      'unauthorized-login',
+                      "Unauthorised-information-access",
+                      "Unauthorised-information-modification",
                       'unauthorized-command',
+                      'unauthorized-login',
+                      "unauthorized-use-of-resources",
                       'unknown',
+                      "unprivileged-account-compromise",
+                      'violence',
                       'vulnerable client',
                       'vulnerable service',
+                      "vulnerable-system",
+                      "weak-crypto",
                       ]
 
     __doc__ += '\n     * '.join(allowed_values)


### PR DESCRIPTION
Updates from the September meeting of the working group

I did not rename any fields yet to be backwards-compatibly (this is for the bug fix release)

see also https://github.com/enisaeu/Reference-Security-Incident-Taxonomy-Task-Force/issues/29

ping @th-certbund 