### PR TITLE
Shadowserver Block List Feed: Parse CIDR-notation entries correctly

### DIFF
--- a/intelmq/bots/parsers/shadowserver/config.py
+++ b/intelmq/bots/parsers/shadowserver/config.py
@@ -187,7 +187,21 @@ def validate_ip(value):
     """Remove "invalid" IP."""
     if value == '0.0.0.0':
         return None
+
+    # FIX: https://github.com/certtools/intelmq/issues/1720 # TODO: Find better fix
+    if '/' in value:
+        return None
+
     if harmonization.IPAddress.is_valid(value, sanitize=True):
+        return value
+
+
+def validate_network(value):
+    # FIX: https://github.com/certtools/intelmq/issues/1720 # TODO: Find better fix
+    if '/' not in value:
+        return None
+
+    if harmonization.IPNetwork.is_valid(value, sanitize=True):
         return value
 
 
@@ -1582,9 +1596,10 @@ open_ldap = {
 blocklist = {
     'required_fields': [
         ('time.source', 'timestamp', add_UTC_to_timestamp),
-        ('source.ip', 'ip'),
     ],
     'optional_fields': [
+        ('source.ip', 'ip', validate_ip),
+        ('source.network', 'ip', validate_network),
         ('source.reverse_dns', 'hostname'),
         ('extra.', 'source', validate_to_none),
         ('extra.', 'reason', validate_to_none),

--- a/intelmq/tests/bots/parsers/shadowserver/test_blocklist.py
+++ b/intelmq/tests/bots/parsers/shadowserver/test_blocklist.py
@@ -56,6 +56,25 @@ EVENTS = [{
     "source.ip": "198.123.245.171",
     "time.observation": "2015-01-01T00:00:00+00:00",
     "time.source": "2019-09-04T07:00:19+00:00"
+},
+{
+    '__type': 'Event',
+    'feed.name': 'Blocklist',
+    "classification.identifier": "blacklisted-ip",
+    "classification.taxonomy": "other",
+    "classification.type": "blacklist",
+    "extra.naics": 517311,
+    "extra.reason": "Malicious Host AA",
+    "extra.source": "Alien Vault",
+    'raw': utils.base64_encode('\n'.join([EXAMPLE_LINES[0],
+                                         EXAMPLE_LINES[3]])),
+    "source.asn": 5678,
+    "source.geolocation.cc": "XX",
+    "source.geolocation.city": "LOCATION",
+    "source.geolocation.region": "LOCATION",
+    "source.network": "198.123.245.0/24",
+    "time.observation": "2015-01-01T00:00:00+00:00",
+    "time.source": "2019-09-04T07:00:19+00:00"
 },]
 
 

--- a/intelmq/tests/bots/parsers/shadowserver/testdata/blocklist.csv
+++ b/intelmq/tests/bots/parsers/shadowserver/testdata/blocklist.csv
@@ -1,3 +1,4 @@
 "timestamp","ip","hostname","source","reason","asn","geo","region","city","naics","sic","sector"
 "2019-09-04 07:00:19","198.123.245.134",host.local,"Alien Vault","Malicious Host AA",5678,"XX","LOCATION","LOCATION",517311,0,0
 "2019-09-04 07:00:19","198.123.245.171",,"Alien Vault","Malicious Host AA",5678,"XX","LOCATION","LOCATION",517311,0,
+"2019-09-04 07:00:19","198.123.245.0/24",,"Alien Vault","Malicious Host AA",5678,"XX","LOCATION","LOCATION",517311,0,


### PR DESCRIPTION
ShadowServer parses not CIDR notation networks correctly.

#Fixes 1720