### PR TITLE
MAINT: Add a workflow that builds Debian packages

### DIFF
--- a/.github/workflows/debian-package.yml
+++ b/.github/workflows/debian-package.yml
@@ -1,0 +1,34 @@
+#Github Workflow to build Debian packages for intelmq-api
+#
+#SPDX-FileCopyrightText: 2020 IntelMQ Team <intelmq-team@cert.at>
+#SPDX-License-Identifier: AGPL-3.0-or-later
+#
+name: "Build Debian packages"
+on:
+  push:
+    branches: [develop, maintenance, master]
+  pull_request:
+    branches: [develop, maintenance]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: Build Debian packages
+    strategy:
+      matrix:
+        codename: ['buster', 'bullseye']
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Build package
+      run: bash .github/workflows/scripts/debian-package.sh ${{ matrix.codename }}
+
+    - name: Upload artifact
+      if: ${{ github.event_name == 'push' }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: debian-package-${{ matrix.codename }}-${{ github.sha }}
+        path: '~/artifacts'
+        retention-days: 5

--- a/.github/workflows/scripts/debian-package.sh
+++ b/.github/workflows/scripts/debian-package.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2020 Birger Schacht
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# Bash script for a github action to build a Debian
+# package in a user-defined Debian container
+
+
+set -x
+set -e
+
+# A list of known Debian releases
+knowncodenames=("stretch" "buster" "bullseye" "stable" "testing")
+
+# We want exactly one argument: the name of the release
+if (( $# != 1 ))
+then
+	>&2 echo "Illegal number of parameters"
+	exit 1
+fi
+
+codename=$1
+
+# check if the releasename is in the list of known Debian distributions
+validcodename=false
+for value in "${knowncodenames[@]}"
+do
+	[[ "$codename" = "$value" ]] && validcodename=true
+done
+
+# If the release name is not valid, simply exit
+unknowncodename () {
+	>&2 echo "Debian distribution not known. Valid arguments are: ${knowncodenames[*]}"
+	exit 1
+}
+
+# Build the package in the container
+build () {
+	codename=$1
+	echo "Building on ${codename}"
+	# run installation in buildah
+
+	ARTIFACTEXTENSIONS=("deb" "xz" "dsc" "buildinfo" "changes")
+	PARENT=$(dirname "${GITHUB_WORKSPACE}")
+	echo "Building on ${codename} in ${GITHUB_WORKSPACE}"
+
+	# fetch and configure the container
+	CONTAINER=$(buildah from docker.io/debian:"${codename}"-slim)
+	buildah config --workingdir "${GITHUB_WORKSPACE}" "${CONTAINER}"
+
+	# install build dependencies in the container
+	BR="buildah run -v ${PARENT}:${PARENT}"
+	${BR} "${CONTAINER}" apt-get update -qq
+	${BR} "${CONTAINER}" apt-get install dpkg-dev lintian -y
+	${BR} "${CONTAINER}" apt-get build-dep -y .
+
+	# this is a hack because intelmq does
+	# not like to be run as root :( :
+	${BR} "${CONTAINER}" chown -R nobody:nogroup "${PARENT}"
+	${BR} --user nobody:nogroup "${CONTAINER}" /bin/sh -c 'dpkg-buildpackage -us -uc -b'
+
+	# create a directory for the artifacts
+	# and copy the relevant files there
+	mkdir -p "${HOME}/artifacts"
+	for extension in "${ARTIFACTEXTENSIONS[@]}"
+	do
+		find "${PARENT}" -type f -name "*.${extension}" -exec cp '{}' "${HOME}/artifacts/" \;
+	done
+}
+
+# check if release name is valid; build if it is, exit if it isn't
+if [ "$validcodename" = true ]
+then
+	build "$codename"
+else
+	unknowncodename
+fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,6 @@ python:
   - 3.8
 jobs:
   include:
-  - python: 3.5
-    env: mode=debian
   - python: 3.8
     env: mode=documentation
   exclude:
@@ -28,7 +26,6 @@ before_install:
   - if [[ -v requirements ]]; then sudo systemctl start elasticsearch; fi
 install:
   - set -e
-  - if [[ $mode == debian ]]; then sudo apt-get install dpkg-dev dh-python python-setuptools python3-setuptools python3-all debhelper quilt fakeroot dh-systemd safe-rm; pip3 install requests; pip3 install redis; pip3 install dnspython; pip3 install psutil; pip3 install python-dateutil; pip3 install termstyle; pip3 install pytz; pip3 install typing; fi
   - if [[ $requirements == true ]]; then for file in intelmq/bots/*/*/REQUIREMENTS.txt; do pip install -r $file; done; fi
   - if [[ -v requirements ]]; then pip install Cerberus!=1.3 codecov pyyaml requests_mock; fi
   - if [[ -v requirements ]]; then sudo sed -i '/^Defaults\tsecure_path.*$/ d' /etc/sudoers; fi
@@ -42,22 +39,10 @@ before_script:
   - if [[ $requirements == true ]] ; then intelmq_psql_initdb; fi
   - if [[ $requirements == true ]] ; then sed -i 's/events/tests/g' /tmp/initdb.sql; fi
   - if [[ $requirements == true ]] ; then psql -v ON_ERROR_STOP=on -f /tmp/initdb.sql intelmq -U intelmq; fi
-  - if [[ $mode == debian ]]; then regex="\(([a-z0-9.~-]+)\)" && [[ $(head -n 1 debian/changelog) =~ $regex ]] && debversion=${BASH_REMATCH[1]} && version=${debversion%-?}; fi
-  - if [[ $mode == debian ]]; then git archive --format=tar.gz HEAD > ../intelmq_$version.orig.tar.gz; fi
-  - if [[ $mode == debian ]]; then git archive --format=tar.gz --prefix=debian/ HEAD:debian/ > ../intelmq_$debversion.debian.tar.gz; fi
-  - if [[ $mode == debian ]]; then pushd ..; fi
-  - if [[ $mode == debian ]]; then mkdir build; fi
-  - if [[ $mode == debian ]]; then cd build; fi
-  - if [[ $mode == debian ]]; then tar -xzf ../intelmq_$version.orig.tar.gz; fi
-  - if [[ $mode == debian ]]; then tar -xzf ../intelmq_$debversion.debian.tar.gz; fi
-  - if [[ $mode == debian ]]; then popd; fi
   - if [[ -v requirements ]]; then gpg --import intelmq/tests/assets/key-public.pgp; fi
   - if [[ $requirements == true ]]; then sudo bash -c 'echo "[rabbitmq_management]." > /etc/rabbitmq/enabled_plugins' && sudo systemctl restart rabbitmq-server; fi
 script:
   - if [[ $requirements == true ]]; then TZ=utc INTELMQ_TEST_DATABASES=1 INTELMQ_TEST_EXOTIC=1 nosetests --with-coverage --cover-package=intelmq --cover-branches; find contrib/ -name "test*.py" -exec nosetests {} \+; elif [[ $requirements == false ]]; then nosetests --with-coverage --cover-package=intelmq --cover-branches; fi
-  - if [[ $mode == debian ]]; then pushd ../build; fi
-  - if [[ $mode == debian ]]; then DEB_BUILD_OPTIONS='nocheck' dpkg-buildpackage -us -uc -d; fi
-  - if [[ $mode == debian ]]; then popd; fi
   - if [[ $mode == documentation ]]; then pushd docs; fi
   - if [[ $mode == documentation ]]; then make html; fi
   - if [[ $mode == documentation ]]; then popd; fi

--- a/debian/control
+++ b/debian/control
@@ -21,6 +21,7 @@ Build-Depends: debhelper (>= 4.1.16),
                python3-termstyle,
                python3-tz,
                quilt,
+               rsync,
                safe-rm
 X-Python3-Version: >= 3.5
 Standards-Version: 3.9.6


### PR DESCRIPTION
The workflow builds debian packages on Debian buster and bullseye. The
action runs on push & pull request events.
Artifacts are stored for 5 days, but only created for push events.
