### PR TITLE
Fixed typo in defaults.conf key

### DIFF
--- a/intelmq/etc/defaults.conf
+++ b/intelmq/etc/defaults.conf
@@ -24,7 +24,7 @@
     "logging_level": "INFO",
     "logging_path": "/opt/intelmq/var/log/",
     "logging_syslog": "/dev/log",
-    "proccess_manager": "intelmq",
+    "process_manager": "intelmq",
     "rate_limit": 0,
     "source_pipeline_db": 2,
     "source_pipeline_host": "127.0.0.1",


### PR DESCRIPTION
This value is used here without this typo:
https://github.com/certtools/intelmq/blob/develop/intelmq/bin/intelmqctl.py#L469 
