### PR TITLE
ENH: default overwrite on reverse_dns and cymru_whois

### DIFF
--- a/intelmq/bots/BOTS
+++ b/intelmq/bots/BOTS
@@ -879,7 +879,8 @@
                 "redis_cache_host": "127.0.0.1",
                 "redis_cache_password": null,
                 "redis_cache_port": "6379",
-                "redis_cache_ttl": "86400"
+                "redis_cache_ttl": "86400",
+                "overwrite": true
             }
         },
         "Sieve": {

--- a/intelmq/bots/BOTS
+++ b/intelmq/bots/BOTS
@@ -696,7 +696,8 @@
                 "redis_cache_host": "127.0.0.1",
                 "redis_cache_password": null,
                 "redis_cache_port": "6379",
-                "redis_cache_ttl": "86400"
+                "redis_cache_ttl": "86400",
+                "overwrite": true
             }
         },
         "Deduplicator": {

--- a/intelmq/bots/experts/cymru_whois/expert.py
+++ b/intelmq/bots/experts/cymru_whois/expert.py
@@ -21,6 +21,8 @@ class CymruExpertBot(Bot):
                                    None)
                            )
 
+        self.overwrite = getattr(self.parameters, 'overwrite', True)
+
     def process(self):
         event = self.receive_message()
 
@@ -61,7 +63,7 @@ class CymruExpertBot(Bot):
             for result_key, result_value in result.items():
                 if result_key == 'registry' and result_value == 'other':
                     continue
-                event.add(key % result_key, result_value, overwrite=True)
+                event.add(key % result_key, result_value, overwrite=self.overwrite)
 
         self.send_message(event)
         self.acknowledge_message()

--- a/intelmq/bots/experts/reverse_dns/expert.py
+++ b/intelmq/bots/experts/reverse_dns/expert.py
@@ -28,6 +28,8 @@ class ReverseDnsExpertBot(Bot):
                                    None)
                            )
 
+        self.overwrite = getattr(self.parameters, 'overwrite', True)
+
     def process(self):
         event = self.receive_message()
 
@@ -37,6 +39,8 @@ class ReverseDnsExpertBot(Bot):
             ip_key = key % "ip"
 
             if ip_key not in event:
+                continue
+            if key % 'reverse_dns' in event and not self.overwrite:
                 continue
 
             ip = event.get(ip_key)
@@ -82,7 +86,7 @@ class ReverseDnsExpertBot(Bot):
                                    ttl=int(ttl.total_seconds()))
 
             if result is not None:
-                event.add(key % 'reverse_dns', str(result), overwrite=True)
+                event.add(key % 'reverse_dns', str(result), overwrite=self.overwrite)
 
         self.send_message(event)
         self.acknowledge_message()

--- a/intelmq/tests/bots/experts/cymru_whois/test_expert.py
+++ b/intelmq/tests/bots/experts/cymru_whois/test_expert.py
@@ -75,6 +75,16 @@ EXAMPLE_6TO4_OUTPUT = {"__type": "Event",
                   "source.as_name": "SURFNET-NL SURFnet, The Netherlands, NL",
                   "time.observation": "2015-01-01T00:00:00+00:00",
                   }
+OVERWRITE_OUT = {"__type": "Event",
+                  "source.ip": "93.184.216.34",
+                  "source.geolocation.cc": "AA",
+                  "source.registry": "LACNIC",
+                  "source.network": "93.184.216.0/24",
+                  "source.allocated": "2008-06-02T00:00:00+00:00",
+                  "source.asn": 15133,
+                  "source.as_name": "EDGECAST - MCI Communications Services, Inc. d/b/a Verizon Business, US",
+                  "time.observation": "2015-01-01T00:00:00+00:00",
+                  }
 
 @test.skip_redis()
 @test.skip_internet()
@@ -113,6 +123,14 @@ class TestCymruExpertBot(test.BotTestCase, unittest.TestCase):
         self.input_message = EXAMPLE_6TO4_INPUT
         self.run_bot()
         self.assertMessageEqual(0, EXAMPLE_6TO4_OUTPUT)
+
+    def test_overwrite(self):
+        self.input_message = EXAMPLE_INPUT.copy()
+        self.input_message["source.geolocation.cc"] = "AA"
+        self.input_message["source.registry"] = "LACNIC"
+        self.sysconfig = {'overwrite' : False}
+        self.run_bot()
+        self.assertMessageEqual(0, OVERWRITE_OUT)
 
     @unittest.expectedFailure
     def test_missing_asn(self):

--- a/intelmq/tests/bots/experts/reverse_dns/test_expert.py
+++ b/intelmq/tests/bots/experts/reverse_dns/test_expert.py
@@ -45,6 +45,13 @@ INVALID_PTR_OUT2 = {"__type": "Event",
                     "source.reverse_dns": "aliancys.peopleinc.nl",
                     "time.observation": "2015-01-01T00:00:00+00:00",
                     }
+OVERWRITE_OUT = {"__type": "Event",
+                    "source.ip": "192.0.43.7",
+                    "source.reverse_dns": "icann.org",
+                    "destination.ip": "192.0.43.8",
+                    "destination.reverse_dns": "example.net",
+                    "time.observation": "2015-01-01T00:00:00+00:00",
+                    }
 
 
 @test.skip_redis()
@@ -78,6 +85,13 @@ class TestReverseDnsExpertBot(test.BotTestCase, unittest.TestCase):
         self.input_message = INVALID_PTR_INP2
         self.run_bot()
         self.assertMessageEqual(0, INVALID_PTR_OUT2)
+
+    def test_overwrite(self):
+        self.input_message = EXAMPLE_INPUT.copy()
+        self.input_message['destination.reverse_dns'] = 'example.net'
+        self.sysconfig = {'overwrite' : False}
+        self.run_bot()
+        self.assertMessageEqual(0, OVERWRITE_OUT)
 
 
 if __name__ == '__main__':  # pragma: no cover


### PR DESCRIPTION
Fixes https://github.com/certtools/intelmq/issues/1452

Default overwrite is set to true.