### PR TITLE
Elasticsearch SSL Support

### DIFF
--- a/docs/Bots.md
+++ b/docs/Bots.md
@@ -1614,6 +1614,10 @@ Output Bot that sends events to Elasticsearch
 * elastic_doctype    : Elasticsearch document type for the event. Default: events
 * http_username      : http_auth basic username
 * http_password      : http_auth basic password
+* use_ssl            : Whether to use SSL/TLS when connecting to Elasticsearch. Default: False
+* http_verify_cert   : Whether to require verification of the server's certificate. Default: False
+* ssl_ca_certificate : An optional path to a certificate bundle to use for verifying the server
+* ssl_show_warnings  : Whether to show warnings if the server's certificate can not be verified. Default: True
 * replacement_char   : If set, dots ('.') in field names will be replaced with this character prior to indexing. This is for backward compatibility with ES 2.X. Default: null. Recommended for ES2.X: '_'
 * flatten_fields     : In ES, some query and aggregations work better if the fields are flat and not JSON. Here you can provide a list of fields to convert.
                        Can be a list of strings (fieldnames) or a string with field names separated by a comma (,). eg `extra,field2` or `['extra', 'field2']`

--- a/intelmq/bots/BOTS
+++ b/intelmq/bots/BOTS
@@ -911,6 +911,10 @@
                 "elastic_doctype": "events",
                 "http_username": null,
                 "http_password": null,
+                "use_ssl": false,
+                "http_verify_cert": false,
+                "ssl_ca_certificate": null,
+                "ssl_show_warnings": true,
                 "flatten_fields": "extra",
                 "replacement_char": null
             }

--- a/intelmq/bots/outputs/elasticsearch/README.md
+++ b/intelmq/bots/outputs/elasticsearch/README.md
@@ -17,6 +17,10 @@ Output Bot that sends events to Elasticsearch
 * elastic_doctype    : Elasticsearch document type for the event. Default: events
 * http_username      : http_auth basic username
 * http_password      : http_auth basic password
+* use_ssl            : Whether to use SSL/TLS when connecting to Elasticsearch. Default: False
+* http_verify_cert   : Whether to require verification of the server's certificate. Default: False
+* ssl_ca_certificate : An optional path to a certificate bundle to use for verifying the server
+* ssl_show_warnings  : Whether to show warnings if the server's certificate can not be verified. Default: True
 * replacement_char   : If set, dots ('.') in field names will be replaced with this character prior to indexing. This is for backward compatibility with ES 2.X. Default: null. Recommended for ES2.X: '_'
 * flatten_fields     : In ES, some query and aggregations work better if the fields are flat and not JSON. Here you can provide a list of fields to convert.
                        Can be a list of strings (fieldnames) or a string with field names separated by a comma (,). eg `extra,field2` or `['extra', 'field2']`

--- a/intelmq/bots/outputs/elasticsearch/output.py
+++ b/intelmq/bots/outputs/elasticsearch/output.py
@@ -61,10 +61,12 @@ class ElasticsearchOutputBot(Bot):
                                      'elastic_index', 'intelmq')
         self.rotate_index = getattr(self.parameters,
                                     'rotate_index', False)
-        self.http_username = getattr(self.parameters,
-                                     'http_username', None)
-        self.http_password = getattr(self.parameters,
-                                     'http_password', None)
+        self.use_ssl = getattr(self.parameters,
+                               'use_ssl', False)
+        self.ssl_ca_certificate = getattr(self.parameters,
+                                          'ssl_ca_certificate', None)
+        self.ssl_show_warnings = getattr(self.parameters,
+                                         'ssl_show_warnings', True)
         self.elastic_doctype = getattr(self.parameters,
                                        'elastic_doctype', 'events')
         self.replacement_char = getattr(self.parameters,
@@ -74,11 +76,17 @@ class ElasticsearchOutputBot(Bot):
         if isinstance(self.flatten_fields, str):
             self.flatten_fields = self.flatten_fields.split(',')
 
-        kwargs = {}
-        if self.http_username and self.http_password:
-            kwargs = {'http_auth': (self.http_username, self.http_password)}
+        self.set_request_parameters()  # Not all parameters set here are used by the ES client
 
-        self.es = Elasticsearch([{'host': self.elastic_host, 'port': self.elastic_port}], **kwargs)
+        self.es = Elasticsearch([{'host': self.elastic_host, 'port': self.elastic_port}],
+                                http_auth=self.auth,
+                                use_ssl=self.use_ssl,
+                                verify_certs=self.http_verify_cert,
+                                ca_certs=self.ssl_ca_certificate,
+                                ssl_show_warn=self.ssl_show_warnings,
+                                # client_cert=self.ssl_client_cert,
+                                # client_key=None
+                                )
 
         if self.should_rotate():
             # Use rotating index names - check that the template exists


### PR DESCRIPTION
Adds SSL for connection to Elasticsearch. Includes:
- new parameters for using + verifying SSL, optional path to CA cert bundle, option to suppress warnings
- docs

Client authentication is not implemented -- I left placeholders in the ES client code but don't have a setup right now using client certs to test the behavior. It may just need two more parameters added to the bot.

Related to #1150 