### PR TITLE
Deprecate the XMPP bots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ CHANGELOG
   - Added PGP signature check functionality (PR#1602 by sinus-x).
   - If status code is not 2xx, the request's and response's headers and body are logged in debug logging level (#1615).
 - `intelmq.bots.collectors.kafka.collector`: Added (PR#1654, closes #1634)
+- `intelmq.bots.collectors.xmpp.collector`: marked as deprecated (see https://lists.cert.at/pipermail/intelmq-users/2020-October/000177.html)
 
 #### Parsers
 - `intelmq.bots.parsers.eset.parser`: Added (PR#1554 by Mikk Margus Möll).
@@ -73,6 +74,7 @@ CHANGELOG
 
 #### Outputs
 - `intelmq.bots.outputs.rt`: Added Request Tracker output bot (PR#1589 by Marius Urkis).
+- `intelmq.bots.outputs.xmpp.output`: marked as deprecated (see https://lists.cert.at/pipermail/intelmq-users/2020-October/000177.html)
 
 ### Documentation
 - Feeds:

--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,8 @@ The documentation is now available at [intelmq.readthedocs.io](https://intelmq.r
 
 ### Tools
 
+### Bots
+
 #### Bot option `--updata-database`
 - Bots that require a database file (such as `maxmind_geoip`, `asn_lookup`, `tor_nodes` and `recordedfuture_iprisk`)
   have new command line option `--update-database`. It is not necessary to specify a
@@ -28,6 +30,9 @@ The documentation is now available at [intelmq.readthedocs.io](https://intelmq.r
   intelmq.bots.experts.tor_nodes.expert --update-database
   ```
   The provided shell scripts use these new commands, however they are now deprecated and will be removed in version 3.0.
+
+#### XMPP Bots
+Both the XMPP output bot and the XMPP collector bot log a deprecation warning now. The plan is to remove them in version 3.0.
 
 ### Harmonization
 

--- a/docs/user/bots.rst
+++ b/docs/user/bots.rst
@@ -627,6 +627,10 @@ If you intend to link two IntelMQ instance via TCP, have a look at the TCP outpu
 
 XMPP collector
 ^^^^^^^^^^^^^^
+
+**Warning:** This bot is deprecated and will be removed in the version 3.0 of IntelMQ.
+**Warning:** This bot is currently *unmaintained*. The used XMPP library *sleekxmpp* is deprecated. For more information see :issue:`Issue #1614 <1614>`.
+
 **Information**
 
 * `name:` intelmq.bots.collectors.xmpp.collector
@@ -634,8 +638,6 @@ XMPP collector
 * `public:` yes
 * `cache (redis db):` none
 * `description:` This bot can connect to an XMPP Server and one room, in order to receive reports from it. TLS is used by default. rate_limit is ineffective here. Bot can either pass the body or the whole event.
-
-**Warning:** This bot is currently *unmaintained* and needs to be adapted. The used XMPP library *sleekxmpp* is deprecated, therefore the bots needs to be adapted to the successor library *slixmpp*. For more information see :issue:`Issue #1614 <1614>`.
 
 **Requirements**
 
@@ -3496,6 +3498,8 @@ Resulting line in syslog:
 
 XMPP
 ^^^^
+**Warning:** This bot is deprecated and will be removed in the version 3.0 of IntelMQ.
+**Warning:** This bot is currently *unmaintained*. The used XMPP library *sleekxmpp* is deprecated. For more information see :issue:`Issue #1614 <1614>`.
 
 **Information**
 
@@ -3505,7 +3509,6 @@ XMPP
 * `cache (redis db):` none
 * `description:` The XMPP Output is capable of sending Messages to XMPP Rooms and as direct messages.
 
-**Warning:** This bot is currently *unmaintained* and needs to be adapted. The used XMPP library *sleekxmpp* is deprecated, therefore the bots needs to be adapted to the successor library *slixmpp*. For more information see :issue:`Issue #1614 <1614>`.
 
 **Requirements**
 

--- a/intelmq/bots/collectors/xmpp/collector.py
+++ b/intelmq/bots/collectors/xmpp/collector.py
@@ -83,6 +83,8 @@ class XMPPCollectorBot(CollectorBot):
     collector_empty_process = True
 
     def init(self):
+        self.logger.warning("The output bot 'intelmq.bots.outputs.xmpp.output' "
+                            "is deprecated. It will be removed in version 3.0.")
         if sleekxmpp is None:
             raise MissingDependencyError("sleekxmpp")
 

--- a/intelmq/bots/outputs/xmpp/output.py
+++ b/intelmq/bots/outputs/xmpp/output.py
@@ -81,6 +81,8 @@ class XMPPOutputBot(Bot):
     xmpp = None
 
     def init(self):
+        self.logger.warning("The output bot 'intelmq.bots.outputs.xmpp.output' "
+                            "is deprecated. It will be removed in version 3.0.")
         if sleekxmpp is None:
             raise MissingDependencyError("sleekxmpp")
 


### PR DESCRIPTION
Both the XMPP output bot as well as the XMPP collector bot require
the `sleekxmpp` library which is deprecated. It would be possible to
modify the bots to use the successor `slixmpp` library, but a short
survey
https://lists.cert.at/pipermail/intelmq-users/2020-October/000177.html
did not bring up anyone using the bots, so they are being marked as
deprecated for now and will be removed in version 3.0.
