### PR TITLE
BUG: fix botnet restart logging message

### DIFF
--- a/intelmq/bin/intelmqctl.py
+++ b/intelmq/bin/intelmqctl.py
@@ -57,6 +57,7 @@ MESSAGES = {
     'enabling': 'Enabling %s.',
     'disabling': 'Disabling %s.',
     'reloaded': 'Bot %s is reloaded.',
+    'restarting': 'Restarting %s...',
 }
 
 ERROR_MESSAGES = {


### PR DESCRIPTION
`MESSAGES` dict of intelmqctl.py doesn't include `restarting` key, so `intelmqctl restart` fails when it tries to log. This PR fixes it.

```
Traceback (most recent call last):
  File "/bin/intelmqctl", line 11, in <module>
    load_entry_point('intelmq==2.1.0', 'console_scripts', 'intelmqctl')()
  File "/usr/lib/python3.6/site-packages/intelmq/bin/intelmqctl.py", line 1732, in main
    return x.run()
  File "/usr/lib/python3.6/site-packages/intelmq/bin/intelmqctl.py", line 956, in run
    retval, results = args.func(**args_dict)
  File "/usr/lib/python3.6/site-packages/intelmq/bin/intelmqctl.py", line 999, in bot_restart
    return self.botnet_restart(group=group)
  File "/usr/lib/python3.6/site-packages/intelmq/bin/intelmqctl.py", line 1112, in botnet_restart
    log_botnet_message('restarting')
  File "/usr/lib/python3.6/site-packages/intelmq/bin/intelmqctl.py", line 110, in log_botnet_message
    logger.info(MESSAGES[status], 'Botnet')
KeyError: 'restarting'
```
