### PR TITLE
Fix usage description for intelmqctl

### DIFF
--- a/intelmq/bin/intelmqctl.py
+++ b/intelmq/bin/intelmqctl.py
@@ -697,7 +697,7 @@ class IntelMQController():
         DESCRIPTION = """
         description: intelmqctl is the tool to control intelmq system.
 
-        Outputs are logged to %s/intelmqctl""" % DEFAULT_LOGGING_PATH
+        Outputs are logged to %s/intelmqctl.log""" % DEFAULT_LOGGING_PATH
         EPILOG = '''
         intelmqctl [start|stop|restart|status|reload] --group [collectors|parsers|experts|outputs]
         intelmqctl [start|stop|restart|status|reload] bot-id


### PR DESCRIPTION
 * Extend the filename for logging in the same way as lib/utils.py .