### PR TITLE
Tell codespell to ignore specific lines

### DIFF
--- a/.github/workflows/codespell.excludelines
+++ b/.github/workflows/codespell.excludelines
@@ -1,0 +1,16 @@
+# Exact lines that should be ignored by codespell
+#
+# from NEWS.md
+The correct name for the parameter "delimeter" is "delimiter". Please fix your configured bots.
+   WHERE "event_description.text" = 'The malicous client used a honeypot as proxy.' AND "classification.taxonomy" = 'other' AND "classification.type" = 'other' AND "classification.identifier" = 'proxyget' AND "feed.name" = 'Spamhaus CERT';
+   WHERE "event_description.text" = 'The infected iot device logged in to a honeypot and issued malicous commands.' AND "classification.taxonomy" = 'intrusions' AND "classification.type" = 'unauthorized-command' AND "classification.identifier" = 'iot' AND "feed.name" = 'Spamhaus CERT';
+
+# from intelmq/tests/lib/test_upgrades.py
+        "delimeter": ","
+        "delimeter": ",",
+
+# from intelmq/lib/upgrades.py
+            if "delimeter" in bot["parameters"] and "delimiter" in bot["parameters"]:
+                del bot["parameters"]["delimeter"]
+            elif "delimeter" in bot["parameters"]:
+                bot["parameters"]["delimiter"] = bot["parameters"]["delimeter"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,7 @@ exclude =
 [codespell]
 skip = *.csv,*.data,./docs/_build,.eggs,.git,testfile.txt,dga.txt
 ignore-words-list = crypted,ba,nwe,ether
+exclude-file = .github/workflows/codespell.excludelines
 
 [metadata]
 name = intelmq


### PR DESCRIPTION
Given that we have to document some spelling mistakes made in the past,
we have to make codespell ignore those lines. This adds a
.github/workflows/codespell.excludelines file, that lists the exact
lines that sould be ignored by codespell, and adds the relevant setting
to the setup.cfg
