### PR TITLE
Set logging_level_stream when defaults are unavailable

### DIFF
--- a/intelmq/bin/intelmqctl.py
+++ b/intelmq/bin/intelmqctl.py
@@ -651,6 +651,7 @@ class IntelMQController():
             self.load_defaults_configuration()
         except Exception:
             log_level = DEFAULT_LOGGING_LEVEL
+            logging_level_stream = 'DEBUG'
         else:
             log_level = self.parameters.logging_level.upper()
             logging_level_stream = log_level if log_level == 'DEBUG' else 'INFO'


### PR DESCRIPTION
Hi! I'm keen to try out IntelMQ but ran into an error straight after installation. Here's a simple fix.

This error occurs when invoking `intelmqctl` on my plain Ubuntu 18.04 LTS install (vagrant, ubuntu/bionic64, dependencies installed as per the install guide):

>UnboundLocalError: local variable 'logging_level_stream' referenced before assignment

The pull request simply sets that to DEBUG, allowing intelmqctl to run. Not exhaustively tested. I tried running the tests in the repo but 26 of them failed, perhaps because of Vagrant? This pull request doesn't change the test results, anyway.