### PR TITLE
Update utils.py

### DIFF
--- a/intelmq/lib/utils.py
+++ b/intelmq/lib/utils.py
@@ -564,6 +564,7 @@ def setup_list_logging(name='intelmq', logging_level='INFO'):
     check_logger.setLevel('INFO')
     return check_logger, list_handler
 
+
 def version_smaller(version1: tuple, version2: tuple) -> Optional[bool]:
     """
     Parameters:

--- a/intelmq/lib/utils.py
+++ b/intelmq/lib/utils.py
@@ -562,7 +562,7 @@ def setup_list_logging(name='intelmq', logging_level='INFO'):
     list_handler.setLevel('INFO')
     check_logger.addHandler(list_handler)
     check_logger.setLevel('INFO')
-
+    return check_logger, list_handler
 
 def version_smaller(version1: tuple, version2: tuple) -> Optional[bool]:
     """


### PR DESCRIPTION
```intelmqctl --type json check``` (as executed by intelmq-manager) fails on RETURN_TYPE == 'json': because setup_list_logging does not return the required iterable:
```
Traceback (most recent call last):
  File "/usr/local/bin/intelmqctl", line 11, in <module>
    load_entry_point('intelmq', 'console_scripts', 'intelmqctl')()
  File "/opt/intelmq.git/intelmq/bin/intelmqctl.py", line 1553, in main
    return x.run()
  File "/opt/intelmq.git/intelmq/bin/intelmqctl.py", line 936, in run
    retval, results = args.func(**args_dict)
  File "/opt/intelmq.git/intelmq/bin/intelmqctl.py", line 1286, in check
    logging_level=self.logging_level)
TypeError: 'NoneType' object is not iterable
```
Which breaks intelmq-manager check page.