### PR TITLE
Fixes sieve timezone "utc" & sieve variable bug

### DIFF
--- a/intelmq/bots/experts/sieve/expert.py
+++ b/intelmq/bots/experts/sieve/expert.py
@@ -10,6 +10,7 @@ import os
 import re
 import traceback
 import datetime
+import pytz
 
 import intelmq.lib.exceptions as exceptions
 from intelmq import HARMONIZATION_CONF_FILE
@@ -242,7 +243,8 @@ class SieveExpertBot(Bot):
 
     @staticmethod
     def compute_basic_math(action, event):
-        date = DateTime.parse_utc_isoformat(event[action.key], True)
+        tz = pytz.timezone('UTC')
+        date = tz.localize(DateTime.parse_utc_isoformat(event[action.key], True))
         if action.operator == '+=':
             return (date + datetime.timedelta(minutes=parse_relative(action.value))).isoformat()
         elif action.operator == '-=':

--- a/intelmq/bots/experts/sieve/expert.py
+++ b/intelmq/bots/experts/sieve/expert.py
@@ -10,7 +10,6 @@ import os
 import re
 import traceback
 import datetime
-import pytz
 
 import intelmq.lib.exceptions as exceptions
 from intelmq import HARMONIZATION_CONF_FILE
@@ -243,8 +242,7 @@ class SieveExpertBot(Bot):
 
     @staticmethod
     def compute_basic_math(action, event):
-        tz = pytz.timezone('UTC')
-        date = tz.localize(DateTime.parse_utc_isoformat(event[action.key], True))
+        date = DateTime.parse_utc_isoformat(event[action.key], True)
         if action.operator == '+=':
             return (date + datetime.timedelta(minutes=parse_relative(action.value))).isoformat()
         elif action.operator == '-=':

--- a/intelmq/bots/experts/sieve/expert.py
+++ b/intelmq/bots/experts/sieve/expert.py
@@ -258,18 +258,21 @@ class SieveExpertBot(Bot):
             event.path = action.path
         elif action.__class__.__name__ == 'AddAction':
             if action.key not in event:
+                value = action.value
                 if action.operator != '=':
-                    action.value = SieveExpertBot.compute_basic_math(action, event)
-                event.add(action.key, action.value)
+                    value = SieveExpertBot.compute_basic_math(action, event)
+                event.add(action.key, value)
         elif action.__class__.__name__ == 'AddForceAction':
+            value = action.value
             if action.operator != '=':
-                action.value = SieveExpertBot.compute_basic_math(action, event)
-            event.add(action.key, action.value, overwrite=True)
+                value = SieveExpertBot.compute_basic_math(action, event)
+            event.add(action.key, value, overwrite=True)
         elif action.__class__.__name__ == 'UpdateAction':
             if action.key in event:
+                value = action.value
                 if action.operator != '=':
-                    action.value = SieveExpertBot.compute_basic_math(action, event)
-                event.change(action.key, action.value)
+                    value = SieveExpertBot.compute_basic_math(action, event)
+                event.change(action.key, value)
         elif action.__class__.__name__ == 'RemoveAction':
             if action.key in event:
                 del event[action.key]

--- a/intelmq/lib/harmonization.py
+++ b/intelmq/lib/harmonization.py
@@ -347,7 +347,7 @@ class DateTime(String):
             dtvalue = datetime.datetime.strptime(value, '%Y-%m-%dT%H:%M:%S.%f+00:00')
 
         if return_datetime:
-            return dtvalue
+            return pytz.timezone('UTC').localize(dtvalue)
         else:
             return value
 


### PR DESCRIPTION
Timezone was not interpreted correctly. Now we localize time to UTC in sieve expert.

Signed-off-by: Sebastian Waldbauer <waldbauer@cert.at>
