### PR TITLE
Enrich failed to parse line error message with feed_url and line

### DIFF
--- a/intelmq/lib/bot.py
+++ b/intelmq/lib/bot.py
@@ -813,7 +813,8 @@ class ParserBot(Bot):
                 else:
                     events = [value]
             except Exception:
-                self.logger.exception("Failed to parse line '{}' for feed '{}'".format(line, report.get('feed.url', 'Feed URL is unspecified')))
+                self.logger.exception("Failed to parse line '{}' for feed '{}'".format(
+                                      line, report.get('feed.url', 'Feed URL is unspecified')))
                 self.__failed.append((traceback.format_exc(), line))
             else:
                 events_count += len(events)

--- a/intelmq/lib/bot.py
+++ b/intelmq/lib/bot.py
@@ -813,7 +813,7 @@ class ParserBot(Bot):
                 else:
                     events = [value]
             except Exception:
-                self.logger.exception("Failed to parse line '{}' for feed '{}'".format(line, report['feed.url']))
+                self.logger.exception("Failed to parse line '{}' for feed '{}'".format(line, report.get('feed.url', 'Feed URL is unspecified')))
                 self.__failed.append((traceback.format_exc(), line))
             else:
                 events_count += len(events)

--- a/intelmq/lib/bot.py
+++ b/intelmq/lib/bot.py
@@ -813,7 +813,7 @@ class ParserBot(Bot):
                 else:
                     events = [value]
             except Exception:
-                self.logger.exception('Failed to parse line.')
+                self.logger.exception("Failed to parse line '{}' for feed '{}'".format(line, report['feed.url']))
                 self.__failed.append((traceback.format_exc(), line))
             else:
                 events_count += len(events)


### PR DESCRIPTION
The `Failed to parse line.` error message is very frequent and missing more direct information about the specific line and feed.