### PR TITLE
Adapt doc buildsystem to only produce restructured text

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,7 @@ src/
 docs/source
 docs/_build
 docs/user/feeds.rst
-docs/dev/harmonization-fields.md
+docs/dev/harmonization-fields.rst
 
 # Debian build filed
 debian/files

--- a/docs/autogen.py
+++ b/docs/autogen.py
@@ -13,21 +13,19 @@ import yaml
 import intelmq.lib.harmonization
 
 
-HEADER = """
+HEADER = """#########################
 Harmonization field names
-=========================
+#########################
 
-|Section|Name|Type|Description|
-|:------|:---|:---|:----------|
+=========================== =================================== ========================= ===========
+Section                     Name                                Type                      Description
+=========================== =================================== ========================= ===========
 """
 HEADER_1 = """
+=========================== =================================== ========================= ===========
 
 Harmonization types
 -------------------
-
-"""
-TYPE_SECTION = """### {}
-{}
 
 """
 BASEDIR = os.path.join(os.path.dirname(__file__), '../')
@@ -41,9 +39,9 @@ def harm_docs():
 
     for key, value in sorted(HARM.items()):
         section = ' '.join([sec.title() for sec in key.split('.')[:-1]])
-        output += '|{}|{}|[{}](#{})|{}|\n'.format(' ' if not section else section,  # needed for GitHub
-                                                  key, value['type'],
-                                                  value['type'].lower(),
+        output += '{:27} {:35} {:25} {}\n'.format('|' if not section else section,  # needed for GitHub
+                                                  key,
+                                                  ':ref:`'+value['type'].lower()+'`',
                                                   value['description'])
 
     output += HEADER_1
@@ -59,7 +57,7 @@ def harm_docs():
                     doc = ''
                 else:
                     doc = textwrap.dedent(doc)
-                output += TYPE_SECTION.format(value, doc)
+                output += ".. _{}:\n\n{}\n{}\n{}\n\n".format(value.lower(),value,'-'*len(value),doc)
         except TypeError:
             pass
 
@@ -140,7 +138,7 @@ To add feeds to this file add them to `intelmq/etc/feeds.yaml` and then rebuild 
 
 
 if __name__ == '__main__':  # pragma: no cover
-    with open('guides/Harmonization-fields.md', 'w') as handle:
+    with open('dev/harmonization-fields.rst', 'w') as handle:
         handle.write(harm_docs())
     with open('user/feeds.rst', 'w') as handle:
         handle.write(feeds_docs())

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,31 +20,6 @@ sys.path.insert(0, os.path.abspath('./'))
 
 import autogen
 
-# This class translates tries to work around a bug in commonmark:
-# commonmark removes the extension from all links ending in .md, even if
-# they are not pointing to a local file built by sphinx
-# See also this TODO in recommonmark.
-# https://github.com/readthedocs/recommonmark/blob/ddd56e7717e9745f11300059e4268e204138a6b1/recommonmark/parser.py#L152-L155
-# This class checks if a link is relative and then replaces the target
-# with an URL built from the github URL and the link text
-# That means we have to use the file extension in the link text for
-# now
-
-class GithubURLDomain(Domain):
-    """
-    Resolve certain links in markdown files to github source.
-    """
-
-    ROOT = "https://github.com/certtools/intelmq/blob/master/"
-
-    def resolve_any_xref(self, env, fromdocname, builder, target, node, contnode):
-        if contnode["refuri"].startswith("../"):
-            print(f"Replacing {contnode['refuri']} with {self.ROOT}{contnode.rawsource}")
-            contnode["refuri"] = self.ROOT + contnode.rawsource
-            return [("githuburl:any", contnode)]
-        else:
-            return []
-
 # -- Project information -----------------------------------------------------
 
 project = 'intelmq'
@@ -67,8 +42,6 @@ rst_prolog = """
 extensions = [
         'sphinx.ext.autodoc',
         'sphinx.ext.extlinks',
-        'recommonmark',
-        'sphinx_markdown_tables',
         'sphinx.ext.napoleon'
 ]
 
