### PR TITLE
[ENH] Sieve datetime operations

### DIFF
--- a/docs/user/bots.rst
+++ b/docs/user/bots.rst
@@ -2561,15 +2561,27 @@ If part of a rule matches the given conditions, the actions enclosed in `{` and
 in the sieve file will be forwarded to the next bot in the pipeline, unless the
 `drop` action is applied.
 
+In addtion `add`, `add!` and `update` do also support super basic math operations `+` and `-`.
+
  * `add` adds a key value pair to the event. This action only applies if the key is not yet defined in the event. If the key is already defined, the action is ignored. Example:
 
    ```add comment = 'hello, world'```
 
+   **ATTENTION** Mathematical expressions currently support only DateTime objects!
+   Basic math operations
+   ```add time.observation += '1 hour'```
+   ```add time.observation -= '10 hours'```
+
  * `add!` same as above, but will force overwrite the key in the event.
 
- * `update` modifies an existing value for a key. Only applies if the key is already defined. If the key is not defined in the event, this action is ignored.  Example:
+ * `update` modifies an existing value for a key. Only applies if the key is already defined. If the key is not defined in the event, this action is ignored. This supports mathematical expressions like above. Example:
 
    ```update feed.accuracy = 50```
+
+   **ATTENTION** Mathematical expressions currently support only DateTime objects!
+   Basic math operations
+   ```update time.observation += '1 hour'```
+   ```update time.observation -= '10 hours'```
 
  * `remove` removes a key/value from the event. Action is ignored if the key is not defined in the event. Example:
 

--- a/intelmq/bots/experts/sieve/sieve.tx
+++ b/intelmq/bots/experts/sieve/sieve.tx
@@ -59,6 +59,11 @@ NumericValue: SingleNumericValue | NumericValueList ;
 SingleNumericValue: value=NUMBER ;
 NumericValueList: '[' values+=SingleNumericValue[','] ']' ;
 
+AssignOperator:
+  '='
+  | '+='
+  | '-='
+;
 
 Action: action=DropAction
     | ( action=KeepAction
@@ -71,9 +76,9 @@ Action: action=DropAction
 DropAction: 'drop';
 KeepAction: 'keep';
 PathAction: 'path' path=STRING;
-AddAction: 'add' key=Key '=' value=STRING;              // add key/value without overwriting existing key
-AddForceAction: 'add!' key=Key '=' value=STRING;        // add key/value, overwriting existing key
-UpdateAction: 'update' key=Key '=' value=STRING;        // update key/value, do not create if not exists
+AddAction: 'add' key=Key operator=AssignOperator value=STRING;              // add key/value without overwriting existing key
+AddForceAction: 'add!' key=Key operator=AssignOperator value=STRING;        // add key/value, overwriting existing key
+UpdateAction: 'update' key=Key operator=AssignOperator value=STRING;        // update key/value, do not create if not exists
 RemoveAction: 'remove' key=Key;
 
 Comment: /(#|\/\/).*$/ ;

--- a/intelmq/tests/bots/experts/sieve/test_expert.py
+++ b/intelmq/tests/bots/experts/sieve/test_expert.py
@@ -975,6 +975,62 @@ class TestSieveExpertBot(test.BotTestCase, unittest.TestCase):
         self.run_bot()
         self.assertMessageEqual(0, numeric_match_true)
 
+    def test_basic_math(self):
+        """ Test basic math operations"""
+        self.sysconfig['file'] = os.path.join(os.path.dirname(__file__), 
+                                                'test_sieve_files/test_basic_math.sieve')
+
+        event = EXAMPLE_INPUT.copy()
+        event['comment'] = "add_force"
+        test_add_force = event.copy()
+        test_add_force['comment'] = "add_force"
+        test_add_force['time.observation'] = '2017-01-01T01:00:00+00:00'
+        self.input_message = event
+        self.run_bot()
+        self.assertMessageEqual(0, test_add_force)
+
+        test_minus_force = event.copy()
+        event['comment'] = "minus_force"
+        test_minus_force['comment'] = 'minus_force'
+        test_minus_force['time.observation'] = '2016-12-31T23:00:00+00:00'
+        self.input_message = event
+        self.run_bot()
+        self.assertMessageEqual(0, test_minus_force)
+        
+        test_minus_normal = event.copy()
+        event['comment'] = "minus_normal"
+        test_minus_normal['comment'] = 'minus_normal'
+        test_minus_normal['time.observation'] = '2016-12-31T23:00:00+00:00'
+        self.input_message = event
+        self.allowed_error_count = 1
+        self.run_bot()
+        self.assertMessageEqual(0, test_minus_normal)
+
+        test_add_normal = event.copy()
+        event['comment'] = "add_normal"
+        test_add_normal['comment'] = 'add_normal'
+        test_add_normal['time.observation'] = '2017-01-01T01:00:00+00:00'
+        self.input_message = event
+        self.allowed_error_count = 1
+        self.run_bot()
+        self.assertMessageEqual(0, test_add_normal)
+
+        test_add_update = event.copy()
+        event['comment'] = "add_update"
+        test_add_update['comment'] = 'add_update'
+        test_add_update['time.observation'] = '2017-01-01T01:00:00+00:00'
+        self.input_message = event
+        self.run_bot()
+        self.assertMessageEqual(0, test_add_update)
+
+        test_minus_update = event.copy()
+        event['comment'] = "minus_update"
+        test_minus_update['comment'] = 'minus_update'
+        test_minus_update['time.observation'] = '2016-12-31T23:00:00+00:00'
+        self.input_message = event
+        self.run_bot()
+        self.assertMessageEqual(0, test_minus_update)
+
 
 if __name__ == '__main__':  # pragma: no cover
     unittest.main()

--- a/intelmq/tests/bots/experts/sieve/test_sieve_files/test_basic_math.sieve
+++ b/intelmq/tests/bots/experts/sieve/test_sieve_files/test_basic_math.sieve
@@ -1,0 +1,23 @@
+if comment == 'add_force' {
+    add! time.observation += '1 hour'
+}
+
+if comment == 'minus_force' {
+    add! time.observation -= '1 hour'
+}
+
+if comment == 'minus_normal' {
+    add time.observation -= '1 hour'
+}
+
+if comment == 'add_normal' {
+    add time.observation += '1 hour'
+}
+
+if comment == 'add_update' {
+    update time.observation += '1 hour'
+}
+
+if comment == 'minus_update' {
+    update time.observation -= '1 hour'
+}


### PR DESCRIPTION
Added possibility to use super basic math ( + and - operations ).

Sieve is now able to calculate a new datetime.

There should be no breaking change!

Usage:
```
add! time.observation += '1 hour'
add! time.observation -= '2 hours'

add time.observation += '1 hour'
add time.observation -= '2 hours'

update time.observation += '1 hour'
update time.observation -= '1 hour'
```

Closes #1680 