### PR TITLE
intelmq list queues: --sum flag for showing total count Fixes #1408

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,10 @@ CHANGELOG
 - Added tests for `intelmq.lib.exceptions.PipelineError`.
 
 ### Tools
-
+- `intelmqctl`
+  - Add `intelmq list queues`: `--sum`, `--count`, `-s` flag for showing total count of messages (PR#1581 by Mladen Markovic)
+  
+  
 ### Contrib
 
 ### Known issues

--- a/docs/intelmqctl.md
+++ b/docs/intelmqctl.md
@@ -52,14 +52,14 @@ This will start the bot with the ID `file-output`. A file with it's PID will be 
 
 ```bash
 > intelmqctl start file-output
-intelmqctl: Starting file-output...
-intelmqctl: file-output is running.
+Starting file-output...
+file-output is running.
 ```
 
 If the bot is already running, it won't be started again:
 ```bash
 > intelmqctl start file-output
-intelmqctl: file-output is running.
+file-output is running.
 ```
 
 ### stop
@@ -68,21 +68,21 @@ If the PID file does exist, a SIGINT will be sent to the process. After 0.25s we
 
 ```bash
 > intelmqctl stop file-output
-intelmqctl: Stopping file-output...
-intelmqctl: file-output is stopped.
+Stopping file-output...
+file-output is stopped.
 ```
 
 If there's no running bot, there's nothing to do.
 ```bash
 > intelmqctl stop file-output
-intelmqctl: file-output was NOT RUNNING.
+file-output was NOT RUNNING.
 ```
 
 If the bot did not stop in 0.25s, intelmqctl will say it's still running:
 
 ```bash
 > intelmqctl stop file-output
-intelmqctl: file-output is still running
+file-output is still running
 ```
 
 ### status
@@ -91,12 +91,12 @@ Checks for the PID file and if the process with the given PID is alive. If the P
 
 ```bash
 > intelmqctl status file-output
-intelmqctl: file-output is stopped.
+file-output is stopped.
 > intelmqctl start file-output
-intelmqctl: Starting file-output...
-intelmqctl: file-output is running.
+Starting file-output...
+file-output is running.
 > intelmqctl status file-output
-intelmqctl: file-output is running.
+file-output is running.
 ```
 
 ### restart
@@ -105,10 +105,10 @@ The same as stop and start consecutively.
 
 ```bash
 > intelmqctl restart file-output
-intelmqctl: Stopping file-output...
-intelmqctl: file-output is stopped.
-intelmqctl: Starting file-output...
-intelmqctl: file-output is running.
+Stopping file-output...
+file-output is stopped.
+Starting file-output...
+file-output is running.
 ```
 
 ### reload
@@ -117,13 +117,13 @@ Sends a SIGHUP to the bot, which will then reload the configuration.
 
 ```bash
 > intelmqctl reload file-output
-intelmqctl: Reloading file-output ...
-intelmqctl: file-output is running.
+Reloading file-output ...
+file-output is running.
 ```
 If the bot is not running, we can't reload it:
 ```bash
 > intelmqctl reload file-output
-intelmqctl: file-output was NOT RUNNING.
+file-output was NOT RUNNING.
 ```
 
 ### run
@@ -153,7 +153,7 @@ Note that if another instance of the bot is running, only warning will be displa
 
 ```bash
 > intelmqctl run file-output
-intelmqctl: Main instance of the bot is running in the background. You may want to launch: intelmqctl stop file-output
+Main instance of the bot is running in the background. You may want to launch: intelmqctl stop file-output
 ```
 
 You can set the log level with the `-l` flag, e.g. `-l DEBUG`. For the 'console' subcommand, 'DEBUG' is the default.
@@ -246,10 +246,10 @@ Example output:
 
 ```bash
 > intelmqctl status file-output
-intelmqctl: file-output is stopped.
+file-output is stopped.
 > intelmqctl disable file-output
 > intelmqctl status file-output
-intelmqctl: file-output is disabled.
+file-output is disabled.
 ```
 
 ### enable
@@ -260,10 +260,10 @@ Example output:
 
 ```bash
 > intelmqctl status file-output
-intelmqctl: file-output is disabled.
+file-output is disabled.
 > intelmqctl enable file-output
 > intelmqctl status file-output
-intelmqctl: file-output is stopped.
+file-output is stopped.
 ```
 
 
@@ -286,27 +286,27 @@ The start action applies to all bots which are enabled.
 
 ```bash
 > intelmqctl start
-intelmqctl: Starting abusech-domain-parser...
-intelmqctl: abusech-domain-parser is running.
-intelmqctl: Starting abusech-feodo-domains-collector...
-intelmqctl: abusech-feodo-domains-collector is running.
-intelmqctl: Starting deduplicator-expert...
-intelmqctl: deduplicator-expert is running.
-intelmqctl: file-output is disabled.
-intelmqctl: Botnet is running.
+Starting abusech-domain-parser...
+abusech-domain-parser is running.
+Starting abusech-feodo-domains-collector...
+abusech-feodo-domains-collector is running.
+Starting deduplicator-expert...
+deduplicator-expert is running.
+file-output is disabled.
+Botnet is running.
 ```
 
 As we can > intelmqctl stop
-intelmqctl: Stopping Botnet...
-intelmqctl: Stopping abusech-domain-parser...
-intelmqctl: abusech-domain-parser is stopped.
-intelmqctl: Stopping abusech-feodo-domains-collector...
-intelmqctl: abusech-feodo-domains-collector is stopped.
-intelmqctl: Stopping deduplicator-expert...
-intelmqctl: deduplicator-expert is stopped.
-intelmqctl: Stopping file-output...
-intelmqctl: file-output is stopped.
-intelmqctl: Botnet is stopped.
+Stopping Botnet...
+Stopping abusech-domain-parser...
+abusech-domain-parser is stopped.
+Stopping abusech-feodo-domains-collector...
+abusech-feodo-domains-collector is stopped.
+Stopping deduplicator-expert...
+deduplicator-expert is stopped.
+Stopping file-output...
+file-output is stopped.
+Botnet is stopped.
 see, file-output is disabled and thus has not been started. You can always explicitly start disabled bots.
 
 ### stop
@@ -314,16 +314,16 @@ The stop action applies to all bots. Assume that all bots have been running:
 
 ```bash
 > intelmqctl stop
-intelmqctl: Stopping Botnet...
-intelmqctl: Stopping abusech-domain-parser...
-intelmqctl: abusech-domain-parser is stopped.
-intelmqctl: Stopping abusech-feodo-domains-collector...
-intelmqctl: abusech-feodo-domains-collector is stopped.
-intelmqctl: Stopping deduplicator-expert...
-intelmqctl: deduplicator-expert is stopped.
-intelmqctl: Stopping file-output...
-intelmqctl: file-output is stopped.
-intelmqctl: Botnet is stopped.
+Stopping Botnet...
+Stopping abusech-domain-parser...
+abusech-domain-parser is stopped.
+Stopping abusech-feodo-domains-collector...
+abusech-feodo-domains-collector is stopped.
+Stopping deduplicator-expert...
+deduplicator-expert is stopped.
+Stopping file-output...
+file-output is stopped.
+Botnet is stopped.
 ```
 
 ### status
@@ -331,27 +331,27 @@ intelmqctl: Botnet is stopped.
 With this command we can see the status of all configured bots. Here, the botnet was started beforehand:
 ```bash
 > intelmqctl status
-intelmqctl: abusech-domain-parser is running.
-intelmqctl: abusech-feodo-domains-collector is running.
-intelmqctl: deduplicator-expert is running.
-intelmqctl: file-output is disabled.
+abusech-domain-parser is running.
+abusech-feodo-domains-collector is running.
+deduplicator-expert is running.
+file-output is disabled.
 ```
 And if the disabled bot has also been started:
 ```bash
 > intelmqctl status
-intelmqctl: abusech-domain-parser is running.
-intelmqctl: abusech-feodo-domains-collector is running.
-intelmqctl: deduplicator-expert is running.
-intelmqctl: file-output is running.
+abusech-domain-parser is running.
+abusech-feodo-domains-collector is running.
+deduplicator-expert is running.
+file-output is running.
 ```
 
 If the botnet is stopped, the output looks like this:
 ```bash
 > intelmqctl status
-intelmqctl: abusech-domain-parser is stopped.
-intelmqctl: abusech-feodo-domains-collector is stopped.
-intelmqctl: deduplicator-expert is stopped.
-intelmqctl: file-output is disabled.
+abusech-domain-parser is stopped.
+abusech-feodo-domains-collector is stopped.
+deduplicator-expert is stopped.
+file-output is disabled.
 ```
 
 ### restart
@@ -365,19 +365,19 @@ The sub commands `enable` and `disable` set the corresponding flags in runtime.c
 
 ```bash
 > intelmqctl status
-intelmqctl: file-output is stopped.
-intelmqctl: malware-domain-list-collector is stopped.
-intelmqctl: malware-domain-list-parser is stopped.
+file-output is stopped.
+malware-domain-list-collector is stopped.
+malware-domain-list-parser is stopped.
 > intelmqctl disable file-output
 > intelmqctl status
-intelmqctl: file-output is disabled.
-intelmqctl: malware-domain-list-collector is stopped.
-intelmqctl: malware-domain-list-parser is stopped.
+file-output is disabled.
+malware-domain-list-collector is stopped.
+malware-domain-list-parser is stopped.
 > intelmqctl enable file-output
 > intelmqctl status
-intelmqctl: file-output is stopped.
-intelmqctl: malware-domain-list-collector is stopped.
-intelmqctl: malware-domain-list-parser is stopped.
+file-output is stopped.
+malware-domain-list-collector is stopped.
+malware-domain-list-parser is stopped.
 ```
 
 ## List bots
@@ -388,20 +388,27 @@ intelmqctl: malware-domain-list-parser is stopped.
 
 ```bash
 > intelmqctl list queues
-intelmqctl: abusech-domain-parser-queue - 0
-intelmqctl: abusech-domain-parser-queue-internal - 0
-intelmqctl: deduplicator-expert-queue - 0
-intelmqctl: deduplicator-expert-queue-internal - 0
-intelmqctl: file-output-queue - 234
-intelmqctl: file-output-queue-internal - 0
+abusech-domain-parser-queue - 0
+abusech-domain-parser-queue-internal - 0
+deduplicator-expert-queue - 0
+deduplicator-expert-queue-internal - 0
+file-output-queue - 234
+file-output-queue-internal - 0
 ```
 
 Use the `-q` or `--quiet` flag to only show non-empty queues:
 
 ```bash
 > intelmqctl list queues -q
-intelmqctl: file-output-queue - 234
+file-output-queue - 234
 ```
+
+The `--sum` or `--count` flag will show the sum of events on all queues:
+```bash
+> intelmqctl list queues --sum
+42
+```
+
 
 ## Log
 

--- a/intelmq/bin/intelmqctl.py
+++ b/intelmq/bin/intelmqctl.py
@@ -855,6 +855,9 @@ Get some debugging output on the settings and the enviroment (to be extended):
             parser_list.add_argument('--non-zero', '--quiet', '-q', action='store_true',
                                      help='Only list non-empty queues '
                                           'or the IDs of enabled bots.')
+            parser_list.add_argument('--count', '--sum', '-s', action='store_true', help='Only show the total '
+                                                                                   'number of messages in queues. '
+                                                                                   'Only valid for listing queues.')
             parser_list.set_defaults(func=self.list)
 
             parser_clear = subparsers.add_parser('clear', help='Clear a queue')
@@ -1196,9 +1199,9 @@ Get some debugging output on the settings and the enviroment (to be extended):
                 retval = 1
         return retval, botnet_status
 
-    def list(self, kind=None, non_zero=False):
+    def list(self, kind=None, non_zero=False, count=False):
         if kind == 'queues':
-            return self.list_queues(non_zero=non_zero)
+            return self.list_queues(non_zero=non_zero, count=count)
         elif kind == 'bots':
             return self.list_bots(non_zero=non_zero)
         elif kind == 'queues-and-status':
@@ -1263,7 +1266,7 @@ Get some debugging output on the settings and the enviroment (to be extended):
 
         return source_queues, destination_queues, internal_queues, all_queues
 
-    def list_queues(self, non_zero=False):
+    def list_queues(self, non_zero=False, count=False):
         pipeline = PipelineFactory.create(self.parameters, logger=self.logger)
         pipeline.set_queues(None, "source")
         pipeline.connect()
@@ -1274,23 +1277,28 @@ Get some debugging output on the settings and the enviroment (to be extended):
         pipeline.disconnect()
         if RETURN_TYPE == 'text':
             for queue, counter in sorted(counters.items(), key=lambda x: str.lower(x[0])):
-                if counter or not non_zero:
+                if (counter or not non_zero) and not count:
                     logger.info("%s - %s", queue, counter)
+            if count:
+                logger.info("%s", sum(counters.values()))
 
         return_dict = {}
-        for bot_id, info in self.pipeline_configuration.items():
-            return_dict[bot_id] = {}
+        if count:
+            return_dict = {'total-messages': sum(counters.values())}
+        else:
+            for bot_id, info in self.pipeline_configuration.items():
+                return_dict[bot_id] = {}
 
-            if 'source-queue' in info:
-                return_dict[bot_id]['source_queue'] = (
-                    info['source-queue'], counters[info['source-queue']])
-                if pipeline.has_internal_queues:
-                    return_dict[bot_id]['internal_queue'] = counters[info['source-queue'] + '-internal']
+                if 'source-queue' in info:
+                    return_dict[bot_id]['source_queue'] = (
+                        info['source-queue'], counters[info['source-queue']])
+                    if pipeline.has_internal_queues:
+                        return_dict[bot_id]['internal_queue'] = counters[info['source-queue'] + '-internal']
 
-            if 'destination-queues' in info:
-                return_dict[bot_id]['destination_queues'] = []
-                for dest_queue in utils.flatten_queues(info['destination-queues']):
-                    return_dict[bot_id]['destination_queues'].append((dest_queue, counters[dest_queue]))
+                if 'destination-queues' in info:
+                    return_dict[bot_id]['destination_queues'] = []
+                    for dest_queue in utils.flatten_queues(info['destination-queues']):
+                        return_dict[bot_id]['destination_queues'].append((dest_queue, counters[dest_queue]))
 
         return 0, return_dict
 


### PR DESCRIPTION
- Adds the `--sum`, `--count` and `-s` flag for `intelmqctl list queues`, which shows the sum of events of all queues
- Updates the corresponding _intelmqctl_ documentation
- Updates CHANGELOG.md