### PR TITLE
hidden bug

### DIFF
--- a/intelmq/bots/experts/reverse_dns/expert.py
+++ b/intelmq/bots/experts/reverse_dns/expert.py
@@ -2,7 +2,7 @@
 
 from datetime import datetime
 
-import dns
+import dns.resolver
 
 from intelmq.lib.bot import Bot
 from intelmq.lib.cache import Cache


### PR DESCRIPTION
Hi, I've found this hidden bug. There was no effect thanks to `harmonisation.py/import dns.resolver`, if you comment this line, the unit test fails.

See:

```python3
import dns
dns.resolver, dns.reversename, dns.exception.DNSException # AttributeError: module 'dns' has no attribute 'resolver'
```

```python3
import dns.resolver
dns.resolver, dns.reversename, dns.exception.DNSException # no problem
```