### PR TITLE
Update `pymongo` to 3.0.0 version

### DIFF
--- a/docs/Bots.md
+++ b/docs/Bots.md
@@ -1768,7 +1768,7 @@ Saves events in a MongoDB either as hierarchical structure or flat with full key
 #### Installation Requirements
 
 ```
-pip3 install pymongo>=2.7.1
+pip3 install pymongo>=3.0.0
 ```
 
 * * *

--- a/intelmq/bots/outputs/mongodb/REQUIREMENTS.txt
+++ b/intelmq/bots/outputs/mongodb/REQUIREMENTS.txt
@@ -1,1 +1,1 @@
-pymongo>=2.7.1
+pymongo>=3.0.0

--- a/intelmq/bots/outputs/mongodb/output.py
+++ b/intelmq/bots/outputs/mongodb/output.py
@@ -65,7 +65,7 @@ class MongoDBOutputBot(Bot):
                 tmp_dict[time_src] = dateutil.parser.parse(tmp_dict[time_obs])
 
         try:
-            self.collection.insert(tmp_dict)
+            self.collection.insert_one(tmp_dict)
         except pymongo.errors.AutoReconnect:
             self.logger.error('Connection Lost. Connecting again.')
             self.connect()


### PR DESCRIPTION
Hi,

I've tried to update package `pymongo` to 3.0.0 because of issue #1063 

To run local mongo:
`$ docker run -i -t --network host mongo:3.4-xenial /bin/bash`

To run tests:
`$ INTELMQ_TEST_DATABASES=1 python intelmq/tests/bots/outputs/mongodb/test_output.py`

To review my changes I used this [changelog](https://github.com/mongodb/mongo-python-driver/blob/0b0f045d56176807edea9e547ab6a1288740a5d8/doc/changelog.rst#changes-in-version-30)

