### PR TITLE
[FIX] Unittest checks if rsync is installed

### DIFF
--- a/intelmq/tests/bots/collectors/rsync/test_collector.py
+++ b/intelmq/tests/bots/collectors/rsync/test_collector.py
@@ -2,6 +2,7 @@
 import tempfile
 import os
 import unittest
+import shutil
 
 import intelmq.lib.test as test
 import intelmq.lib.utils as utils
@@ -17,7 +18,7 @@ OUTPUT = {"__type": "Report",
           "raw": utils.base64_encode(EXAMPLE_FILE),
           }
 
-
+@unittest.skipIf(shutil.which("rsync") is None, "RSync is not installed")
 class TestRsyncCollectorBot(test.BotTestCase, unittest.TestCase):
     @classmethod
     def set_bot(cls):


### PR DESCRIPTION
Currently this test will fail and throw an exception if rsync is not installed. So we should check first if rsync is installed, before running this test.