### PR TITLE
BUG: danger rulez parser: correctly skip malformed rows

### DIFF
--- a/intelmq/bots/parsers/danger_rulez/parser.py
+++ b/intelmq/bots/parsers/danger_rulez/parser.py
@@ -22,15 +22,19 @@ class BruteForceBlockerParserBot(Bot):
             event = self.new_event(report)
 
             match = re.search(REGEX_IP, row)
+            ip = None
             if match:
                 ip = match.group()
 
             match = re.search(REGEX_TIMESTAMP, row)
+            timestamp = None
             if match:
                 timestamp = match.group(1) + " UTC"
 
             if not timestamp:
                 raise ValueError('No timestamp found.')
+            elif not ip:
+                raise ValueError('No ip found.')
 
             event.add('time.source', timestamp)
             event.add('source.ip', ip)


### PR DESCRIPTION
Define variables before referencing

add the same behavior to all dynamic fields i.e. timestamp and ip.