### PR TITLE
DOC: remove old toc entry from README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -54,14 +54,13 @@ Table of Contents
 -----------------
 
 1. `How to Install <#how-to-install>`__
-2. `Developers Guide <#developers-guide>`__
-3. `User Guide <#user-guide>`__
-4. `IntelMQ Manager and more tools <#intelmq-manager-and-more-tools>`__
-5. `How to Participate <#how-to-participate>`__
-6. `Incident Handling Automation
+2. `User Guide <#user-guide>`__
+3. `IntelMQ Manager and more tools <#intelmq-manager-and-more-tools>`__
+4. `How to Participate <#how-to-participate>`__
+5. `Incident Handling Automation
    Project <#incident-handling-automation-project>`__
-7. `Licence <#licence>`__
-8. `Funded by <#funded-by>`__
+6. `Licence <#licence>`__
+7. `Funded by <#funded-by>`__
 
 How to Install
 --------------


### PR DESCRIPTION
 * remove toc for developers-guide as the section is gone and now part of how to participate