### PR TITLE
remove undesired quotes in harmonization.conf

### DIFF
--- a/intelmq/etc/harmonization.conf
+++ b/intelmq/etc/harmonization.conf
@@ -10,7 +10,7 @@
             "type": "LowercaseString"
         },
         "classification.type": {
-            "description": "The abuse type IOC is one of the most crucial pieces of information for any given abuse event. The main idea of dynamic typing is to keep our ontology flexible, since we need to evolve with the evolving threatscape of abuse data. In contrast with the static taxonomy below, the dynamic typing is used to perform business decisions in the abuse handling pipeline. Furthermore, the value data set should be kept as minimal as possible to avoid \u201ctype explosion\u201d, which in turn dilutes the business value of the dynamic typing. In general, we normally have two types of abuse type IOC: ones referring to a compromised resource or ones referring to pieces of the criminal infrastructure, such as a command and control servers for example.",
+            "description": "The abuse type IOC is one of the most crucial pieces of information for any given abuse event. The main idea of dynamic typing is to keep our ontology flexible, since we need to evolve with the evolving threatscape of abuse data. In contrast with the static taxonomy below, the dynamic typing is used to perform business decisions in the abuse handling pipeline. Furthermore, the value data set should be kept as minimal as possible to avoid ``type explosion``, which in turn dilutes the business value of the dynamic typing. In general, we normally have two types of abuse type IOC: ones referring to a compromised resource or ones referring to pieces of the criminal infrastructure, such as a command and control servers for example.",
             "type": "ClassificationType"
         },
         "comment": {


### PR DESCRIPTION
change unicode right/left double quotes to utf-8 (imho as it is intend to)

`event.classification.identifier.description` in harmonization.conf served as an example to correct usage.