### PR TITLE
PKG: drop the dh-systemd dependency from the package

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,6 @@ Section: python
 Priority: optional
 Build-Depends: debhelper (>= 4.1.16),
                dh-python,
-               dh-systemd,
                lsb-release,
                python-setuptools,
                python3-all,


### PR DESCRIPTION
dh-systemd is a transitional package that is not needed anymore and
leads to dependency errors on bullseye.
