### PR TITLE
MISP parser: added functionality to honor/filter the "to_ids" attribute of MISP

### DIFF
--- a/docs/user/bots.rst
+++ b/docs/user/bots.rst
@@ -1341,6 +1341,10 @@ for processing. Supported MISP event categories and attribute types are
 defined in the `SUPPORTED_MISP_CATEGORIES` and `MISP_TYPE_MAPPING` class
 constants.
 
+**Configuration Parameters**
+
+* `only_ids`: If set to true, MISP events will be discardrd if their to_ids attribute is set to false
+
 n6
 ^^
 

--- a/intelmq/bots/BOTS
+++ b/intelmq/bots/BOTS
@@ -553,7 +553,9 @@
         "MISP": {
             "description": "Parse MISP events.",
             "module": "intelmq.bots.parsers.misp.parser",
-            "parameters": {}
+            "parameters": {
+                "ids_only": false
+            }
         },
         "Malc0de": {
             "description": "Parse the Malc0de IP feed in either IP Blacklist, Windows Format or Bind format.",

--- a/intelmq/bots/parsers/misp/parser.py
+++ b/intelmq/bots/parsers/misp/parser.py
@@ -1,4 +1,12 @@
 # -*- coding: utf-8 -*-
+
+"""
+MISP parser
+
+Parameters:
+ids_only: boolean
+"""
+
 import json
 from datetime import datetime
 from urllib.parse import urljoin
@@ -95,10 +103,13 @@ class MISPParserBot(Bot):
             timestamp = attribute['timestamp']
             category = attribute['category']
             type_ = attribute['type']
+            to_ids = attribute['to_ids']
+            ids_only = self.parameters.ids_only
 
             # create intelmq events based on the category
             if (category in self.SUPPORTED_MISP_CATEGORIES and
-                    type_ in self.MISP_TYPE_MAPPING):
+                    type_ in self.MISP_TYPE_MAPPING and
+                    (not ids_only or to_ids)):
 
                 # Create and send the intelmq event
                 event = self.new_event(report)
@@ -106,6 +117,7 @@ class MISPParserBot(Bot):
                 event.add(self.MISP_TYPE_MAPPING[type_], value)
                 event.add('misp.event_uuid', misp_event['uuid'])
                 event.add('misp.attribute_uuid', uuid)
+                event.add('misp.to_ids', to_ids)
                 event.add('comment', comment)
                 event.add('event_description.text', category)
                 event.add('event_description.url', misp_event_url)

--- a/intelmq/etc/harmonization.conf
+++ b/intelmq/etc/harmonization.conf
@@ -205,6 +205,10 @@
             "regex": "^[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[0-9a-z]{12}$",
             "type": "LowercaseString"
         },
+        "misp.to_ids": {
+            "description": "MISP - Malware Information Sharing Platform & Threat Sharing IDS flag",
+            "type": "Boolean"
+        },
         "output": {
             "description": "Event data converted into foreign format, intended to be exported by output plugin.",
             "type": "JSON"

--- a/intelmq/tests/bots/parsers/misp/test_parser.py
+++ b/intelmq/tests/bots/parsers/misp/test_parser.py
@@ -36,6 +36,7 @@ EXAMPLE_EVENT = {
     "malware.name": "locky",
     'misp.attribute_uuid': '575c8598-f1f0-4c16-a94a-0612c0a83866',
     'misp.event_uuid': '5758ebf5-c898-48e6-9fe9-5665c0a83866',
+    'misp.to_ids': "false", 
     "raw": base64_encode(EXAMPLE_MISP_ATTR)
 }
 


### PR DESCRIPTION
Added the following to honor the "to_ids" attribute of MISP:

* added the new field "misp.to_ids" to harmonization.conf (Boolean)
* added the new parameter "only_ids" to the MISP parser
* MISP parser now inserts the MISP attribute "to_ids" into the resulting IntelMQ events
* When parameter "only_ids" is set to "true", the MISP parser only processes and forwards MISP events if their "to_ids" attribute's value is true