### PR TITLE
Update Microsoft Collector REQUIREMENTS.txt

### DIFF
--- a/intelmq/bots/collectors/microsoft/REQUIREMENTS.txt
+++ b/intelmq/bots/collectors/microsoft/REQUIREMENTS.txt
@@ -1,1 +1,1 @@
-azure-storage>=0.33
+azure-storage >=0.33,<0.37


### PR DESCRIPTION
Starting with v0.37.0, the 'azure-storage' meta-package is deprecated and cannot be installed anymore.
see https://github.com/certtools/intelmq/issues/1530