@@ -124,13 +97,12 @@ def run_apidoc(_):
 
 
 def run_autogen(_):
-    with open('dev/harmonization-fields.md', 'w') as handle:
+    with open('dev/harmonization-fields.rst', 'w') as handle:
         handle.write(autogen.harm_docs())
     with open('user/feeds.rst', 'w') as handle:
         handle.write(autogen.feeds_docs())
 
 
 def setup(app):
-    app.add_domain(GithubURLDomain)
     app.connect("builder-inited", run_apidoc)
     app.connect("builder-inited", run_autogen)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -52,10 +52,9 @@ Getting involved
 
    dev/guide
    dev/data-harmonization
-   dev/harmonization-fields.md
+   dev/harmonization-fields
    dev/release-procedure
    dev/feeds-wishlist
-   dev/IntelMQ-3.0-Architecture.md
 
 Licence
 =======

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,4 @@
-recommonmark>=0.6.0
 Sphinx>=3.2.1
-sphinx-markdown-tables>=0.0.15
 PyYAML>=5.3.1
 dnspython>=1.11.1
 psutil>=1.2.1
@@ -9,4 +7,3 @@ python-termstyle>=0.1.10
 pytz>=2012c
 redis>=2.10
 requests>=2.2.0
-

--- a/intelmq/etc/harmonization.conf
+++ b/intelmq/etc/harmonization.conf
@@ -1,11 +1,11 @@
 {
     "event": {
         "classification.identifier": {
-            "description": "The lowercase identifier defines the actual software or service (e.g. 'heartbleed' or 'ntp_version') or standardized malware name (e.g. 'zeus'). Note that you MAY overwrite this field during processing for your individual setup. This field is not standardized across IntelMQ setups/users.",
+            "description": "The lowercase identifier defines the actual software or service (e.g. ``heartbleed`` or ``ntp_version``) or standardized malware name (e.g. ``zeus``). Note that you MAY overwrite this field during processing for your individual setup. This field is not standardized across IntelMQ setups/users.",
             "type": "String"
         },
         "classification.taxonomy": {
-            "description": "We recognize the need for the CSIRT teams to apply a static (incident) taxonomy to abuse data. With this goal in mind the type IOC will serve as a basis for this activity. Each value of the dynamic type mapping translates to a an element in the static taxonomy. The European CSIRT teams for example have decided to apply the eCSIRT.net incident classification. The value of the taxonomy key is thus a derivative of the dynamic type above. For more information about check [ENISA taxonomies](http://www.enisa.europa.eu/activities/cert/support/incident-management/browsable/incident-handling-process/incident-taxonomy/existing-taxonomies).",
+            "description": "We recognize the need for the CSIRT teams to apply a static (incident) taxonomy to abuse data. With this goal in mind the type IOC will serve as a basis for this activity. Each value of the dynamic type mapping translates to a an element in the static taxonomy. The European CSIRT teams for example have decided to apply the eCSIRT.net incident classification. The value of the taxonomy key is thus a derivative of the dynamic type above. For more information about check `ENISA taxonomies <http://www.enisa.europa.eu/activities/cert/support/incident-management/browsable/incident-handling-process/incident-taxonomy/existing-taxonomies>`_.",
             "length": 100,
             "type": "LowercaseString"
         },


### PR DESCRIPTION
The script `docs/autogen.py` still generated the harmonization field
overview as markdown file. To get rid of the recommonmark dependency,
the script now generates restructured text, like all the other
documentaiton source files.
This commit modifies the autogen.py file as described, it changes the
extension of the autogenerated file in .gitignore; it removes all traces
of recommonmark configs in the sphinx configuration files docs/conf.py.
It changes the inclusion of the autogenerated file in the documentation
index.rst file.
The commit also drops the doc/dev/IntelMQ-3.0-Architecture.md file from
the documentation- this is an internal WIP file and does not need to be
part of the user facing docs.
TODO: there are some field descriptions containing markdown syntax, they
should be updated.
