### PR TITLE
A couple of bug fixes and updates of the Debian package

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -122,7 +122,7 @@ intelmq (1.2.0~alpha2-1) unstable; urgency=low
 
   * Update to version 1.2.0 alpha 2
 
- -- sebastianw <sebastianw@localhost>  Sat, 24 Nov 2018 22:40:21 +0100
+ -- sebastianw <wagner@cert.at>  Sat, 24 Nov 2018 22:40:21 +0100
 
 intelmq (1.2.0~alpha1-1) unstable; urgency=low
 
@@ -230,11 +230,13 @@ intelmq (1.0.0.rc1-2) UNRELEASED; urgency=medium
 
   * remove python3-requests from dependencies and add it to recommended packages
 
- -- Sebastian Wagner <sebastian@linux-7nbu.substi>  Tue, 18 Jul 2017 16:23:43 +0200
+ -- Sebastian Wagner <wagner@cert.at>  Tue, 18 Jul 2017 16:23:43 +0200
 
 intelmq (1.0.0.rc1-1) experimental; urgency=medium
 
   * update to version 1.0.0.rc1
+
+ -- Sebastian Wagner <wagner@cert.at>  Wed, 20 Jun 2017 16:05:00 +0200
 
 intelmq (1.0.0.dev8-2) experimental; urgency=medium
 

--- a/debian/control
+++ b/debian/control
@@ -2,22 +2,58 @@ Source: intelmq
 Maintainer: Sebastian Wagner <wagner@cert.at>
 Section: python
 Priority: optional
-Build-Depends: debhelper (>= 4.1.16), python3-all, python3-setuptools, quilt, dh-python, python-setuptools, dh-systemd, safe-rm, python3-requests, python3-redis, python3-dnspython, python3-psutil, python3-dateutil, python3-termstyle, python3-tz, lsb-release
+Build-Depends: debhelper (>= 4.1.16),
+               dh-python,
+               dh-systemd,
+               lsb-release,
+               python-setuptools,
+               python3-all,
+               python3-cerberus,
+               python3-dateutil,
+               python3-dnspython,
+               python3-yaml,
+               python3-psutil,
+               python3-redis,
+               python3-requests,
+               python3-requests-mock,
+               python3-setuptools,
+               python3-sphinx,
+               python3-sphinx-rtd-theme,
+               python3-termstyle,
+               python3-tz,
+               quilt,
+               safe-rm
 X-Python3-Version: >= 3.5
 Standards-Version: 3.9.6
 Homepage: https://github.com/certtools/intelmq/
 
 Package: intelmq
 Architecture: all
-Depends: ${misc:Depends}, ${python3:Depends},
- python3-dateutil (>= 2.5), python3-dnspython (>= 1.11.1),
- python3-openssl, python3-psutil (>= 1.2.1), python3-redis (>= 2.10),
- python3-requests (>= 2.2.1), python3-termstyle (>= 0.1.10), python3-tz,
- redis-server, cron, bash-completion, jq, systemd, debianutils
-Suggests: python3-imbox (>= 0.8), python3-pyasn (>= 1.5.0),
- python3-stomp.py (>= 4.1.9), python3-sleekxmpp (>= 1.3.1),
- python3-geoip2 (>= 2.2.0), python3-pymongo, python3-psycopg2
-Description: IntelMQ is a solution for IT security teams (CERTs, CSIRTs, abuse
+Depends: bash-completion,
+         cron,
+         jq,
+         python3-dateutil (>= 2.5),
+         python3-dnspython (>= 1.11.1),
+         python3-openssl,
+         python3-psutil (>= 1.2.1),
+         python3-redis (>= 2.10),
+         python3-requests (>= 2.2.1),
+         python3-termstyle (>= 0.1.10),
+         python3-tz,
+         redis-server,
+         systemd,
+         ${misc:Depends},
+         ${sphinxdoc:Depends},
+         ${python3:Depends}
+Suggests: python3-geoip2 (>= 2.2.0),
+          python3-imbox (>= 0.8),
+          python3-psycopg2,
+          python3-pyasn (>= 1.5.0),
+          python3-pymongo,
+          python3-sleekxmpp (>= 1.3.1),
+          python3-stomp.py (>= 4.1.9)
+Description: Solution for IT security teams for collecting and processing security feeds
+ IntelMQ is a solution for IT security teams (CERTs, CSIRTs, abuse
  departments,...) for collecting and processing security feeds (such as log
  files) using a message queuing protocol. It's a community driven initiative
  called IHAP (Incident Handling Automation Project) which was conceptually

--- a/debian/py3dist-overrides
+++ b/debian/py3dist-overrides
@@ -1,0 +1,1 @@
+pyyaml python3-yaml

--- a/debian/rules
+++ b/debian/rules
@@ -17,13 +17,13 @@ BOTDOCS := $(foreach bot,$(BOTS),$(wildcard $(bot)/*.md))
 # Wed, 23 Mar 2016 17:49:26 +0000
 export PYBUILD_NAME=intelmq
 %:
-	dh $@ --with python3 --without python2 --buildsystem=pybuild --with quilt --with systemd
+	dh $@ --with python3,sphinxdoc --without python2 --buildsystem=pybuild --with quilt --with systemd
 
 build:
 	if [ $(CODENAME) = 'xenial' ] || [ $(CODENAME) = 'jessie' ]; then\
 		patch -p1 setup.py debian/patches/fix-dnspython-name.patch;\
 	fi
-	dh build --with python3 --without python2 --buildsystem=pybuild --with quilt --with systemd
+	dh build --with python3,sphinxdoc --without python2 --buildsystem=pybuild --with quilt --with systemd
 	# These tests frequently fail on Ubuntu and Debian systems.
 	# On some systems this command will be executed twice, so -f
 	rm -rf intelmq/tests/bots/collectors/tcp/


### PR DESCRIPTION
 d/changelog:
  * Fix bogus-mail-host-in-debian-changelog
    https://lintian.debian.org/tags/bogus-mail-host-in-debian-changelog.html
  * Fix depends-on-essential-package-without-using-version
    This referres to `debianutils`. See
    https://lintian.debian.org/tags/build-depends-on-essential-package-without-using-version.html
    "The only reason to list an explicit dependency on an essential package
    is if you need a particular version of that package"
  * Fix: description-starts-with-package-name
    https://lintian.debian.org/tags/description-starts-with-package-name.html
    This also adds a synopsis, because according to policy, a Debian
    package description consists 'of two parts, the synopsis or the
    short description, and the long description'
  * Fix: syntax-error-in-debian-changelog
    There was a changed-by line missing, this got somehow introduced in
    eb6b38091d865f5e36920df57984eec638fed7a0; not a big deal, but fixing
    it makes lintian happy.
 d/control:
  * Run wrap-and-sort on d/control
  * Use sphinx and the sphinx rdt theme to build and manage
    documentation. This adds the necessary dependencies to the control
    file
  * Replaces the old style debian/compat file with a build-dependency on
    debhelper-compat.
 d/rules:
  * Enable the sphinx debhelper
    The --with systemd argument for debhelper is no longer provided in
    compat >= 11 - Debian packages use dh_installsystemd nowadays
    This also removes the systemd override in d/rules, because this is
    now default behaviour since compat 10.
