### PR TITLE
Rotating file handler added as another logging option

### DIFF
--- a/intelmq/lib/bot.py
+++ b/intelmq/lib/bot.py
@@ -729,7 +729,9 @@ class Bot(object):
             syslog = False
         self.logger = utils.log(self.__bot_id_full, syslog=syslog,
                                 log_path=self.parameters.logging_path,
-                                log_level=self.parameters.logging_level)
+                                log_level=self.parameters.logging_level,
+                                log_max_size=getattr(self.parameters, "logging_max_size", None),
+                                log_max_copies=getattr(self.parameters, "logging_max_copies", None))
 
     def __load_pipeline_configuration(self):
         self.logger.debug("Loading pipeline configuration from %r.", PIPELINE_CONF_FILE)

--- a/intelmq/lib/utils.py
+++ b/intelmq/lib/utils.py
@@ -307,7 +307,7 @@ def log(name: str, log_path: Union[str, bool] = intelmq.DEFAULT_LOGGING_PATH,
         log_level: str = intelmq.DEFAULT_LOGGING_LEVEL,
         stream: Optional[object] = None, syslog: Union[bool, str, list, tuple] = None,
         log_format_stream: str = LOG_FORMAT_STREAM,
-        logging_level_stream: Optional[str] = None):
+        logging_level_stream: Optional[str] = None, log_max_size: Optional[int] = None, log_max_copies: Optional[int] = None):
     """
     Returns a logger instance logging to file and sys.stderr or other stream.
     The warnings module will log to the same handlers.
@@ -350,7 +350,11 @@ def log(name: str, log_path: Union[str, bool] = intelmq.DEFAULT_LOGGING_PATH,
         logging_level_stream = log_level
 
     if log_path and not syslog:
-        handler = FileHandler("%s/%s.log" % (log_path, name))
+        if not all((log_max_size, log_max_copies)):
+            handler = FileHandler("%s/%s.log" % (log_path, name))
+        else:
+            handler = logging.handlers.RotatingFileHandler("%s/%s.log" % (log_path, name), maxBytes=log_max_size,
+                                                           backupCount=log_max_copies)
         handler.setLevel(log_level)
         handler.setFormatter(logging.Formatter(LOG_FORMAT))
     elif syslog:


### PR DESCRIPTION
The purpose of this PR is to add the support for log rotation to the intelmq. The need for this is, at least in my case, for log running deployments typically in Docker. Since the processing info logs can take a large portion of disk space this feature could be used as a solution. I'm well aware that the amount of logs could be reduced by restricting the log level to warning of error but this solution is in my opinion better since it allows for a greater control over disk usage and keeping the info logs, which might still hold some value for troubleshooting.

To enable rotation of logs I've added two parameters _logging_max_size_ and _logging_max_copies_ which directly map to the values for limiting the sizes of logs and backup counts from Python's [RotatingFileHandler](https://docs.python.org/3/library/logging.handlers.html#rotatingfilehandler). If both parameters are set the Rotating file handler is used instead of the default FileHandler.

I haven't customised the handler class, like it is done for example for [FileHandler](https://github.com/certtools/intelmq/blob/develop/intelmq/lib/utils.py#L259), since this would require to handle the log rotation in some way and I wasn't sure whether there is still any need for overriding the emit. Also I haven't added any test cases yet since I wasn't sure whether it is needed for logging purposes. If any of these two features are needed just let me know and I will add them. 