### PR TITLE
FIX: feed revision: Abuse.ch URLhaus

### DIFF
--- a/docs/Feeds.md
+++ b/docs/Feeds.md
@@ -110,8 +110,8 @@ To add feeds to this file add them to `intelmq/etc/feeds.yaml` and then run
 ## URLhaus
 
 * **Public:** yes
-* **Revision:** 2019-02-14
-* **Documentation:** https://urlhaus.abuse.ch/
+* **Revision:** 2020-07-07
+* **Documentation:** https://urlhaus.abuse.ch/feeds/
 * **Description:** URLhaus is a project from abuse.ch with the goal of sharing malicious URLs that are being used for malware distribution. URLhaus offers a country, ASN (AS number) and Top Level Domain (TLD) feed for network operators / Internet Service Providers (ISPs), Computer Emergency Response Teams (CERTs) and domain registries.
 
 ### Collector
@@ -127,8 +127,9 @@ To add feeds to this file add them to `intelmq/etc/feeds.yaml` and then run
 
 * **Module:** intelmq.bots.parsers.generic.parser_csv
 * **Configuration Parameters:**
-*  * `columns`: `time.source,source.url,status,extra.urlhaus.threat_type,source.fqdn,source.ip,source.asn,source.geolocation.cc`
+*  * `columns`: `['time.source', 'source.url', 'status', 'classification.type|__IGNORE__', 'source.fqdn|__IGNORE__', 'source.ip', 'source.asn', 'source.geolocation.cc']`
 *  * `default_url_protocol`: `http://`
+*  * `delimeter`: `,`
 *  * `skip_header`: `False`
 *  * `type_translation`: `{"malware_download": "malware-distribution"}`
 

--- a/intelmq/etc/feeds.yaml
+++ b/intelmq/etc/feeds.yaml
@@ -296,9 +296,18 @@ providers:
             skip_header: false
             default_url_protocol: http://
             type_translation: '{"malware_download": "malware-distribution"}'
-            columns: time.source,source.url,status,extra.urlhaus.threat_type,source.fqdn,source.ip,source.asn,source.geolocation.cc
-      revision: 2019-02-14
-      documentation: https://urlhaus.abuse.ch/
+            delimeter: ","
+            columns:
+              - time.source
+              - source.url
+              - status
+              - classification.type|__IGNORE__
+              - source.fqdn|__IGNORE__
+              - source.ip
+              - source.asn
+              - source.geolocation.cc
+      revision: 2020-07-07
+      documentation: https://urlhaus.abuse.ch/feeds/
       public: yes
     Feodo Tracker Browse:
       description: ''


### PR DESCRIPTION
Fixes #1571.

I kept the `type_translation` even tho the feed always (as far as I can say) sets `Threat` column to `malware_download` (I found very few occasions where the `Threat` column was empty). If there ever appears any other `Threat` value, it will be ignored (the feed documentation doesn't list them therefore we can not map them before they appear and so far it seems very unlikely anyway).