### PR TITLE
add redis_cache_host to defaults.conf

### DIFF
--- a/intelmq/etc/defaults.conf
+++ b/intelmq/etc/defaults.conf
@@ -36,4 +36,5 @@
     "statistics_host": "127.0.0.1",
     "statistics_password": null,
     "statistics_port": 6379
+    "redis_cache_host": "127.0.0.1"
 }


### PR DESCRIPTION
As it's assumed it's 127.0.0.1