### PR TITLE
Ignore any lines starting with blank characters in netlab 360 parser

### DIFF
--- a/intelmq/bots/parsers/netlab_360/parser.py
+++ b/intelmq/bots/parsers/netlab_360/parser.py
@@ -11,7 +11,7 @@ class Netlab360ParserBot(ParserBot):
     MIRAI_SCANNER_FEED = {'http://data.netlab.360.com/feeds/mirai-scanner/scanner.list'}
 
     def parse_line(self, line, report):
-        if line.startswith('#') or len(line) == 0:
+        if line.startswith('#') or not line.strip():
             self.tempdata.append(line)
 
         else:


### PR DESCRIPTION
In our intelmq instance the parser was raising IndexErrors for DGA feed. The empty blank line separating comments from data could include multiple blank characters and therefore raising an IndexError. This was caused by checking the length of string and not stripping it from blank character prefixes and suffixes.

We couldn't target the main cause yet, but this could affect the parsing process.