### PR TITLE
BUG: fix cymru expert cache key calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ CHANGELOG
 - `intelmq/bots/parsers/danger_rulez/parser`: correctly skip malformed rows by defining variables before referencing (PR#1601 by Tomas Bellus).
 
 #### Experts
+- `intelmq.bots.experts.cymru_whois`:
+  - Fix cache key calculation which previously led to duplicate keys and therefore wrong results in rare cases. The cache key calculation is intentionally not backwards-compatible (#1592, PR#1606).
+  - The bot now caches and logs (as level INFO) empty responses from Cymru (PR#1606).
 
 #### Outputs
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,11 @@ See the changelog for a full list of changes.
 2.2.2 Bugfix release (unreleased)
 ---------------------------------
 
+### Bots
+#### Cymru Whois Lookup
+The cache key calculation has been fixed. It previously led to duplicate keys for different IP addresses and therefore wrong results in rare cases. The cache key calculation is intentionally not backwards-compatible. Therefore, this bot may take longer processing events than usual after applying this update.
+More details can be found in [issue #1592](https://github.com/certtools/intelmq/issues/1592).
+
 ### Requirements
 
 ### Tools


### PR DESCRIPTION
The cache key calculation has been fixed. It previously led to duplicate keys for different IP addresses and therefore wrong results in rare cases. The cache key calculation is intentionally not backwards-compatible. Therefore, this bot may take longer processing events than usual after applying this update.

fixes certtools/intelmq#1592