### PR TITLE
FIX: feed revision: DynDNS Infected Domains

### DIFF
--- a/docs/Feeds.md
+++ b/docs/Feeds.md
@@ -22,7 +22,6 @@ To add feeds to this file add them to `intelmq/etc/feeds.yaml` and then run
 - [DShield](#dshield)
 - [Danger Rulez](#danger-rulez)
 - [Dataplane](#dataplane)
-- [DynDNS](#dyndns)
 - [Fraunhofer](#fraunhofer)
 - [HPHosts](#hphosts)
 - [Have I Been Pwned](#have-i-been-pwned)
@@ -51,6 +50,7 @@ To add feeds to this file add them to `intelmq/etc/feeds.yaml` and then run
 - [ViriBack](#viriback)
 - [WebInspektor](#webinspektor)
 - [ZoneH](#zoneh)
+- [cAPTure](#capture)
 
 
 <!-- /TOC -->
@@ -881,30 +881,6 @@ To add feeds to this file add them to `intelmq/etc/feeds.yaml` and then run
 ### Parser
 
 * **Module:** intelmq.bots.parsers.dataplane.parser
-* **Configuration Parameters:**
-
-
-# DynDNS
-
-## Infected Domains
-
-* **Public:** yes
-* **Revision:** 2018-01-20
-* **Documentation:** http://security-research.dyndns.org/pub/malware-feeds/
-* **Description:** DynDNS ponmocup. List of ponmocup malware redirection domains and infected web-servers. See also http://security-research.dyndns.org/pub/botnet-links.html
-
-### Collector
-
-* **Module:** intelmq.bots.collectors.http.collector_http
-* **Configuration Parameters:**
-*  * `http_url`: `http://security-research.dyndns.org/pub/malware-feeds/ponmocup-infected-domains-CIF-latest.txt`
-*  * `name`: `Infected Domains`
-*  * `provider`: `DynDNS`
-*  * `rate_limit`: `10800`
-
-### Parser
-
-* **Module:** intelmq.bots.parsers.dyn.parser
 * **Configuration Parameters:**
 
 
@@ -1998,5 +1974,33 @@ server {
 
 * **Module:** intelmq.bots.parsers.zoneh.parser
 * **Configuration Parameters:**
+
+
+# cAPTure
+
+## Ponmocup Domains
+
+* **Public:** yes
+* **Revision:** 2020-07-08
+* **Documentation:** http://security-research.dyndns.org/pub/malware-feeds/
+* **Description:** List of ponmocup malware redirection domains and infected web-servers from cAPTure. See also http://security-research.dyndns.org/pub/botnet-links.htm and http://c-apt-ure.blogspot.com/search/label/ponmocup
+
+### Collector
+
+* **Module:** intelmq.bots.collectors.http.collector_http
+* **Configuration Parameters:**
+*  * `http_url`: `http://security-research.dyndns.org/pub/malware-feeds/ponmocup-infected-domains-shadowserver.csv`
+*  * `name`: `Ponmocup Domains`
+*  * `provider`: `cAPTure`
+*  * `rate_limit`: `10800`
+
+### Parser
+
+* **Module:** intelmq.bots.parsers.generic.parser_csv
+* **Configuration Parameters:**
+*  * `columns`: `['time.source', 'source.ip', 'source.fqdn', 'source.urlpath', 'source.port', 'protocol.application', 'extra.tag', 'extra.redirect_target', 'extra.category']`
+*  * `delimiter`: `,`
+*  * `skip_header`: `True`
+*  * `type`: `malware-distribution`
 
 

--- a/intelmq/etc/feeds.yaml
+++ b/intelmq/etc/feeds.yaml
@@ -1217,23 +1217,37 @@ providers:
       revision: 2018-01-20
       documentation: https://osint.bambenekconsulting.com/feeds/
       public: yes
-  DynDNS:
-    Infected Domains:
-      description: DynDNS ponmocup. List of ponmocup malware redirection domains and
-        infected web-servers. See also http://security-research.dyndns.org/pub/botnet-links.html
+  cAPTure:
+    Ponmocup Domains:
+      description: List of ponmocup malware redirection domains and infected web-servers from cAPTure.
+        See also http://security-research.dyndns.org/pub/botnet-links.htm
+        and http://c-apt-ure.blogspot.com/search/label/ponmocup
       additional_information:
       bots:
         collector:
           module: intelmq.bots.collectors.http.collector_http
           parameters:
-            http_url: http://security-research.dyndns.org/pub/malware-feeds/ponmocup-infected-domains-CIF-latest.txt
+            http_url: http://security-research.dyndns.org/pub/malware-feeds/ponmocup-infected-domains-shadowserver.csv
             rate_limit: 10800
             name: __FEED__
             provider: __PROVIDER__
         parser:
-          module: intelmq.bots.parsers.dyn.parser
+          module: intelmq.bots.parsers.generic.parser_csv
           parameters:
-      revision: 2018-01-20
+            columns:
+              - time.source
+              - source.ip
+              - source.fqdn
+              - source.urlpath
+              - source.port
+              - protocol.application
+              - extra.tag
+              - extra.redirect_target
+              - extra.category
+            skip_header: true
+            delimiter: ","
+            type: malware-distribution
+      revision: 2020-07-08
       documentation: http://security-research.dyndns.org/pub/malware-feeds/
       public: yes
   DShield:


### PR DESCRIPTION
* Changes the feed provider name to it's true author.
* Changes feed url to csv file with shadowserver-like syntax (it includes more information).
  * This allows using generic csv parser, therefore `intelmq.bots.parsers.dyn.parser` could be deprecated.