### PR TITLE
ESET parser: workaround NXDOMAIN in place of IP, add recover_line

### DIFF
--- a/intelmq/bots/BOTS
+++ b/intelmq/bots/BOTS
@@ -244,6 +244,7 @@
                 "password": "<password>",
                 "endpoint": "eti.eset.com",
                 "time_delta": 3600,
+                "rate_limit": 3600,
                 "collection": "<collection>"
             }
         },

--- a/intelmq/bots/parsers/eset/parser.py
+++ b/intelmq/bots/parsers/eset/parser.py
@@ -61,7 +61,7 @@ class ESETParserBot(ParserBot):
         event.add('source.fqdn', line['domain'], raise_failure=False)  # IP addresses may be passed in line['domain']
 
         ip = line['ip']
-        if not ip.endswith('_NXDOMAIN'):
+        if ip and not ip.endswith('_NXDOMAIN'):
             event.add('source.ip', ip)
 
     recover_line = ParserBot.recover_line_json

--- a/intelmq/bots/parsers/eset/parser.py
+++ b/intelmq/bots/parsers/eset/parser.py
@@ -60,7 +60,7 @@ class ESETParserBot(ParserBot):
         event.add('classification.type', type)
         event.add('source.fqdn', line['domain'], raise_failure=False)  # IP addresses may be passed in line['domain']
 
-        event.add('source.ip', line['ip'])
+        event.add('source.ip', line['ip'], raise_failure=False)
 
 
 BOT = ESETParserBot

--- a/intelmq/bots/parsers/eset/parser.py
+++ b/intelmq/bots/parsers/eset/parser.py
@@ -62,5 +62,7 @@ class ESETParserBot(ParserBot):
 
         event.add('source.ip', line['ip'], raise_failure=False)
 
+    recover_line = ParserBot.recover_line_json
+
 
 BOT = ESETParserBot

--- a/intelmq/bots/parsers/eset/parser.py
+++ b/intelmq/bots/parsers/eset/parser.py
@@ -60,7 +60,9 @@ class ESETParserBot(ParserBot):
         event.add('classification.type', type)
         event.add('source.fqdn', line['domain'], raise_failure=False)  # IP addresses may be passed in line['domain']
 
-        event.add('source.ip', line['ip'], raise_failure=False)
+        ip = line['ip']
+        if not ip.endswith('_NXDOMAIN'):
+            event.add('source.ip', ip, raise_failure=False)
 
     recover_line = ParserBot.recover_line_json
 

--- a/intelmq/bots/parsers/eset/parser.py
+++ b/intelmq/bots/parsers/eset/parser.py
@@ -62,7 +62,7 @@ class ESETParserBot(ParserBot):
 
         ip = line['ip']
         if not ip.endswith('_NXDOMAIN'):
-            event.add('source.ip', ip, raise_failure=False)
+            event.add('source.ip', ip)
 
     recover_line = ParserBot.recover_line_json
 


### PR DESCRIPTION
Occasionally, `@ipv4_NXDOMAIN` (and presumably the same with ipv6) may pop up in place of an IP or null in the `ip` field. This is a simple workaround to still add those entries.
Also, a recover_line won't hurt.