### PR TITLE
ENH: I can't start my intelMQ

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ CHANGELOG
 
 ### Documentation
 - Feeds: Document abuse.ch URLhaus feed (#1379).
+- Install and Upgrading: Use `intelmqsetup` tool.
 
 ### Packaging
 
@@ -75,6 +76,7 @@ CHANGELOG
 - `intelmqdump`: Inspecting dumps locks the dump file using unix file locks (#574).
 - `intelmqctl`:
   - After the check if the program runs as root, it tries to drop privileges. Only if this does not work, a warning is shown.
+- `intelmqsetup`: New tool for initialize an IntelMQ environment.
 
 ### Contrib
 - `malware_name_mapping`:

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -38,7 +38,7 @@ If you are using native packages, you can simply skip this section as all depend
 
 ```bash
 apt-get install python3 python3-pip
-apt-get install git build-essential libffi-dev
+apt-get install build-essential libffi-dev
 apt-get install python3-dev
 apt-get install redis-server
 ```
@@ -55,7 +55,7 @@ python3.4 /tmp/get-pip.py
 
 ```bash
 apt install python3-pip python3-dnspython python3-psutil python3-redis python3-requests python3-termstyle python3-tz python3-dateutil
-apt install git redis-server
+apt install redis-server
 ```
 
 Optional dependencies:
@@ -69,7 +69,7 @@ apt install python3-sleekxmpp python3-pymongo python3-psycopg2
 ```bash
 yum install epel-release
 yum install python34 python34-devel
-yum install git gcc gcc-c++
+yum install gcc gcc-c++
 yum install redis
 ```
 
@@ -83,7 +83,7 @@ python3.4 /tmp/get-pip.py
 
 ```bash
 zypper install python3-dateutil python3-dnspython python3-psutil python3-pytz python3-redis python3-requests python3-python-termstyle
-zypper install git redis
+zypper install redis
 ```
 
 Optional dependencies:
@@ -125,18 +125,13 @@ Please report any errors or improvements at [IntelMQ Issues](https://github.com/
 ## PyPi
 
 ```bash
-sudo -s
+sudo -i
 
 pip3 install intelmq
 
-mv `python3 -c "import site; print(site.getsitepackages()[0] + '/opt/intelmq')"` /opt/
-
 useradd -d /opt/intelmq -U -s /bin/bash intelmq
-chmod -R 0770 /opt/intelmq
-chown -R intelmq.intelmq /opt/intelmq
+sudo intelmqsetup
 ```
-
-**Note:** the reason why instructions have the `mv` command using python output is because pip3 installation method does not (and cannot) create `/opt/intelmq`, as described in [Issue #189](https://github.com/certtools/intelmq/issues/819).
 
 
 ## Additional Information

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -39,7 +39,8 @@ Use your systems package management.
 ### PyPi
 
 ```
-> pip install -U --no-deps intelmq
+pip install -U --no-deps intelmq
+sudo intelmqsetup
 ```
 Using `--no-deps` will not upgrade dependencies, which would probably overwrite the system's libraries.
 Remove this option to also upgrade dependencies.
@@ -52,26 +53,19 @@ Update the repository depending on your setup (e.g. `git pull origin master`).
 
 And run the installation again:
 ```bash
-> pip install .
+pip install .
+sudo intelmqsetup
 ```
-For editable installations, run `pip install -e .` instead.
+For editable installations (development only), run `pip install -e .` instead.
 
 ## Check the installation
 
 Go through [NEWS.md](../NEWS.md) and apply necessary adaptions to your setup.
 If you have adapted IntelMQ's code, also read the [CHANGELOG.md](../CHANGELOG.md).
 
-Check your installation and configuration fix detected problems:
+Check your installation and configuration to detect any problems:
 ```bash
-> intelmqctl check
-```
-
-## Redefine/Check permissions
-
-If you used `pip` for installation check and/or fix the permissions:
-```bash
-> chmod -R 0770 /opt/intelmq
-> chown -R intelmq.intelmq /opt/intelmq
+intelmqctl check
 ```
 
 ## Start IntelMQ

--- a/intelmq/bin/intelmqsetup.py
+++ b/intelmq/bin/intelmqsetup.py
@@ -1,0 +1,71 @@
+#!/usr/bin/python3
+# -*- coding: utf-8 -*-
+"""
+© 2019 Sebastian Wagner <wagner@cert.at>
+
+SPDX-License-Identifier: AGPL-3.0
+
+Sets up an intelmq environment after installation or upgrade by
+ * creating needed directories
+ * set intelmq as owner for those
+ * providing example configuration files if not already existing
+
+Reasoning:
+Pip does not (and cannot) create `/opt/intelmq`, as described in
+https://github.com/certtools/intelmq/issues/819
+"""
+import glob
+import os
+import shutil
+import site
+import sys
+
+from intelmq import (CONFIG_DIR, DEFAULT_LOGGING_PATH, ROOT_DIR, VAR_RUN_PATH,
+                     VAR_STATE_PATH)
+
+
+def main():
+    if os.geteuid() != 0:
+        sys.exit('You need to run this program as root.')
+
+    if not ROOT_DIR.startswith('/opt/'):
+        print('Not a pip-installation of IntelMQ.')
+
+    intelmq_path = os.path.join(site.getsitepackages()[0], 'opt/intelmq/')
+    opt_path = os.path.join(site.getsitepackages()[0], 'opt/')
+    if os.path.isdir(intelmq_path) and os.path.isdir(ROOT_DIR):
+        print('%r already exists, not moving %r there.' % (ROOT_DIR,
+                                                           intelmq_path))
+    elif os.path.isdir(intelmq_path):
+        shutil.move(intelmq_path, '/opt/')
+        print('Moved %r to %r.' % (intelmq_path, '/opt/'))
+        try:
+            os.rmdir(opt_path)
+        except OSError:
+            print('Directory %r is not empty, did not remove it.' % opt_path)
+    create_dirs = ('/opt/intelmq/var/lib/bots/file-output',
+                   '/opt/intelmq/var/run',
+                   '/opt/intelmq/var/log')
+    for create_dir in create_dirs:
+        if not os.path.isdir(create_dir):
+            os.makedirs(create_dir, mode=0o755,
+                        exist_ok=True)
+            print('Created directory %r.' % create_dir)
+
+    example_confs = glob.glob(os.path.join(CONFIG_DIR, 'examples/*.conf'))
+    for example_conf in example_confs:
+        fname = os.path.split(example_conf)[-1]
+        if os.path.exists(os.path.join(CONFIG_DIR, fname)):
+            print('Not overwriting existing %r with example.' % fname)
+        else:
+            shutil.copy(example_conf, CONFIG_DIR)
+            print('Use example %r.' % fname)
+
+    print('Setting intelmq as owner for it\'s directories.')
+    for obj in (CONFIG_DIR, DEFAULT_LOGGING_PATH, ROOT_DIR, VAR_RUN_PATH,
+                VAR_STATE_PATH):
+        shutil.chown(obj, user='intelmq')
+
+
+if __name__ == '__main__':
+    main()

--- a/setup.py
+++ b/setup.py
@@ -30,15 +30,6 @@ DATA = [
       'intelmq/etc/runtime.conf',
       ],
      ),
-    ('/opt/intelmq/var/log/',
-     [],
-     ),
-    ('/opt/intelmq/var/lib/bots/file-output/',
-     [],
-     ),
-    ('/opt/intelmq/var/lib/bots/rsync_collector',
-     [],
-     ),
 ]
 
 exec(open(os.path.join(os.path.dirname(__file__),
@@ -105,6 +96,7 @@ setup(
             'intelmqdump = intelmq.bin.intelmqdump:main',
             'intelmq_psql_initdb = intelmq.bin.intelmq_psql_initdb:main',
             'intelmq.bots.experts.sieve.validator = intelmq.bots.experts.sieve.validator:main',
+            'intelmqsetup = intelmq.bin.intelmqsetup:main',
         ] + BOTS,
     },
     scripts=[


### PR DESCRIPTION
intelmq@intelmq:~$ intelmqctl -n start
Traceback (most recent call last):
  File "/usr/local/bin/intelmqctl", line 11, in <module>
    load_entry_point('intelmq==2.0.0b2', 'console_scripts', 'intelmqctl')()
  File "/usr/local/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 489, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/usr/local/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 2843, in load_entry_point
    return ep.load()
  File "/usr/local/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 2434, in load
    return self.resolve()
  File "/usr/local/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 2440, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
  File "/usr/local/lib/python2.7/dist-packages/intelmq-2.0.0b2-py2.7.egg/intelmq/bin/intelmqctl.py", line 291
    def bot_status(self, bot_id, *, proc=None):
                                  ^
SyntaxError: invalid syntax
intelmq@intelmq:~$ 