### PR TITLE
Added documentation for abuse.ch URLhaus feed

### DIFF
--- a/docs/Feeds.md
+++ b/docs/Feeds.md
@@ -120,6 +120,31 @@ To add feeds to this file add them to `intelmq/etc/feeds.yaml` and then run
 * **Configuration Parameters:**
 
 
+## URLhaus
+
+* **Status:** on
+* **Revision:** 14-02-2019
+* **Description:** URLhaus is a project from abuse.ch with the goal of sharing malicious URLs that are being used for malware distribution. URLhaus offers a country, ASN (AS number) and Top Level Domain (TLD) feed for network operators / Internet Service Providers (ISPs), Computer Emergency Response Teams (CERTs) and domain registries.
+
+### Collector
+
+* **Module:** intelmq.bots.collectors.http.collector_http
+* **Configuration Parameters:**
+*  * `http_url`: `https://urlhaus.abuse.ch/feeds/tld/<TLD>/, https://urlhaus.abuse.ch/feeds/country/<CC>/, or https://urlhaus.abuse.ch/feeds/asn/<ASN>/`
+*  * `name`: `URLhaus`
+*  * `provider`: `Abuse.ch`
+*  * `rate_limit`: `129600`
+
+### Parser
+
+* **Module:** intelmq.bots.parsers.generic.parser_csv
+* **Configuration Parameters:**
+*  * `columns`: `time.source,source.url,status,extra.urlhaus.threat_type,source.fqdn,source.ip,source.asn,source.geolocation.cc`
+*  * `default_url_protocol`: `http://`
+*  * `skip_header`: `False`
+*  * `type`: `malware`
+
+
 ## Zeus Tracker Domains
 
 * **Status:** off
@@ -160,33 +185,6 @@ To add feeds to this file add them to `intelmq/etc/feeds.yaml` and then run
 
 * **Module:** intelmq.bots.parsers.abusech.parser_ip
 * **Configuration Parameters:**
-
-
-## URLhaus
-
-* **Status:** on
-* **Revision:** 14-02-2019
-* **Description:** URLhaus is a project from abuse.ch with the goal of sharing malicious URLs that are being used for malware distribution.
-
-### Collector
-
-* **Module:** intelmq.bots.collectors.http.collector_http
-* **Configuration Parameters:**
-*  * `http_url`: `https://urlhaus.abuse.ch/feeds/tld/<TLD>/`,
-     `https://urlhaus.abuse.ch/feeds/country/<CC>/`, or
-     `https://urlhaus.abuse.ch/feeds/asn/<ASN>/`
-   * `name`: `URLhaus`
-   * `provider`: `Abuse.ch`
-   * `rate_limit`: `129600`
-
-### Parser
-
-* **Module:** intelmq.bots.parsers.generic.parser_csv
-* **Configuration Parameters:**
-*  * `skip_header`: `false`
-*  * `default_url_protocol`: `http://`
-*  * `type`: `malware`
-*  * `columns`: `time.source,source.url,status,extra.urlhaus.threat_type,source.fqdn,source.ip,source.asn,source.geolocation.cc`
 
 
 # AlienVault

--- a/docs/Feeds.md
+++ b/docs/Feeds.md
@@ -142,7 +142,7 @@ To add feeds to this file add them to `intelmq/etc/feeds.yaml` and then run
 *  * `columns`: `time.source,source.url,status,extra.urlhaus.threat_type,source.fqdn,source.ip,source.asn,source.geolocation.cc`
 *  * `default_url_protocol`: `http://`
 *  * `skip_header`: `False`
-*  * `type`: `malware`
+*  * `type_translation`: `{"malware_download": "malware-distribution"}`
 
 
 ## Zeus Tracker Domains

--- a/docs/Feeds.md
+++ b/docs/Feeds.md
@@ -162,6 +162,33 @@ To add feeds to this file add them to `intelmq/etc/feeds.yaml` and then run
 * **Configuration Parameters:**
 
 
+## URLhaus
+
+* **Status:** on
+* **Revision:** 14-02-2019
+* **Description:** URLhaus is a project from abuse.ch with the goal of sharing malicious URLs that are being used for malware distribution.
+
+### Collector
+
+* **Module:** intelmq.bots.collectors.http.collector_http
+* **Configuration Parameters:**
+*  * `http_url`: `https://urlhaus.abuse.ch/feeds/tld/<TLD>/`,
+     `https://urlhaus.abuse.ch/feeds/country/<CC>/`, or
+     `https://urlhaus.abuse.ch/feeds/asn/<ASN>/`
+   * `name`: `URLhaus`
+   * `provider`: `Abuse.ch`
+   * `rate_limit`: `129600`
+
+### Parser
+
+* **Module:** intelmq.bots.parsers.generic.parser_csv
+* **Configuration Parameters:**
+*  * `skip_header`: `false`
+*  * `default_url_protocol`: `http://`
+*  * `type`: `malware`
+*  * `columns`: `time.source,source.url,status,extra.urlhaus.threat_type,source.fqdn,source.ip,source.asn,source.geolocation.cc`
+
+
 # AlienVault
 
 ## OTX

--- a/intelmq/etc/feeds.yaml
+++ b/intelmq/etc/feeds.yaml
@@ -489,7 +489,7 @@ providers:
           parameters:
             skip_header: false
             default_url_protocol: http://
-            type: malware
+            type_translation: '{"malware_download": "malware-distribution"}'
             columns: time.source,source.url,status,extra.urlhaus.threat_type,source.fqdn,source.ip,source.asn,source.geolocation.cc
       revision: 14-02-2019
       status: on

--- a/intelmq/etc/feeds.yaml
+++ b/intelmq/etc/feeds.yaml
@@ -468,6 +468,32 @@ providers:
       revision: 20-01-2018
       status: on
       documentation:
+    URLhaus:
+      description: URLhaus is a project from abuse.ch with the goal of sharing malicious
+        URLs that are being used for malware distribution. URLhaus offers a country, ASN
+        (AS number) and Top Level Domain (TLD) feed for network operators / Internet Service
+        Providers (ISPs), Computer Emergency Response Teams (CERTs) and domain registries.
+      additional_information:
+      bots:
+        collector:
+          module: intelmq.bots.collectors.http.collector_http
+          parameters:
+            http_url: https://urlhaus.abuse.ch/feeds/tld/<TLD>/,
+              https://urlhaus.abuse.ch/feeds/country/<CC>/, or
+              https://urlhaus.abuse.ch/feeds/asn/<ASN>/
+            rate_limit: 129600
+            name: __FEED__
+            provider: __PROVIDER__
+        parser:
+          module: intelmq.bots.parsers.generic.parser_csv
+          parameters:
+            skip_header: false
+            default_url_protocol: http://
+            type: malware
+            columns: time.source,source.url,status,extra.urlhaus.threat_type,source.fqdn,source.ip,source.asn,source.geolocation.cc
+      revision: 14-02-2019
+      status: on
+      documentation:
   Blueliv:
     CrimeServer:
       description: Blueliv Crimeserver Collector is the bot responsible to get the


### PR DESCRIPTION
Following the discussion in https://github.com/certtools/intelmq/pull/1378, here's the documentation for the Abuse.ch URLhaus feed for malicious URLs. Please note that this configuration is targeted at the CSV Feeds provided for specific ASNs, country codes or top level domains as described here: https://urlhaus.abuse.ch/feeds/

The config mentioned by @navtej in https://github.com/certtools/intelmq/pull/1378#issuecomment-463500234 corresponds to the CSV format for the entire URLhaus dump, which is probably not suitable to pull as feed (https://urlhaus.abuse.ch/downloads/csv/).