### PR TITLE
BUG: parser fails when IP address comes in the domain column

### DIFF
--- a/intelmq/bots/parsers/malwareurl/parser.py
+++ b/intelmq/bots/parsers/malwareurl/parser.py
@@ -3,6 +3,7 @@ from html.parser import HTMLParser
 
 from intelmq.lib import utils
 from intelmq.lib.bot import Bot
+import intelmq.lib.harmonization as harmonization
 
 
 class MyHTMLParser(HTMLParser):
@@ -47,8 +48,10 @@ class MalwareurlParserBot(Bot):
                 else:
                     ip = parser.lsValue
                     event = self.new_event(report)
-                    event.add("source.fqdn", url)
-                    event.add("source.ip", ip)
+                    if harmonization.FQDN.is_valid(url, sanitize=True):
+                        event.add("source.fqdn", url)
+                    if harmonization.IPAddress.is_valid(ip, sanitize=True):
+                        event.add("source.ip", ip)
                     event.add("raw", url_raw_line + actual_line)
                     event.add("classification.type", "phishing")
                     self.send_message(event)


### PR DESCRIPTION
Some alerts from malwareurl.com contain IP address in the Domain column.  Adding IP address value into source.fqdn field results in error.