### PR TITLE
collector http time-delta ability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,9 @@ CHANGELOG
 - added `intelmq.bots.parsers.opendxl.collector` (#1265).
 - added `intelmq.bots.collectors.api`: collecting data using an HTTP API (#123, #1187).
 - added `intelmq.bots.collectors.rsync` (#1286).
-- `intelmq.bots.collectors.http.collector_http`: Add support for uncompressing of gzipped-files (#1270).
+- `intelmq.bots.collectors.http.collector_http`:
+  - Add support for uncompressing of gzipped-files (#1270).
+  - Add time-delta support for time formatted URLs.
 - `intelmq.collectors.blueliv.collector_crimeserver`: Allow setting the API URL by parameter (#1336).
 
 #### Parsers

--- a/docs/Bots.md
+++ b/docs/Bots.md
@@ -268,7 +268,8 @@ This configuration resides in the file `runtime.conf` in your intelmq's configur
 * **HTTP parameters** (see above)
 * `extract_files`: Optional, boolean or list of strings. If it is not false, the retrieved (compressed) file or archived will be uncompressed/unpacked and the files are extracted. If the parameter is a list for strings, only the files matching the filenames are extracted. Extraction handles gziped files and both compressed and uncompressed tar-archives.
 * `http_url`: location of information resource (e.g. https://feodotracker.abuse.ch/blocklist/?download=domainblocklist)
-* `http_url_formatting`: If `True` (default `False`) `{time[format]}` will be replaced by the current time formatted by the given format. E.g. if the URL is `http://localhost/{time[%Y]}`, then the resulting URL is `http://localhost/2018` for the year 2018. Currently only the time in local timezone is available. Python's [Format Specification Mini-Language¶](https://docs.python.org/3/library/string.html) is used for this.
+* `http_url_formatting`: (`bool|JSON`, default: `false`) If `true`, `{time[format]}` will be replaced by the current time in local timezone formatted by the given format. E.g. if the URL is `http://localhost/{time[%Y]}`, then the resulting URL is `http://localhost/2019` for the year 2019. (Python's [Format Specification Mini-Language](https://docs.python.org/3/library/string.html#formatspec) is used for this.)
+You may use `a JSON` specifiying [time-delta](https://docs.python.org/3/library/datetime.html#datetime.timedelta) parameters to shift the current time accordingly. Ex: type in `{"days": -1}` to use yesterday's date; the URL `http://localhost/{time[%Y-%m-%d]}` will get translated to "http://localhost/2018-12-31" for the 1st Jan of 2019.
 
 Zipped files are automatically extracted if detected.
 

--- a/intelmq/bots/collectors/http/collector_http.py
+++ b/intelmq/bots/collectors/http/collector_http.py
@@ -11,14 +11,15 @@ http_verify_cert: boolean
 extract_files: value used to extract files from downloaded compressed file
     default: None
     all: True; some: string with file names separated by ,
+http_url_formatting: bool|json to turn on time formatting (and to specify delta to current time)
 http_username, http_password: string
 http_proxy, https_proxy: string
 http_timeout_sec: tuple of two floats or float
 http_timeout_max_tries: an integer depicting how often a connection attempt is retried
 """
-import datetime
 import io
 import zipfile
+from datetime import datetime, timedelta
 
 try:
     import requests
@@ -30,8 +31,14 @@ from intelmq.lib.utils import unzip
 
 
 class Time(object):
+    def __init__(self, delta=None):
+        """ Delta is a datetime.timedelta JSON string, ex: '{days=-1}'. """
+        self.time = datetime.now()
+        if not isinstance(delta, bool):
+            self.time += timedelta(**delta)
+
     def __getitem__(self, timeformat):
-        return datetime.datetime.now().strftime(timeformat)
+        return self.time.strftime(timeformat)
 
 
 class HTTPCollectorBot(CollectorBot):
@@ -44,8 +51,17 @@ class HTTPCollectorBot(CollectorBot):
         self.extract_files = getattr(self.parameters, "extract_files", None)
 
     def process(self):
-        if getattr(self.parameters, 'http_url_formatting', False):
-            http_url = self.parameters.http_url.format(time=Time())
+
+        formatting = getattr(self.parameters, 'http_url_formatting', False)
+        if formatting:
+            try:
+                http_url = self.parameters.http_url.format(time=Time(formatting))
+            except TypeError:
+                self.logger.error("Wrongly formatted http_url_formatting parameter: %s. Should be boolean or a time-delta JSON.", formatting)
+                raise
+            except KeyError:
+                self.logger.error("Wrongly formatted http_url parameter: %s. Possible misspell with 'time' variable.", self.parameters.http_url)
+                raise
         else:
             http_url = self.parameters.http_url
 


### PR DESCRIPTION
Generic URL fetcher used local time only. But my feed generates always generates yesterday's data. So I needed to fetch yesterday.

`http_url_formatting` previously could be `true` to turn on time formatting. Now, it can contain a JSON that is passed to timedelta function so that one can easily do the relative date shift.