### PR TITLE
ENH: makes bot parameters optional

### DIFF
--- a/intelmq/lib/bot.py
+++ b/intelmq/lib/bot.py
@@ -705,7 +705,7 @@ class Bot(object):
         if self.__bot_id in config:
             params = config[self.__bot_id]
             self.run_mode = params.get('run_mode', 'continuous')
-            for option, value in params['parameters'].items():
+            for option, value in params.get('parameters', {}).items():
                 setattr(self.parameters, option, value)
                 self.__log_configuration_parameter("runtime", option, value)
                 if option.startswith('logging_'):


### PR DESCRIPTION
This is a tiny change to make `parameters` key optional for bot runtime configuration. Some bots do not require any specific parameters. With this PR it is no longer necessary to have empty `"parameters": {}` inside `runtime.conf` and therefore it reduces configuration size.

Before this PR the intelmq would raise KeyError exception when `parameters` is omitted from the configuration.