### PR TITLE
Get rid of parameters

### DIFF
--- a/intelmq/bots/collectors/alienvault_otx/collector.py
+++ b/intelmq/bots/collectors/alienvault_otx/collector.py
@@ -12,6 +12,11 @@ except ImportError:
 
 
 class AlienVaultOTXCollectorBot(CollectorBot):
+    "Collect reports from the AlienVault OTX Collector API. Report varies according to subscriptions."
+    api_key: str = "<insert your api key>"
+    interval: int = 24
+    modified_pulses_only: bool = False
+    rate_limit: int = 3600
 
     def init(self):
         if OTXv2 is None:
@@ -20,7 +25,6 @@ class AlienVaultOTXCollectorBot(CollectorBot):
         self.modified_pulses_only = False
         if hasattr(self, 'modified_pulses_only'):
             self.modified_pulses_only = self.modified_pulses_only
-            self.interval = getattr(self, 'interval', 24)
 
     def process(self):
         self.logger.info("Downloading report through API.")

--- a/intelmq/bots/collectors/alienvault_otx/collector.py
+++ b/intelmq/bots/collectors/alienvault_otx/collector.py
@@ -18,13 +18,13 @@ class AlienVaultOTXCollectorBot(CollectorBot):
             raise MissingDependencyError("OTXv2")
 
         self.modified_pulses_only = False
-        if hasattr(self.parameters, 'modified_pulses_only'):
-            self.modified_pulses_only = self.parameters.modified_pulses_only
-            self.interval = getattr(self.parameters, 'interval', 24)
+        if hasattr(self, 'modified_pulses_only'):
+            self.modified_pulses_only = self.modified_pulses_only
+            self.interval = getattr(self, 'interval', 24)
 
     def process(self):
         self.logger.info("Downloading report through API.")
-        otx = OTXv2(self.parameters.api_key, proxy=self.parameters.https_proxy)
+        otx = OTXv2(self.api_key, proxy=self.https_proxy)
         if self.modified_pulses_only:
             self.logger.info("Fetching only modified pulses.")
             interval = (datetime.datetime.now() -

--- a/intelmq/bots/collectors/amqp/collector_amqp.py
+++ b/intelmq/bots/collectors/amqp/collector_amqp.py
@@ -20,6 +20,16 @@ class AMQPCollectorBot(AMQPTopicOutputBot, CollectorBot):
     Inheriting from AMQPTopicOutputBot for connect_server method
     """
     exchange = False
+    connection_heartbeat = 3600
+    connection_host = "127.0.0.1"
+    connection_port = 5672
+    connection_vhost = None
+    username = None
+    password = None
+    use_ssl = False
+    connection_attempts = 3
+    queue_name = None
+    expect_intelmq_message = False
 
     def init(self):
         if pika is None:
@@ -34,28 +44,21 @@ class AMQPCollectorBot(AMQPTopicOutputBot, CollectorBot):
                                          installed=pika.__version__)
 
         self.kwargs = {}
-        self.kwargs['heartbeat'] = self.parameters.connection_heartbeat
+        self.kwargs['heartbeat'] = self.connection_heartbeat
 
-        self.connection_host = self.parameters.connection_host
-        self.connection_port = self.parameters.connection_port
-        self.connection_vhost = self.parameters.connection_vhost
-        if self.parameters.username and self.parameters.password:
-            self.kwargs['credentials'] = pika.PlainCredentials(self.parameters.username,
-                                                               self.parameters.password)
+        if self.username and self.password:
+            self.kwargs['credentials'] = pika.PlainCredentials(self.username,
+                                                               self.password)
 
-        if getattr(self.parameters, 'use_ssl', False):
+        if self.use_ssl:
             self.kwargs['ssl_options'] = pika.SSLOptions(context=ssl.create_default_context(ssl.Purpose.CLIENT_AUTH))
 
         self.connection_parameters = pika.ConnectionParameters(
             host=self.connection_host,
             port=self.connection_port,
             virtual_host=self.connection_vhost,
-            connection_attempts=self.parameters.connection_attempts,
+            connection_attempts=self.connection_attempts,
             **self.kwargs)
-
-        self.queue_name = self.parameters.queue_name
-        self.expect_intelmq_message = getattr(self.parameters, 'expect_intelmq_message',
-                                              False)
 
         self.connect_server()
 

--- a/intelmq/bots/collectors/amqp/collector_amqp.py
+++ b/intelmq/bots/collectors/amqp/collector_amqp.py
@@ -17,19 +17,20 @@ except ImportError:
 
 class AMQPCollectorBot(AMQPTopicOutputBot, CollectorBot):
     """
+    Collect data from an AMQP Server and fetch either intelmq or any other messages. Requires the pika python library.
     Inheriting from AMQPTopicOutputBot for connect_server method
     """
-    exchange = False
-    connection_heartbeat = 3600
-    connection_host = "127.0.0.1"
-    connection_port = 5672
-    connection_vhost = None
-    username = None
-    password = None
-    use_ssl = False
-    connection_attempts = 3
-    queue_name = None
-    expect_intelmq_message = False
+    exchange: bool = False
+    connection_attempts: int = 3
+    connection_heartbeat: int = 3600
+    connection_host: str = "127.0.0.1"  # TODO should be ipaddress
+    connection_port: int = 5672
+    connection_vhost: str = None
+    expect_intelmq_message: bool = False
+    password: str = None
+    queue_name: str = None
+    use_ssl: bool = False
+    username: str = None
 
     def init(self):
         if pika is None:

--- a/intelmq/bots/collectors/api/collector_api.py
+++ b/intelmq/bots/collectors/api/collector_api.py
@@ -25,8 +25,12 @@ else:
 
 
 class APICollectorBot(CollectorBot):
-    collector_empty_process = True
-    is_multithreadable = False
+    """Collect data by exposing a HTTP API interface"""
+    name: str = "API"
+    port: int = 5000
+    provider: str = "APICollector"
+    collector_empty_process: bool = True
+    is_multithreadable: bool = False
 
     def init(self):
         if IOLoop is None:
@@ -36,7 +40,6 @@ class APICollectorBot(CollectorBot):
             ("/intelmq/push", MainHandler),
         ])
 
-        self.port = getattr(self.parameters, 'port', 5000)
         self.server = app.listen(self.port)
         self.eventLoopThread = Thread(target=IOLoop.current().start)
         self.eventLoopThread.daemon = True

--- a/intelmq/bots/collectors/blueliv/collector_crimeserver.py
+++ b/intelmq/bots/collectors/blueliv/collector_crimeserver.py
@@ -12,21 +12,23 @@ except ImportError:
 
 
 class BluelivCrimeserverCollectorBot(CollectorBot):
+    """Collect reports from the Blueliv Crimeserver API"""
+    api_key: str = "<insert your api key>"
+    api_url: str = "https://freeapi.blueliv.com"
+    rate_limit: int = 3600
+
     def init(self):
         if BluelivAPI is None:
             raise MissingDependencyError("sdk.blueliv_api.BluelivAPI")
 
-        if not hasattr(self.parameters, 'api_url'):
-            setattr(self.parameters, 'api_url', 'https://freeapi.blueliv.com')
-
     def process(self):
         self.logger.debug("Downloading report through API.")
         proxy = None
-        if self.parameters.http_proxy and self.parameters.https_proxy:
-            proxy = {'http': self.parameters.http_proxy,
-                     'https': self.parameters.https_proxy}
-        api = BluelivAPI(base_url=self.parameters.api_url,
-                         token=self.parameters.api_key,
+        if self.http_proxy and self.https_proxy:
+            proxy = {'http': self.http_proxy,
+                     'https': self.https_proxy}
+        api = BluelivAPI(base_url=self.api_url,
+                         token=self.api_key,
                          log_level=logging.INFO,
                          proxy=proxy)
 

--- a/intelmq/bots/collectors/calidog/collector_certstream.py
+++ b/intelmq/bots/collectors/calidog/collector_certstream.py
@@ -19,6 +19,8 @@ except ImportError:
 
 
 class CertstreamCollectorBot(CollectorBot):
+    """Collect information from CertStream certificate transparency logs"""
+
     def init(self):
         if CertStreamClient is None:
             raise MissingDependencyError("certstream")

--- a/intelmq/bots/collectors/eset/collector.py
+++ b/intelmq/bots/collectors/eset/collector.py
@@ -10,14 +10,20 @@ except ImportError:
 
 
 class ESETCollectorBot(CollectorBot):
+    """Collect data from ESET's TAXII API"""
+    collection: str = "<collection>"
+    endpoint: str = "eti.eset.com"
+    password: str = "<password>"
+    rate_limit: int = 3600
+    time_delta: int = 3600
+    username: str = "<username>"
+
     def init(self):
         if cabby is None:
             raise MissingDependencyError('cabby')
-        self.user = self.parameters.username
-        self.passwd = self.parameters.password
-        self.endpoint = self.parameters.endpoint
-        self.time_delta = int(self.parameters.time_delta)
-        self.collection = self.parameters.collection
+        self.user = self.username
+        self.passwd = self.password
+        self.time_delta = int(self.time_delta)
 
     def process(self):
         end = datetime.datetime.now(datetime.timezone.utc)
@@ -38,7 +44,7 @@ class ESETCollectorBot(CollectorBot):
 
             report = self.new_report()
             report.add("feed.url", "https://%s/taxiiservice/discovery" % self.endpoint)
-            report.add('extra.eset_feed', self.parameters.collection)
+            report.add('extra.eset_feed', self.collection)
             report.add('raw', item.content)
             self.send_message(report)
 

--- a/intelmq/bots/collectors/file/collector_file.py
+++ b/intelmq/bots/collectors/file/collector_file.py
@@ -31,34 +31,33 @@ class FileCollectorBot(CollectorBot):
 
     def init(self):
         # Test if path is a directory
-        if not os.path.isdir(self.parameters.path):
-            raise exceptions.InvalidArgument('path', got=self.parameters.path,
+        if not os.path.isdir(self.path):
+            raise exceptions.InvalidArgument('path', got=self.path,
                                              expected="directory")
 
-        if not self.parameters.postfix:
+        if not self.postfix:
             self.logger.warn("No file extension was set. The collector will"
-                             " read all files in %s.", self.parameters.path)
-            if self.parameters.delete_file:
+                             " read all files in %s.", self.path)
+            if self.delete_file:
                 self.logger.error("This configuration would delete all files"
                                   " in %s. I'm stopping now....",
-                                  self.parameters.path)
+                                  self.path)
                 self.stop()
 
-        self.chunk_size = getattr(self.parameters, 'chunk_size', None)
-        self.chunk_replicate_header = getattr(self.parameters,
-                                              'chunk_replicate_header', None)
+        self.chunk_size = getattr(self, 'chunk_size', None)
+        self.chunk_replicate_header = getattr(self, 'chunk_replicate_header', None)
 
     def process(self):
         self.logger.debug("Started looking for files.")
 
-        if os.path.isdir(self.parameters.path):
-            p = os.path.abspath(self.parameters.path)
+        if os.path.isdir(self.path):
+            p = os.path.abspath(self.path)
 
             # iterate over all files in dir
             for f in os.listdir(p):
                 filename = os.path.join(p, f)
                 if os.path.isfile(filename):
-                    if fnmatch.fnmatch(f, '*' + self.parameters.postfix):
+                    if fnmatch.fnmatch(f, '*' + self.postfix):
                         self.logger.info("Processing file %r.", filename)
 
                         template = self.new_report()
@@ -70,7 +69,7 @@ class FileCollectorBot(CollectorBot):
                                                            self.chunk_replicate_header):
                                 self.send_message(report)
 
-                        if self.parameters.delete_file:
+                        if self.delete_file:
                             try:
                                 os.remove(filename)
                                 self.logger.debug("Deleted file: %r.", filename)

--- a/intelmq/bots/collectors/file/collector_file.py
+++ b/intelmq/bots/collectors/file/collector_file.py
@@ -28,6 +28,13 @@ from intelmq.lib.splitreports import generate_reports
 
 
 class FileCollectorBot(CollectorBot):
+    """Fetch data from the file system"""
+    chunk_replicate_header: bool = True
+    chunk_size: int = None
+    delete_file: bool = False
+    path: str = "/tmp/"  # TODO pathlib.Path
+    postfix: str = ".csv"
+    rate_limit: int = 300
 
     def init(self):
         # Test if path is a directory
@@ -43,9 +50,6 @@ class FileCollectorBot(CollectorBot):
                                   " in %s. I'm stopping now....",
                                   self.path)
                 self.stop()
-
-        self.chunk_size = getattr(self, 'chunk_size', None)
-        self.chunk_replicate_header = getattr(self, 'chunk_replicate_header', None)
 
     def process(self):
         self.logger.debug("Started looking for files.")

--- a/intelmq/bots/collectors/github_api/collector_github_api.py
+++ b/intelmq/bots/collectors/github_api/collector_github_api.py
@@ -25,9 +25,9 @@ class GithubAPICollectorBot(CollectorBot):
             raise ValueError('Could not import requests. Please install it.')
 
         self.__user_headers = static_params['headers']
-        if hasattr(self.parameters, 'basic_auth_username') and hasattr(self.parameters, 'basic_auth_password'):
-            self.__user_headers.update(self.__produce_auth_header(getattr(self.parameters, 'basic_auth_username'),
-                                                                  getattr(self.parameters, 'basic_auth_password')))
+        if hasattr(self, 'basic_auth_username') and hasattr(self, 'basic_auth_password'):
+            self.__user_headers.update(self.__produce_auth_header(getattr(self, 'basic_auth_username'),
+                                                                  getattr(self, 'basic_auth_password')))
         else:
             self.logger.warning('Using unauthenticated API access, means the request limit is at 60 per hour.')
 

--- a/intelmq/bots/collectors/github_api/collector_github_api.py
+++ b/intelmq/bots/collectors/github_api/collector_github_api.py
@@ -19,15 +19,16 @@ static_params = {
 
 
 class GithubAPICollectorBot(CollectorBot):
+    basic_auth_username = None
+    basic_auth_password = None
 
     def init(self):
         if requests is None:
             raise ValueError('Could not import requests. Please install it.')
 
         self.__user_headers = static_params['headers']
-        if hasattr(self, 'basic_auth_username') and hasattr(self, 'basic_auth_password'):
-            self.__user_headers.update(self.__produce_auth_header(getattr(self, 'basic_auth_username'),
-                                                                  getattr(self, 'basic_auth_password')))
+        if self.basic_auth_username is not None and self.basic_auth_password is not None:
+            self.__user_headers.update(self.__produce_auth_header(self.basic_auth_username, self.basic_auth_password))
         else:
             self.logger.warning('Using unauthenticated API access, means the request limit is at 60 per hour.')
 

--- a/intelmq/bots/collectors/github_api/collector_github_contents_api.py
+++ b/intelmq/bots/collectors/github_api/collector_github_contents_api.py
@@ -24,21 +24,21 @@ class GithubContentsAPICollectorBot(GithubAPICollectorBot):
 
     def init(self):
         super().init()
-        if hasattr(self.parameters, 'repository'):
+        if hasattr(self, 'repository'):
             self.__base_api_url = 'https://api.github.com/repos/{}/contents'.format(
-                getattr(self.parameters, 'repository'))
-        if hasattr(self.parameters, 'regex'):
+                getattr(self, 'repository'))
+        if hasattr(self, 'regex'):
             try:
-                re.compile(getattr(self.parameters, 'regex'))
+                re.compile(getattr(self, 'regex'))
             except Exception:
-                raise InvalidArgument('regex', expected='string', got=getattr(self.parameters, 'regex'))
+                raise InvalidArgument('regex', expected='string', got=getattr(self, 'regex'))
         else:
             raise InvalidArgument('regex', expected='string', got=None)
-        if not hasattr(self.parameters, 'repository'):
+        if not hasattr(self, 'repository'):
             raise InvalidArgument('repository', expected='string')
-        if hasattr(self.parameters, 'extra_fields'):
+        if hasattr(self, 'extra_fields'):
             try:
-                self.__extra_fields = [x.strip() for x in getattr(self.parameters, 'extra_fields').split(',')]
+                self.__extra_fields = [x.strip() for x in getattr(self, 'extra_fields').split(',')]
             except Exception:
                 raise InvalidArgument('extra_fields', expected='comma-separated list')
         else:
@@ -63,7 +63,7 @@ class GithubContentsAPICollectorBot(GithubAPICollectorBot):
         for github_file in data:
             if github_file['type'] == 'dir':
                 extracted_github_files = self.__recurse_repository_files(github_file['url'], extracted_github_files)
-            elif github_file['type'] == 'file' and bool(re.search(getattr(self.parameters, 'regex', '.*.json'),
+            elif github_file['type'] == 'file' and bool(re.search(getattr(self, 'regex', '.*.json'),
                                                                   github_file['name'])):
                 extracted_github_file_data = {
                     'download_url': github_file['download_url'],

--- a/intelmq/bots/collectors/http/collector_http.py
+++ b/intelmq/bots/collectors/http/collector_http.py
@@ -52,6 +52,19 @@ class Time(object):
 
 
 class HTTPCollectorBot(CollectorBot):
+    """Fetch reports from an URL"""
+    extract_files: bool = False
+    gpg_keyring: str = None  # TODO: pathlib.Path
+    http_password: str = None
+    http_url: str = "<insert url of feed>"
+    http_url_formatting: bool = False
+    http_username: str = None
+    rate_limit: int = 3600
+    signature_url: str = None
+    signature_url_formatting: bool = False
+    ssl_client_certificate: str = None  # TODO: pathlib.Path
+    verify_pgp_signatures: bool = False
+
     def init(self):
         if requests is None:
             raise MissingDependencyError("requests")
@@ -60,14 +73,14 @@ class HTTPCollectorBot(CollectorBot):
 
         self.session = create_request_session(self)
 
-        self.use_gpg = getattr(self, "verify_pgp_signatures", False)
+        self.use_gpg = self.verify_pgp_signatures
         if self.use_gpg and gnupg is None:
             raise MissingDependencyError("gnupg")
         else:
             self.logger.info('PGP signature verification is active.')
 
     def process(self):
-        formatting = getattr(self, 'http_url_formatting', False)
+        formatting = self.http_url_formatting
         if formatting:
             http_url = self.format_url(self.http_url, formatting)
         else:
@@ -152,7 +165,7 @@ class HTTPCollectorBot(CollectorBot):
         Download signature file and verify the report data.
         """
         # get PGP parameters
-        formatting = getattr(self, 'signature_url_formatting', False)
+        formatting = self.signature_url_formatting
         if formatting:
             http_url = self.format_url(self.signature_url, formatting)
         else:
@@ -173,7 +186,7 @@ class HTTPCollectorBot(CollectorBot):
         sign.flush()
 
         # check signature
-        keyring = getattr(self, "gpg_keyring", None)
+        keyring = self.gpg_keyring
         gpg = gnupg.GPG(keyring=keyring)
         verified = gpg.verify_data(sign.name, data)
 

--- a/intelmq/bots/collectors/http/collector_http.py
+++ b/intelmq/bots/collectors/http/collector_http.py
@@ -60,18 +60,18 @@ class HTTPCollectorBot(CollectorBot):
 
         self.session = create_request_session(self)
 
-        self.use_gpg = getattr(self.parameters, "verify_pgp_signatures", False)
+        self.use_gpg = getattr(self, "verify_pgp_signatures", False)
         if self.use_gpg and gnupg is None:
             raise MissingDependencyError("gnupg")
         else:
             self.logger.info('PGP signature verification is active.')
 
     def process(self):
-        formatting = getattr(self.parameters, 'http_url_formatting', False)
+        formatting = getattr(self, 'http_url_formatting', False)
         if formatting:
-            http_url = self.format_url(self.parameters.http_url, formatting)
+            http_url = self.format_url(self.http_url, formatting)
         else:
-            http_url = self.parameters.http_url
+            http_url = self.http_url
 
         self.logger.info("Downloading report from %r.", http_url)
 
@@ -133,7 +133,7 @@ class HTTPCollectorBot(CollectorBot):
 
     def format_url(self, url: str, formatting) -> str:
         try:
-            return self.parameters.http_url.format(time=Time(formatting))
+            return self.http_url.format(time=Time(formatting))
         except TypeError:
             self.logger.error(
                 "Wrong formatting parameter: %s. Should be boolean or a time-delta JSON.",
@@ -143,7 +143,7 @@ class HTTPCollectorBot(CollectorBot):
         except KeyError:
             self.logger.error(
                 "Wrongly formatted url parameter: %s. Possible misspell with 'time' variable.",
-                self.parameters.http_url
+                self.http_url
             )
             raise
 
@@ -152,11 +152,11 @@ class HTTPCollectorBot(CollectorBot):
         Download signature file and verify the report data.
         """
         # get PGP parameters
-        formatting = getattr(self.parameters, 'signature_url_formatting', False)
+        formatting = getattr(self, 'signature_url_formatting', False)
         if formatting:
-            http_url = self.format_url(self.parameters.signature_url, formatting)
+            http_url = self.format_url(self.signature_url, formatting)
         else:
-            http_url = self.parameters.signature_url
+            http_url = self.signature_url
 
         # download signature file
         self.logger.info("Downloading PGP signature from {}.".format(http_url))
@@ -173,7 +173,7 @@ class HTTPCollectorBot(CollectorBot):
         sign.flush()
 
         # check signature
-        keyring = getattr(self.parameters, "gpg_keyring", None)
+        keyring = getattr(self, "gpg_keyring", None)
         gpg = gnupg.GPG(keyring=keyring)
         verified = gpg.verify_data(sign.name, data)
 

--- a/intelmq/bots/collectors/kafka/collector.py
+++ b/intelmq/bots/collectors/kafka/collector.py
@@ -18,22 +18,16 @@ except ImportError:
 
 
 class KafkaCollectorBot(CollectorBot):
+    """Fetch data from the Apache Kafka distributed stream processing system"""
+    bootstrap_servers: str = "localhost:9092"
+    topic = []
+    ssl_cafile = None
+    ssl_certfile = None
+    ssl_check_hostname = None
 
     def init(self):
         if kafka is None:
             raise MissingDependencyError("kafka")
-
-        self.topic = []
-        if getattr(self.parameters, 'topic', '') != '':
-            self.topic = self.parameters.topic
-
-        self.bootstrap_servers = 'localhost:9092'
-        if getattr(self.parameters, 'bootstrap_servers', '') != '':
-            self.bootstrap_servers = self.parameters.bootstrap_servers
-
-        self.ssl_cafile = getattr(self.parameters, 'ssl_ca_certificate', None)
-        self.ssl_certfile = getattr(self.parameters, 'ssl_client_certificate', None)
-        self.ssl_check_hostname = getattr(self.parameters, 'ssl_check_hostname', False)
 
         self.logger.debug("Topic set to {}, bootstrap_servers set to {}".format(self.topic, self.bootstrap_servers))
         self.logger.debug("ssl_cafile set to {}, ssl_certfile set to {}, ssl_check_hostname set to {}".format(self.ssl_cafile, self.ssl_certfile, self.ssl_check_hostname))

--- a/intelmq/bots/collectors/mail/collector_mail_attach.py
+++ b/intelmq/bots/collectors/mail/collector_mail_attach.py
@@ -14,7 +14,16 @@ from .lib import MailCollectorBot
 
 
 class MailAttachCollectorBot(MailCollectorBot):
-    attach_regex = None
+    """Monitor IMAP mailboxes and retrieve mail attachments"""
+    attach_regex: str = "csv.zip"
+    extract_files: bool = True
+    folder: str = "INBOX"
+    mail_host: str = "<host>"
+    mail_password: str = "<password>"
+    mail_ssl: bool = True
+    mail_user: str = "<user>"
+    rate_limit: int = 60
+    subject_regex: str = "<subject>"
 
     def init(self):
         super().init()

--- a/intelmq/bots/collectors/mail/collector_mail_attach.py
+++ b/intelmq/bots/collectors/mail/collector_mail_attach.py
@@ -14,10 +14,11 @@ from .lib import MailCollectorBot
 
 
 class MailAttachCollectorBot(MailCollectorBot):
+    attach_regex = None
 
     def init(self):
         super().init()
-        if not getattr(self.parameters, 'attach_regex', None):
+        if self.attach_regex is None:
             raise InvalidArgument('attach_regex', expected='string')
 
     def process_message(self, uid, message):
@@ -36,7 +37,7 @@ class MailAttachCollectorBot(MailCollectorBot):
             if attach_filename.startswith('"'):  # for imbox versions older than 0.9.5, see also above
                 attach_filename = attach_filename[1:-1]
 
-            if re.search(self.parameters.attach_regex, attach_filename):
+            if re.search(self.attach_regex, attach_filename):
 
                 self.logger.debug("Found suitable attachment %s.", attach_filename)
 

--- a/intelmq/bots/collectors/mail/collector_mail_body.py
+++ b/intelmq/bots/collectors/mail/collector_mail_body.py
@@ -6,11 +6,19 @@ from .lib import MailCollectorBot
 
 
 class MailBodyCollectorBot(MailCollectorBot):
+    "Monitor IMAP mailboxes and fetch mail bodies"
+    content_types = ['plain', 'html']
+    folder: str = "INBOX"
+    mail_host: str = "<host>"
+    mail_password: str = "<password>"
+    mail_ssl: bool = True
+    mail_user: str = "<user>"
+    rate_limit: int = 60
+    subject_regex: str = "<subject>"
 
     def init(self):
         super().init()
 
-        self.content_types = getattr(self.parameters, 'content_types', ('plain', 'html'))
         if isinstance(self.content_types, str):
             self.content_types = [x.strip() for x in self.content_types.split(',')]
         elif not self.content_types or self.content_types is True:  # empty string, null, false, true

--- a/intelmq/bots/collectors/mail/collector_mail_url.py
+++ b/intelmq/bots/collectors/mail/collector_mail_url.py
@@ -18,10 +18,22 @@ except ImportError:
 
 
 class MailURLCollectorBot(MailCollectorBot):
-    chunk_size = None
-    chunk_replicate_header = None
-    url_regex = None
+    """Monitor IMAP mailboxes and fetch files from URLs contained in mail bodies"""
     error_procedure = None
+
+    chunk_replicate_header: bool = True
+    chunk_size: int = None
+    folder: str = "INBOX"
+    http_password: str = None
+    http_username: str = None
+    mail_host: str = "<host>"
+    mail_password: str = "<password>"
+    mail_ssl: bool = True
+    mail_user: str = "<user>"
+    rate_limit: int = 60
+    ssl_client_certificate: str = None  # TODO pathlib.Path
+    subject_regex: str = "<subject>"
+    url_regex: str = "http://"
 
     def init(self):
         super().init()

--- a/intelmq/bots/collectors/mail/collector_mail_url.py
+++ b/intelmq/bots/collectors/mail/collector_mail_url.py
@@ -18,6 +18,10 @@ except ImportError:
 
 
 class MailURLCollectorBot(MailCollectorBot):
+    chunk_size = None
+    chunk_replicate_header = None
+    url_regex = None
+    error_procedure = None
 
     def init(self):
         super().init()
@@ -28,16 +32,12 @@ class MailURLCollectorBot(MailCollectorBot):
         self.set_request_parameters()
         self.session = create_request_session(self)
 
-        self.chunk_size = getattr(self.parameters, 'chunk_size', None)
-        self.chunk_replicate_header = getattr(self.parameters,
-                                              'chunk_replicate_header', None)
-
     def process_message(self, uid, message):
         erroneous = False  # If errors occurred this will be set to true.
         seen = False
 
         for body in message.body['plain']:
-            match = re.search(self.parameters.url_regex, str(body.decode('utf-8') if isinstance(body, bytes) else body))
+            match = re.search(self.url_regex, str(body.decode('utf-8') if isinstance(body, bytes) else body))
             if match:
                 url = match.group()
                 # strip leading and trailing spaces, newlines and
@@ -83,7 +83,7 @@ class MailURLCollectorBot(MailCollectorBot):
         if not erroneous:
             self.logger.info("Email report read.")
         else:
-            if self.parameters.error_procedure == 'pass':
+            if self.error_procedure == 'pass':
                 seen = True
             else:
                 self.logger.error("Email report read with above errors, the report was not processed.")

--- a/intelmq/bots/collectors/microsoft/collector_interflow.py
+++ b/intelmq/bots/collectors/microsoft/collector_interflow.py
@@ -60,7 +60,7 @@ class MicrosoftInterflowCollectorBot(CollectorBot):
         """
         if isinstance(self.time_match, datetime):  # absolute
             now = datetime.now(tz=pytz.timezone('UTC'))
-            if now - timedelta(seconds=self.parameters.redis_cache_ttl) > self.time_match:
+            if now - timedelta(seconds=self.redis_cache_ttl) > self.time_match:
                 raise ValueError("The cache's TTL must be higher than 'not_older_than', "
                                  "otherwise the bot is processing the same data over and over again.")
 
@@ -70,33 +70,33 @@ class MicrosoftInterflowCollectorBot(CollectorBot):
 
         self.set_request_parameters()
 
-        self.http_header['Ocp-Apim-Subscription-Key'] = self.parameters.api_key
-        if self.parameters.file_match:
-            self.file_match = re.compile(self.parameters.file_match)
+        self.http_header['Ocp-Apim-Subscription-Key'] = self.api_key
+        if self.file_match:
+            self.file_match = re.compile(self.file_match)
         else:
             self.file_match = None
 
-        if self.parameters.not_older_than:
+        if self.not_older_than:
             try:
-                self.time_match = timedelta(minutes=parse_relative(self.parameters.not_older_than))
+                self.time_match = timedelta(minutes=parse_relative(self.not_older_than))
             except ValueError:
-                self.time_match = parser.parse(self.parameters.not_older_than).astimezone(pytz.utc)
+                self.time_match = parser.parse(self.not_older_than).astimezone(pytz.utc)
                 self.logger.info("Filtering files absolute %r.", self.time_match)
                 self.check_ttl_time()
             else:
                 self.logger.info("Filtering files relative %r.", self.time_match)
-                if timedelta(seconds=self.parameters.redis_cache_ttl) < self.time_match:
+                if timedelta(seconds=self.redis_cache_ttl) < self.time_match:
                     raise ValueError("The cache's TTL must be higher than 'not_older_than', "
                                      "otherwise the bot is processing the same data over and over again.")
         else:
             self.time_match = None
         self.session = create_request_session(self)
 
-        self.cache = Cache(self.parameters.redis_cache_host,
-                           self.parameters.redis_cache_port,
-                           self.parameters.redis_cache_db,
-                           self.parameters.redis_cache_ttl,
-                           getattr(self.parameters, "redis_cache_password",
+        self.cache = Cache(self.redis_cache_host,
+                           self.redis_cache_port,
+                           self.redis_cache_db,
+                           self.redis_cache_ttl,
+                           getattr(self, "redis_cache_password",
                                    None)
                            )
 

--- a/intelmq/bots/collectors/microsoft/collector_interflow.py
+++ b/intelmq/bots/collectors/microsoft/collector_interflow.py
@@ -51,6 +51,17 @@ URL_DOWNLOAD = 'https://interflow.azure-api.net/file/api/file/download?fileName=
 
 
 class MicrosoftInterflowCollectorBot(CollectorBot):
+    "Fetch data from the Microsoft Interflow API"
+    api_key: str = ""
+    file_match = None  # TODO type
+    http_timeout_sec: int = 300
+    not_older_than: str = "2 days"
+    rate_limit: int = 3600
+    redis_cache_db: str = "5"  # TODO type: int?
+    redis_cache_host: str = "127.0.0.1"  # TODO type ipadress
+    redis_cache_password: str = None
+    redis_cache_port: int = 6379
+    redis_cache_ttl: int = 604800
 
     def check_ttl_time(self):
         """
@@ -96,8 +107,7 @@ class MicrosoftInterflowCollectorBot(CollectorBot):
                            self.redis_cache_port,
                            self.redis_cache_db,
                            self.redis_cache_ttl,
-                           getattr(self, "redis_cache_password",
-                                   None)
+                           self.redis_cache_password
                            )
 
     def process(self):

--- a/intelmq/bots/collectors/opendxl/collector.py
+++ b/intelmq/bots/collectors/opendxl/collector.py
@@ -22,6 +22,9 @@ except ImportError:
 
 
 class openDXLCollectorBot(CollectorBot):
+    "Listen to  McAfee openDXL fabric"
+    dxl_config_file: str = None  # TODO: use pathlib.Path
+    dxl_topic: str = "/mcafee/event/atd/file/report"
 
     def init(self):
         if DxlClient is None:
@@ -31,7 +34,7 @@ class openDXLCollectorBot(CollectorBot):
     def process(self):
 
         if self.dxlclient is None:
-            self.dxlclient = openDXLListener(self.parameters.dxl_config_file, self.parameters.dxl_topic,
+            self.dxlclient = openDXLListener(self.dxl_config_file, self.dxl_topic,
                                              self.new_report, self.send_message, self.logger)
         self.logger.info('Starting DXL Client.')
         self.dxlclient.start()  # blocks

--- a/intelmq/bots/collectors/rsync/collector_rsync.py
+++ b/intelmq/bots/collectors/rsync/collector_rsync.py
@@ -8,7 +8,7 @@ from intelmq.lib.bot import CollectorBot
 
 class RsyncCollectorBot(CollectorBot):
     def init(self):
-        self.rsync_data_directory = getattr(self.parameters, 'temp_directory',
+        self.rsync_data_directory = getattr(self, 'temp_directory',
                                             path.join(VAR_STATE_PATH, "rsync_collector"))
         try:
             mkdir(self.rsync_data_directory)
@@ -16,17 +16,17 @@ class RsyncCollectorBot(CollectorBot):
             pass
 
     def process(self):
-        self.logger.info("Updating file {}.".format(self.parameters.file))
-        process = run(["rsync", path.join(self.parameters.rsync_path, self.parameters.file),
+        self.logger.info("Updating file {}.".format(self.file))
+        process = run(["rsync", path.join(self.rsync_path, self.file),
                        self.rsync_data_directory],
                       stderr=PIPE)
         if process.returncode != 0:
             raise ValueError("Rsync on file {!r} failed with exitcode {} and stderr {!r}."
-                             "".format(self.parameters.file,
+                             "".format(self.file,
                                        process.returncode,
                                        process.stderr))
         report = self.new_report()
-        with open(path.join(self.rsync_data_directory, self.parameters.file), "r") as rsync_file:
+        with open(path.join(self.rsync_data_directory, self.file), "r") as rsync_file:
             report.add("raw", rsync_file.read())
             self.send_message(report)
 

--- a/intelmq/bots/collectors/rsync/collector_rsync.py
+++ b/intelmq/bots/collectors/rsync/collector_rsync.py
@@ -7,9 +7,14 @@ from intelmq.lib.bot import CollectorBot
 
 
 class RsyncCollectorBot(CollectorBot):
+    "Collect data with rsync from any resource rsync supports"
+    file: str = "<file>"
+    rate_limit: int = 1000
+    rsync_path: str = "<path>"
+    temp_directory: str = path.join(VAR_STATE_PATH, "rsync_collector")  # TODO: should be pathlib.Path
+
     def init(self):
-        self.rsync_data_directory = getattr(self, 'temp_directory',
-                                            path.join(VAR_STATE_PATH, "rsync_collector"))
+        self.rsync_data_directory = self.temp_directory
         try:
             mkdir(self.rsync_data_directory)
         except FileExistsError:

--- a/intelmq/bots/collectors/shadowserver/collector_reports_api.py
+++ b/intelmq/bots/collectors/shadowserver/collector_reports_api.py
@@ -37,18 +37,23 @@ class ShadowServerAPICollectorBot(CollectorBot):
         A list of strings or a string of comma-separated values with the names of reporttypes you want to process. If you leave this empty, all the available reports will be downloaded and processed (i.e. 'scan', 'drones', 'intel', 'sandbox_connection', 'sinkhole_combined').
     """
 
+    apikey = None
+    secret = None
+    country = None
+    types = None
+
     def init(self):
-        self.apikey = getattr(self.parameters, "api_key", None)
+        self.apikey = getattr(self, "api_key", None)
         if self.apikey is None:
             raise ValueError('No api_key provided.')
-        self.secret = getattr(self.parameters, "secret", None)
+        self.secret = getattr(self, "secret", None)
         if self.secret is None:
             raise ValueError('No secret provided.')
-        self.country = getattr(self.parameters, "country", None)
+        self.country = getattr(self, "country", None)
         if self.country is None:
             raise ValueError('No country provided.')
 
-        self.types = getattr(self.parameters, 'types', None)
+        self.types = getattr(self, 'types', None)
         if isinstance(self.types, str):
             self.types = self.types.split(',')
 
@@ -57,11 +62,11 @@ class ShadowServerAPICollectorBot(CollectorBot):
         self.set_request_parameters()
         self.session = create_request_session(self)
 
-        self.cache = Cache(self.parameters.redis_cache_host,
-                           self.parameters.redis_cache_port,
-                           self.parameters.redis_cache_db,
-                           getattr(self.parameters, 'redis_cache_ttl', 864000),  # 10 days
-                           getattr(self.parameters, "redis_cache_password", None)
+        self.cache = Cache(self.redis_cache_host,
+                           self.redis_cache_port,
+                           self.redis_cache_db,
+                           getattr(self, 'redis_cache_ttl', 864000),  # 10 days
+                           getattr(self, "redis_cache_password", None)
                            )
 
     def _headers(self, data):

--- a/intelmq/bots/collectors/shadowserver/collector_reports_api.py
+++ b/intelmq/bots/collectors/shadowserver/collector_reports_api.py
@@ -23,7 +23,7 @@ APIROOT = 'https://transform.shadowserver.org/api2/'
 
 class ShadowServerAPICollectorBot(CollectorBot):
     """
-    Shadowserver Reports API Collector Bot
+    Connects to the Shadowserver API, requests a list of all the reports for a specific country and processes the ones that are new
 
     Parameters
     ----------
@@ -37,27 +37,28 @@ class ShadowServerAPICollectorBot(CollectorBot):
         A list of strings or a string of comma-separated values with the names of reporttypes you want to process. If you leave this empty, all the available reports will be downloaded and processed (i.e. 'scan', 'drones', 'intel', 'sandbox_connection', 'sinkhole_combined').
     """
 
-    apikey = None
-    secret = None
     country = None
+    api_key = None
+    secret = None
     types = None
+    rate_limit: int = 86400
+    redis_cache_db: int = 12
+    redis_cache_host: str = "127.0.0.1"  # TODO: type could be ipadress
+    redis_cache_port: int = 6379
+    redis_cache_ttl: int = 864000  # 10 days
 
     def init(self):
-        self.apikey = getattr(self, "api_key", None)
-        if self.apikey is None:
+        if self.api_key is None:
             raise ValueError('No api_key provided.')
-        self.secret = getattr(self, "secret", None)
         if self.secret is None:
             raise ValueError('No secret provided.')
-        self.country = getattr(self, "country", None)
         if self.country is None:
             raise ValueError('No country provided.')
 
-        self.types = getattr(self, 'types', None)
         if isinstance(self.types, str):
             self.types = self.types.split(',')
 
-        self.preamble = '{{ "apikey": "{}" '.format(self.apikey)
+        self.preamble = '{{ "apikey": "{}" '.format(self.api_key)
 
         self.set_request_parameters()
         self.session = create_request_session(self)
@@ -65,8 +66,8 @@ class ShadowServerAPICollectorBot(CollectorBot):
         self.cache = Cache(self.redis_cache_host,
                            self.redis_cache_port,
                            self.redis_cache_db,
-                           getattr(self, 'redis_cache_ttl', 864000),  # 10 days
-                           getattr(self, "redis_cache_password", None)
+                           self.redis_cache_ttl,
+                           self.redis_cache_password
                            )
 
     def _headers(self, data):

--- a/intelmq/bots/collectors/shodan/collector_stream.py
+++ b/intelmq/bots/collectors/shodan/collector_stream.py
@@ -12,6 +12,8 @@ from http.client import IncompleteRead
 from urllib3.exceptions import ProtocolError, ReadTimeoutError
 
 from requests.exceptions import ChunkedEncodingError, ConnectionError
+from typing import List
+
 from intelmq.lib.bot import CollectorBot
 
 try:
@@ -22,6 +24,10 @@ except ImportError:
 
 
 class ShodanStreamCollectorBot(CollectorBot):
+    "Collect the Shodan stream from the Shodan API"
+    api_key: str = "<INSERT your API key>"
+    countries: List[str] = []
+
     def init(self):
         if shodan is None:
             raise ValueError("Library 'shodan' is needed but not installed.")
@@ -31,12 +37,12 @@ class ShodanStreamCollectorBot(CollectorBot):
             if self.proxy:
                 raise ValueError('Proxies are given but shodan-python > 1.8.1 is needed for proxy support.')
             else:
-                self.api = shodan.Shodan(self.parameters.api_key)
+                self.api = shodan.Shodan(self.api_key)
         else:
-            self.api = shodan.Shodan(self.parameters.api_key,
+            self.api = shodan.Shodan(self.api_key,
                                      proxies=self.proxy)
-        if isinstance(self.parameters.countries, str):
-            self.countries = self.parameters.countries.split(',')
+        if isinstance(self.countries, str):
+            self.countries = self.countries.split(',')
 
         self.__error_count = 0
 

--- a/intelmq/bots/collectors/stomp/collector.py
+++ b/intelmq/bots/collectors/stomp/collector.py
@@ -35,9 +35,9 @@ else:
             report = self.stompbot.new_report()
             report.add("raw", message.rstrip())
             report.add("feed.url", "stomp://" +
-                       self.stompbot.parameters.server +
-                       ":" + str(self.stompbot.parameters.port) +
-                       "/" + self.stompbot.parameters.exchange)
+                       self.stompbot.server +
+                       ":" + str(self.stompbot.port) +
+                       "/" + self.stompbot.exchange)
             self.stompbot.send_message(report)
 
         def on_disconnected(self):
@@ -55,7 +55,16 @@ def connect_and_subscribe(conn, logger, destination, start=False):
 
 
 class StompCollectorBot(CollectorBot):
+    """Collect data from a STOMP Interface"""
     """ main class for the STOMP protocol collector """
+    exchange: str = ''
+    port: int = 61614
+    server: str = "n6stream.cert.pl"
+    http_verify_cert: bool = True
+    ssl_ca_certificate: str = 'ca.pem'  # TODO pathlib.Path
+    ssl_client_certificate: str = 'client.pem'  # TODO pathlib.Path
+    ssl_client_certificate_key: str = 'client.key'  # TODO pathlib.Path
+    heartbeat: int = 6000
 
     collector_empty_process = True
     conn = False  # define here so shutdown method can check for it
@@ -67,19 +76,9 @@ class StompCollectorBot(CollectorBot):
             raise MissingDependencyError("stomp", version="4.1.8",
                                          installed=stomp.__version__)
 
-        self.server = getattr(self.parameters, 'server', 'n6stream.cert.pl')
-        self.port = getattr(self.parameters, 'port', 61614)
-        self.exchange = getattr(self.parameters, 'exchange', '')
-        self.heartbeat = getattr(self.parameters, 'heartbeat', 60000)
-        self.ssl_ca_cert = getattr(self.parameters, 'ssl_ca_certificate',
-                                   'ca.pem')
-        self.ssl_cl_cert = getattr(self.parameters, 'ssl_client_certificate',
-                                   'client.pem')
-        self.ssl_cl_cert_key = getattr(self.parameters,
-                                       'ssl_client_certificate_key',
-                                       'client.key')
-        self.http_verify_cert = getattr(self.parameters,
-                                        'http_verify_cert', True)
+        self.ssl_ca_cert = self.ssl_ca_certificate
+        self.ssl_cl_cert = self.ssl_client_certificate
+        self.ssl_cl_cert_key = self.ssl_client_certificate_key
 
         # check if certificates exist
         for f in [self.ssl_ca_cert, self.ssl_cl_cert, self.ssl_cl_cert_key]:

--- a/intelmq/bots/collectors/tcp/collector.py
+++ b/intelmq/bots/collectors/tcp/collector.py
@@ -7,6 +7,9 @@ from intelmq.lib.bot import CollectorBot
 
 
 class TCPCollectorBot(CollectorBot):
+    """Receive events by opening a TCP port (ex: from TCP Output of another IntelMQ instance)"""
+    ip: str = "<ip>"
+    port: int = "<port>"
 
     def init(self):
         self.address = (self.ip, int(self.port))

--- a/intelmq/bots/collectors/tcp/collector.py
+++ b/intelmq/bots/collectors/tcp/collector.py
@@ -9,7 +9,7 @@ from intelmq.lib.bot import CollectorBot
 class TCPCollectorBot(CollectorBot):
 
     def init(self):
-        self.address = (self.parameters.ip, int(self.parameters.port))
+        self.address = (self.ip, int(self.port))
         self.connect()
 
     def recvall(self, conn, n):

--- a/intelmq/bots/collectors/xmpp/collector.py
+++ b/intelmq/bots/collectors/xmpp/collector.py
@@ -27,6 +27,7 @@ xmpp_userlist: array
 xmpp_whitelist_mode: boolean
 """
 
+from typing import List
 
 from intelmq.lib.bot import CollectorBot
 from intelmq.lib.exceptions import MissingDependencyError
@@ -78,6 +79,19 @@ except ImportError:
 
 
 class XMPPCollectorBot(CollectorBot):
+    "Connect to an XMPP Server and a room, in order to receive reports from it. TLS is used by default. Bot can either pass on the body or the whole event"
+    ca_certs: str = "/etc/ssl/certs/ca-certificates.crt"  # TODO should be pathlib.Path
+    pass_full_xml: str = None
+    strip_message: bool = True
+    use_muc: bool = False
+    xmpp_password: str = "<xmpp password>"
+    xmpp_room: str = None
+    xmpp_room_nick: str = None
+    xmpp_room_password: str = None
+    xmpp_server: str = "<xmpp server>"
+    xmpp_user: str = "<xmpp username>"
+    xmpp_userlist: List[str] = []
+    xmpp_whitelist_mode: bool = False
 
     xmpp = None
     collector_empty_process = True
@@ -90,34 +104,24 @@ class XMPPCollectorBot(CollectorBot):
         if sleekxmpp is None:
             raise MissingDependencyError("sleekxmpp")
 
-        # Retrieve Parameters from configuration
-        xmpp_user = getattr(self.parameters, "xmpp_user", None)
-        xmpp_server = getattr(self.parameters, "xmpp_server", None)
-        xmpp_password = getattr(self.parameters, "xmpp_password", None)
-
         if None in (xmpp_user, xmpp_server, xmpp_password):
             raise ValueError('No User / Password provided.')
         else:
             xmpp_login = xmpp_user + '@' + xmpp_server
 
-        self.userlist = getattr(self.parameters, "xmpp_userlist", [])
+        self.userlist = self.xmpp_userlist
         # When configured in manager this is most likely a ,-separated string, we'd like an array
         if type(self.userlist) is str:
             self.userlist = [u.strip() for u in self.userlist.split(",")]
         elif self.userlist is None:  # if value is unset, set to empty list
             self.userlist = []
 
-        self.whitelist_mode = getattr(self.parameters, "xmpp_whitelist_mode", False)
+        self.whitelist_mode = self.xmpp_whitelist_mode
 
-        self.muc = getattr(self.parameters, "use_muc", None)
-        xmpp_room = getattr(self.parameters, "xmpp_room", None) if self.muc else None
-        xmpp_room_nick = getattr(self.parameters, "xmpp_room_nick", None) if self.muc else None
-        xmpp_room_password = getattr(self.parameters, "xmpp_room_password", None) if self.muc else None
-
-        self.pass_full_xml = getattr(self.parameters, "pass_full_xml", None)
-        self.strip_message = getattr(self.parameters, "strip_message", None)
-
-        ca_certs = getattr(self.parameters, "ca_certs", None)
+        self.muc = self.use_muc
+        xmpp_room = self.xmpp_room if self.muc else None
+        xmpp_room_nick = self.xmpp_room_nick if self.muc else None
+        xmpp_room_password = self.xmpp_room_password if self.muc else None
 
         if self.muc and not xmpp_room:
             raise ValueError('No room provided.')

--- a/intelmq/bots/experts/abusix/expert.py
+++ b/intelmq/bots/experts/abusix/expert.py
@@ -28,7 +28,7 @@ class AbusixExpertBot(Bot):
         for key in ['source.', 'destination.']:
             ip_key = key + "ip"
             abuse_contact_key = key + "abuse_contact"
-            if abuse_contact_key in event and not self.parameters.overwrite:
+            if abuse_contact_key in event and not self.overwrite:
                 continue
             if ip_key in event:
                 ip = event.get(ip_key)

--- a/intelmq/bots/experts/abusix/expert.py
+++ b/intelmq/bots/experts/abusix/expert.py
@@ -14,6 +14,7 @@ except ImportError:
 
 
 class AbusixExpertBot(Bot):
+    """Add abuse contact information from the Abusix online service for source and destination IP address"""
 
     def init(self):
         if querycontacts:

--- a/intelmq/bots/experts/asn_lookup/expert.py
+++ b/intelmq/bots/experts/asn_lookup/expert.py
@@ -21,7 +21,8 @@ except ImportError:
 
 
 class ASNLookupExpertBot(Bot):
-    database = None
+    """Add ASN and netmask information from a local BGP dump"""
+    database = None  # TODO: should be pathlib.Path
 
     def init(self):
         if pyasn is None:

--- a/intelmq/bots/experts/asn_lookup/expert.py
+++ b/intelmq/bots/experts/asn_lookup/expert.py
@@ -21,16 +21,17 @@ except ImportError:
 
 
 class ASNLookupExpertBot(Bot):
+    database = None
 
     def init(self):
         if pyasn is None:
             raise MissingDependencyError("pyasn")
 
         try:
-            self.database = pyasn.pyasn(self.parameters.database)
+            self._database = pyasn.pyasn(self.database)
         except IOError:
             self.logger.error("pyasn data file does not exist or could not be "
-                              "accessed in %r.", self.parameters.database)
+                              "accessed in %r.", self.database)
             self.logger.error("Read 'bots/experts/asn_lookup/README' and "
                               "follow the procedure.")
             self.stop()
@@ -47,7 +48,7 @@ class ASNLookupExpertBot(Bot):
             if ip_key not in event:
                 continue
 
-            info = self.database.lookup(event.get(ip_key))
+            info = self._database.lookup(event.get(ip_key))
 
             if info:
                 if info[0]:

--- a/intelmq/bots/experts/csv_converter/expert.py
+++ b/intelmq/bots/experts/csv_converter/expert.py
@@ -5,8 +5,9 @@ from intelmq.lib.bot import Bot
 
 
 class CSVConverterExpertBot(Bot):
-    fieldnames = None
-    delimiter = ','
+    """Convert data to CSV"""
+    fieldnames: str = "time.source,classification.type,source.ip"  # TODO: could maybe be List[str]
+    delimiter: str = ','
 
     def init(self):
         self.fieldnames = self.fieldnames.split(',')

--- a/intelmq/bots/experts/csv_converter/expert.py
+++ b/intelmq/bots/experts/csv_converter/expert.py
@@ -5,10 +5,11 @@ from intelmq.lib.bot import Bot
 
 
 class CSVConverterExpertBot(Bot):
+    fieldnames = None
+    delimiter = ','
 
     def init(self):
-        self.fieldnames = self.parameters.fieldnames.split(',')
-        self.delimiter = getattr(self.parameters, 'delimiter', ',')
+        self.fieldnames = self.fieldnames.split(',')
 
     def process(self):
         event = self.receive_message()

--- a/intelmq/bots/experts/cymru_whois/expert.py
+++ b/intelmq/bots/experts/cymru_whois/expert.py
@@ -10,21 +10,16 @@ CACHE_KEY = "%d_%s"
 
 
 class CymruExpertBot(Bot):
+    overwrite = False
 
     def init(self):
-        self.cache = Cache(self.parameters.redis_cache_host,
-                           self.parameters.redis_cache_port,
-                           self.parameters.redis_cache_db,
-                           self.parameters.redis_cache_ttl,
-                           getattr(self.parameters, "redis_cache_password",
+        self.cache = Cache(self.redis_cache_host,
+                           self.redis_cache_port,
+                           self.redis_cache_db,
+                           self.redis_cache_ttl,
+                           getattr(self, "redis_cache_password",
                                    None)
                            )
-
-        if not hasattr(self.parameters, 'overwrite'):
-            self.logger.warning("Parameter 'overwrite' is not given, assuming 'True'. "
-                                "Please set it explicitly, default will change to "
-                                "'False' in version 3.0.0'.")
-        self.overwrite = getattr(self.parameters, 'overwrite', True)
 
     def process(self):
         event = self.receive_message()

--- a/intelmq/bots/experts/cymru_whois/expert.py
+++ b/intelmq/bots/experts/cymru_whois/expert.py
@@ -10,15 +10,20 @@ CACHE_KEY = "%d_%s"
 
 
 class CymruExpertBot(Bot):
+    """Add ASN, netmask, AS name, country, registry and allocation time from the Cymru Whois DNS service"""
     overwrite = False
+    redis_cache_db: int = 5
+    redis_cache_host: str = "127.0.0.1"  # TODO: could be ipaddress
+    redis_cache_password: str = None
+    redis_cache_port: int = 6379
+    redis_cache_ttl: int = 86400
 
     def init(self):
         self.cache = Cache(self.redis_cache_host,
                            self.redis_cache_port,
                            self.redis_cache_db,
                            self.redis_cache_ttl,
-                           getattr(self, "redis_cache_password",
-                                   None)
+                           self.redis_cache_password
                            )
 
     def process(self):

--- a/intelmq/bots/experts/deduplicator/expert.py
+++ b/intelmq/bots/experts/deduplicator/expert.py
@@ -27,6 +27,14 @@ from intelmq.lib.cache import Cache
 
 
 class DeduplicatorExpertBot(Bot):
+    """Detection and drop exact duplicate messages. Message hashes are cached in the Redis database"""
+    filter_keys: str = "raw,time.observation"  # TODO: could be List[str]
+    filter_type: str = "blacklist"
+    redis_cache_db: int = 6
+    redis_cache_host: str = "127.0.0.1"  # TODO: could be ipaddress
+    redis_cache_password: str = None
+    redis_cache_port: int = 6379
+    redis_cache_ttl: int = 86400
 
     _message_processed_verb = 'Forwarded'
     bypass = False
@@ -37,8 +45,7 @@ class DeduplicatorExpertBot(Bot):
                            self.redis_cache_port,
                            self.redis_cache_db,
                            self.redis_cache_ttl,
-                           getattr(self, "redis_cache_password",
-                                   None)
+                           self.redis_cache_password
                            )
         self.filter_keys = {k.strip() for k in
                             self.filter_keys.split(',')}

--- a/intelmq/bots/experts/deduplicator/expert.py
+++ b/intelmq/bots/experts/deduplicator/expert.py
@@ -29,18 +29,19 @@ from intelmq.lib.cache import Cache
 class DeduplicatorExpertBot(Bot):
 
     _message_processed_verb = 'Forwarded'
+    bypass = False
+    filter_keys = None
 
     def init(self):
-        self.cache = Cache(self.parameters.redis_cache_host,
-                           self.parameters.redis_cache_port,
-                           self.parameters.redis_cache_db,
-                           self.parameters.redis_cache_ttl,
-                           getattr(self.parameters, "redis_cache_password",
+        self.cache = Cache(self.redis_cache_host,
+                           self.redis_cache_port,
+                           self.redis_cache_db,
+                           self.redis_cache_ttl,
+                           getattr(self, "redis_cache_password",
                                    None)
                            )
         self.filter_keys = {k.strip() for k in
-                            self.parameters.filter_keys.split(',')}
-        self.bypass = getattr(self.parameters, "bypass", False)
+                            self.filter_keys.split(',')}
 
     def process(self):
         message = self.receive_message()
@@ -49,7 +50,7 @@ class DeduplicatorExpertBot(Bot):
             self.send_message(message)
         else:
             message_hash = message.hash(filter_keys=self.filter_keys,
-                                        filter_type=self.parameters.filter_type)
+                                        filter_type=self.filter_type)
 
             if not self.cache.exists(message_hash):
                 self.cache.set(message_hash, 'hash')

--- a/intelmq/bots/experts/do_portal/expert.py
+++ b/intelmq/bots/experts/do_portal/expert.py
@@ -14,19 +14,23 @@ from intelmq.lib.bot import Bot
 
 
 class DoPortalExpertBot(Bot):
+    """Retrieve abuse contact information for the source IP address from a do-portal instance"""
+    mode: str = "append"
+    portal_api_key: str = None
+    portal_url: str = None
+
     def init(self):
         if requests is None:
             raise ValueError("Library 'requests' could not be loaded. Please install it.")
 
         self.set_request_parameters()
 
-        self.url = self.parameters.portal_url + '/api/1.0/ripe/contact?cidr=%s'
+        self.url = self.portal_url + '/api/1.0/ripe/contact?cidr=%s'
         self.http_header.update({
             "Content-Type": "application/json",
             "Accept": "application/json",
-            "API-Authorization": self.parameters.portal_api_key
+            "API-Authorization": self.portal_api_key
         })
-        self.mode = self.parameters.mode
 
         self.session = utils.create_request_session(self)
         retries = requests.urllib3.Retry.from_int(self.http_timeout_max_tries)

--- a/intelmq/bots/experts/domain_suffix/expert.py
+++ b/intelmq/bots/experts/domain_suffix/expert.py
@@ -27,12 +27,13 @@ ALLOWED_FIELDS = ['fqdn', 'reverse_dns']
 
 class DomainSuffixExpertBot(Bot):
     suffixes = {}
+    field = None
+    suffix_file = None
 
     def init(self):
-        self.field = self.parameters.field
         if self.field not in ALLOWED_FIELDS:
             raise InvalidArgument('key', got=self.field, expected=ALLOWED_FIELDS)
-        with codecs.open(self.parameters.suffix_file, encoding='UTF-8') as file_handle:
+        with codecs.open(self.suffix_file, encoding='UTF-8') as file_handle:
             self.psl = PublicSuffixList(source=file_handle, only_icann=True)
 
     def process(self):

--- a/intelmq/bots/experts/domain_suffix/expert.py
+++ b/intelmq/bots/experts/domain_suffix/expert.py
@@ -26,9 +26,10 @@ ALLOWED_FIELDS = ['fqdn', 'reverse_dns']
 
 
 class DomainSuffixExpertBot(Bot):
+    """Extract the domain suffix from a domain and save it in the the domain_suffix field. Requires a local file with valid domain suffixes"""
     suffixes = {}
-    field = None
-    suffix_file = None
+    field: str = None
+    suffix_file: str = None  # TODO: should be pathlib.Path
 
     def init(self):
         if self.field not in ALLOWED_FIELDS:

--- a/intelmq/bots/experts/field_reducer/expert.py
+++ b/intelmq/bots/experts/field_reducer/expert.py
@@ -8,6 +8,7 @@ from intelmq.lib.message import Event
 
 
 class FieldReducerExpertBot(Bot):
+    """Remove fields from events"""
     type = None
     keys = None
 

--- a/intelmq/bots/experts/field_reducer/expert.py
+++ b/intelmq/bots/experts/field_reducer/expert.py
@@ -8,11 +8,10 @@ from intelmq.lib.message import Event
 
 
 class FieldReducerExpertBot(Bot):
+    type = None
+    keys = None
 
     def init(self):
-        self.type = self.parameters.type
-        self.keys = self.parameters.keys
-
         if self.type not in ['whitelist', 'blacklist']:
             raise ValueError("Invalid configuration: value of 'type' not allowed.")
         if isinstance(self.keys, str):

--- a/intelmq/bots/experts/filter/expert.py
+++ b/intelmq/bots/experts/filter/expert.py
@@ -11,10 +11,15 @@ from intelmq.lib.utils import parse_relative, TIMESPANS
 
 
 class FilterExpertBot(Bot):
+    """Filter events, supports named paths for splitting the message flow"""
 
     _message_processed_verb = 'Forwarded'
     not_after = None
     not_before = None
+    filter_action: str = None
+    filter_key: str = None
+    filter_regex: str = None  # TODO: could be re
+    filter_value: str = None
 
     def parse_timeattr(self, time_attr):
         """
@@ -40,23 +45,23 @@ class FilterExpertBot(Bot):
             self.not_before = self.parse_timeattr(self.not_before)
 
         self.filter = True
-        if not (hasattr(self, 'filter_key')):
+        if self.filter_key is None:
             self.logger.info("No filter_key parameter found.")
             self.filter = False
-        elif not (hasattr(self, 'filter_value')):
+        elif self.filter_value is None:
             self.logger.info("No filter_value parameter found.")
             self.filter = False
-        elif not (hasattr(self, 'filter_action')):
+        elif self.filter_action is None:
             self.logger.info("No filter_action parameter found.")
             self.filter = False
-        elif hasattr(self, 'filter_action') and not \
+        elif self.filter_action is not None and not \
             (self.filter_action == "drop" or
              self.filter_action == "keep"):
             self.logger.info("Filter_action parameter definition unknown.")
             self.filter = False
 
         self.regex = False
-        if hasattr(self, 'filter_regex') and self.filter_regex:
+        if self.filter_regex is not None:
             self.regex = re.compile(self.filter_value)
 
         self.time_filter = self.not_after is not None or self.not_before is not None

--- a/intelmq/bots/experts/format_field/expert.py
+++ b/intelmq/bots/experts/format_field/expert.py
@@ -3,18 +3,18 @@ from intelmq.lib.bot import Bot
 
 
 class FormatFieldExpertBot(Bot):
+    strip_columns = None
+    strip_chars     = ' '
+    split_column    = None
+    split_separator = ','
+    replace_column  = None
+    old_value       = None
+    new_value       = None
+    replace_count   = 1
 
     def init(self):
-        self.strip_columns   = getattr(self.parameters, 'strip_columns', None)
         if type(self.strip_columns) is str:
             self.strip_columns = [column.strip() for column in self.strip_columns.split(",")]
-        self.strip_chars     = getattr(self.parameters, 'strip_chars', ' ')
-        self.split_column    = getattr(self.parameters, 'split_column', None)
-        self.split_separator = getattr(self.parameters, 'split_separator', ',')
-        self.replace_column  = getattr(self.parameters, 'replace_column', None)
-        self.old_value       = getattr(self.parameters, 'old_value', None)
-        self.new_value       = getattr(self.parameters, 'new_value', None)
-        self.replace_count   = getattr(self.parameters, 'replace_count', 1)
 
     def process(self):
         event = self.receive_message()

--- a/intelmq/bots/experts/format_field/expert.py
+++ b/intelmq/bots/experts/format_field/expert.py
@@ -3,14 +3,15 @@ from intelmq.lib.bot import Bot
 
 
 class FormatFieldExpertBot(Bot):
-    strip_columns = None
+    """Perform string method operations on column values"""
+    new_value       = ""
+    old_value       = ""
+    replace_column  = ""
+    replace_count   = 1
+    strip_columns   = ""
+    split_separator = ','
     strip_chars     = ' '
     split_column    = None
-    split_separator = ','
-    replace_column  = None
-    old_value       = None
-    new_value       = None
-    replace_count   = 1
 
     def init(self):
         if type(self.strip_columns) is str:

--- a/intelmq/bots/experts/generic_db_lookup/expert.py
+++ b/intelmq/bots/experts/generic_db_lookup/expert.py
@@ -7,22 +7,29 @@ from intelmq.lib.bot import SQLBot
 
 
 class GenericDBLookupExpertBot(SQLBot):
+    _replace = None
+    replace_fields = {'contact': 'source.abuse_contact', 'note': 'comment'}
+    _match = None
+    match_fields = {'source.asn': 'asn'}
+    table = None
+    overwrite = None
+    engine = None
 
     def init(self):
         super().init()
 
-        self.replace = self.parameters.replace_fields
-        self.match = self.parameters.match_fields
-        query = 'SELECT "{replace}" FROM "{table}" WHERE ' + 'AND '.join(['"{}" = ' + self.format_char + ' '] * len(self.match))
-        self.query = query.format(*self.match.values(),
-                                  table=self.parameters.table,
-                                  replace='", "'.join(self.replace.keys()))
+        self._replace = self.replace_fields
+        self._match = self.match_fields
+        query = 'SELECT "{replace}" FROM "{table}" WHERE ' + 'AND '.join(['"{}" = ' + self.format_char + ' '] * len(self._match))
+        self.query = query.format(*self._match.values(),
+                                  table=self.table,
+                                  replace='", "'.join(self._replace.keys()))
 
     def process(self):
         event = self.receive_message()
 
         # Skip events with missing match-keys
-        for key in self.match.keys():
+        for key in self._match.keys():
             if key not in event:
                 self.logger.debug('%s not present in event. Skipping event.', key)
                 self.send_message(event)
@@ -30,25 +37,25 @@ class GenericDBLookupExpertBot(SQLBot):
                 return
 
         # Skip events with existing data and overwrite is not allowed
-        if all([key in event for key in self.replace.values()]) and not self.parameters.overwrite:
+        if all([key in event for key in self._replace.values()]) and not self.overwrite:
             self.send_message(event)
             self.acknowledge_message()
             return
 
-        if self.execute(self.query, [event[key] for key in self.match.keys()]):
+        if self.execute(self.query, [event[key] for key in self._match.keys()]):
             if self.cur.rowcount > 1:
                 raise ValueError('Lookup returned more then one result. Please inspect.')
-            elif self.cur.rowcount == 1 or (self.cur.rowcount == -1 and self.parameters.engine == SQLBot.SQLITE):
+            elif self.cur.rowcount == 1 or (self.cur.rowcount == -1 and self.engine == SQLBot.SQLITE):
                 result = None
                 if self.cur.rowcount == 1:
                     result = self.cur.fetchone()
-                elif self.cur.rowcount == -1 and self.parameters.engine == SQLBot.SQLITE:
+                elif self.cur.rowcount == -1 and self.engine == SQLBot.SQLITE:
                     # https://docs.python.org/2/library/sqlite3.html#sqlite3.Cursor.rowcount
                     # since the DB’s own support for the determination is quirky we try to fetch even when rowcount=-1
                     result = self.cur.fetchone()
 
                 if result:
-                    for i, (key, value) in enumerate(self.replace.items()):
+                    for i, (key, value) in enumerate(self._replace.items()):
                         event.add(value, result[i], overwrite=True)
                     self.logger.debug('Applied.')
                 else:

--- a/intelmq/bots/experts/generic_db_lookup/expert.py
+++ b/intelmq/bots/experts/generic_db_lookup/expert.py
@@ -7,13 +7,21 @@ from intelmq.lib.bot import SQLBot
 
 
 class GenericDBLookupExpertBot(SQLBot):
-    _replace = None
+    """Fetche data from a database"""
+    database: str = "intelmq"
+    engine: str = "<postgresql OR sqlite>"
+    host: str = "localhost"
+    match_fields = {"source.asn": "asn"}
+    overwrite: bool = False
+    password: str = "<password>"
+    port: int = 5432
     replace_fields = {'contact': 'source.abuse_contact', 'note': 'comment'}
+    sslmode: str = "require"
+    table: str = "contacts"
+    user: str = "intelmq"
+
+    _replace = None
     _match = None
-    match_fields = {'source.asn': 'asn'}
-    table = None
-    overwrite = None
-    engine = None
 
     def init(self):
         super().init()

--- a/intelmq/bots/experts/geohash/expert.py
+++ b/intelmq/bots/experts/geohash/expert.py
@@ -13,6 +13,8 @@ except ImportError:
 
 
 class GeohashExpertBot(Bot):
+    precision = 7
+    overwrite = False
 
     def init(self):
         if not geohash:
@@ -30,8 +32,8 @@ class GeohashExpertBot(Bot):
             event.add(geohash_key,
                       geohash.encode(event[latitude_key],
                                      event[longitude_key],
-                                     precision=self.parameters.precision),
-                      overwrite=self.parameters.overwrite)
+                                     precision=self.precision),
+                      overwrite=self.overwrite)
 
         self.send_message(event)
         self.acknowledge_message()

--- a/intelmq/bots/experts/geohash/expert.py
+++ b/intelmq/bots/experts/geohash/expert.py
@@ -13,8 +13,9 @@ except ImportError:
 
 
 class GeohashExpertBot(Bot):
-    precision = 7
-    overwrite = False
+    """Compute the geohash from longitude/latitude information, save it to extra.(source|destination)"""
+    overwrite: bool = False
+    precision: int = 7
 
     def init(self):
         if not geohash:

--- a/intelmq/bots/experts/gethostbyname/expert.py
+++ b/intelmq/bots/experts/gethostbyname/expert.py
@@ -29,9 +29,9 @@ class GethostbynameExpertBot(Bot):
 
     def init(self):
         # although True is the default value, we leave False here for backwards compatibility
-        self.fallback_to_url = getattr(self.parameters, 'fallback_to_url', False)
+        self.fallback_to_url = getattr(self, 'fallback_to_url', False)
 
-        ignore = getattr(self.parameters, 'gaierrors_to_ignore', ())
+        ignore = getattr(self, 'gaierrors_to_ignore', ())
         if not isinstance(ignore, (list, tuple)):
             ignore = ignore.split(',')
         elif not ignore:  # for null/None
@@ -48,7 +48,7 @@ class GethostbynameExpertBot(Bot):
         ignore = tuple(int(x) for x in ignore)  # convert to integers
 
         self.ignore = (-2, -4, -5, -8, -11) + ignore
-        self.overwrite = getattr(self.parameters, 'overwrite', False)
+        self.overwrite = getattr(self, 'overwrite', False)
 
     def process(self):
         event = self.receive_message()

--- a/intelmq/bots/experts/gethostbyname/expert.py
+++ b/intelmq/bots/experts/gethostbyname/expert.py
@@ -26,12 +26,13 @@ from intelmq.lib.exceptions import InvalidArgument
 
 
 class GethostbynameExpertBot(Bot):
+    """Resolve the IP address for the FQDN"""
+    fallback_to_url: bool = True
+    gaierrors_to_ignore = ()
+    overwrite: bool = False
 
     def init(self):
-        # although True is the default value, we leave False here for backwards compatibility
-        self.fallback_to_url = getattr(self, 'fallback_to_url', False)
-
-        ignore = getattr(self, 'gaierrors_to_ignore', ())
+        ignore = self.gaierrors_to_ignore
         if not isinstance(ignore, (list, tuple)):
             ignore = ignore.split(',')
         elif not ignore:  # for null/None
@@ -48,7 +49,6 @@ class GethostbynameExpertBot(Bot):
         ignore = tuple(int(x) for x in ignore)  # convert to integers
 
         self.ignore = (-2, -4, -5, -8, -11) + ignore
-        self.overwrite = getattr(self, 'overwrite', False)
 
     def process(self):
         event = self.receive_message()

--- a/intelmq/bots/experts/idea/expert.py
+++ b/intelmq/bots/experts/idea/expert.py
@@ -114,7 +114,7 @@ class IdeaExpertBot(Bot):
             ),
             "Category": [
                 lambda s: self.type_to_category[s.get("classification.type", "undetermined")],
-                lambda s: "Test" if self.parameters.test_mode else None
+                lambda s: "Test" if self.test_mode else None
             ],
             "DetectTime": "time.observation",
             "EventTime": "time.source",

--- a/intelmq/bots/experts/idea/expert.py
+++ b/intelmq/bots/experts/idea/expert.py
@@ -23,6 +23,8 @@ def addr6(s):
 
 
 class IdeaExpertBot(Bot):
+    """Convert events into the IDEA format"""
+    test_mode: bool = False
 
     type_to_category = {
         "phishing": "Fraud.Phishing",

--- a/intelmq/bots/experts/mcafee/expert_mar.py
+++ b/intelmq/bots/experts/mcafee/expert_mar.py
@@ -25,6 +25,9 @@ from intelmq.lib.exceptions import MissingDependencyError
 
 
 class MARExpertBot(Bot):
+    """Query connections to IP addresses to the given destination within the local environment using McAfee Active Response queries"""
+    dxl_config_file: str = "<insert /path/to/dxlclient.config>"  # TODO: should be pathlib.Path
+    lookup_type: str = "<Hash|DestSocket|DestIP|DestFQDN>"
 
     query = {
         'Hash':
@@ -89,13 +92,13 @@ class MARExpertBot(Bot):
         if MarClient is None:
             raise MissingDependencyError('dxlmarclient')
 
-        self.config = DxlClientConfig.create_dxl_config_from_file(self.parameters.dxl_config_file)
+        self.config = DxlClientConfig.create_dxl_config_from_file(self.dxl_config_file)
 
     def process(self):
         report = self.receive_message()
 
         try:
-            mar_search_str = self.query[self.parameters.lookup_type] % report
+            mar_search_str = self.query[self.lookup_type] % report
             for ip_address in self.MAR_Query(mar_search_str):
                 event = self.new_event(report)
                 event.add('source.ip', ip_address)

--- a/intelmq/bots/experts/misp/expert.py
+++ b/intelmq/bots/experts/misp/expert.py
@@ -19,15 +19,18 @@ except ImportError:
 
 
 class MISPExpertBot(Bot):
+    """Looking up the IP address in MISP instance and retrieve attribute and event UUIDs"""
+    misp_key: str = "<insert MISP Authkey>"
+    misp_url: str = "<insert url of MISP server (with trailing '/')>"
 
     def init(self):
         if ExpandedPyMISP is None:
             raise MissingDependencyError('pymisp', '>=2.4.117.3')
 
         # Initialize MISP connection
-        self.misp = ExpandedPyMISP(self.parameters.misp_url,
-                                   self.parameters.misp_key,
-                                   self.parameters.http_verify_cert)
+        self.misp = ExpandedPyMISP(self.misp_url,
+                                   self.misp_key,
+                                   self.http_verify_cert)
 
     def process(self):
         event = self.receive_message()

--- a/intelmq/bots/experts/modify/expert.py
+++ b/intelmq/bots/experts/modify/expert.py
@@ -37,23 +37,23 @@ class MatchGroupMapping:
 class ModifyExpertBot(Bot):
 
     def init(self):
-        config = load_configuration(self.parameters.configuration_path)
+        config = load_configuration(self.configuration_path)
         if type(config) is dict:
             self.logger.warning('Support for dict-based configuration will be '
                                 'removed in version 3.0. Have a look at the '
                                 'NEWS file section 1.0.0.dev7.')
             config = modify_expert_convert_config(config)
 
-        if getattr(self.parameters, 'case_sensitive', True):
+        if getattr(self, 'case_sensitive', True):
             self.re_kwargs = {}
         else:
             self.re_kwargs = {'flags': re.IGNORECASE}
 
-        if not hasattr(self.parameters, 'overwrite'):
+        if not hasattr(self, 'overwrite'):
             self.logger.warning("Parameter 'overwrite' is not given, assuming 'True'. "
                                 "Please set it explicitly, default will change to "
                                 "'False' in version 3.0.0'.")
-        self.overwrite = getattr(self.parameters, 'overwrite', True)
+        self.overwrite = getattr(self, 'overwrite', True)
 
         # regex compilation
         self.config = []
@@ -63,7 +63,7 @@ class ModifyExpertBot(Bot):
                 if isinstance(expression, str) and expression != '':
                     self.config[-1]["if"][field] = re.compile(expression, **self.re_kwargs)
 
-        self.maximum_matches = getattr(self.parameters, 'maximum_matches', None)
+        self.maximum_matches = getattr(self, 'maximum_matches', None)
 
     def matches(self, identifier, event, condition):
         matches = {}

--- a/intelmq/bots/experts/national_cert_contact_certat/expert.py
+++ b/intelmq/bots/experts/national_cert_contact_certat/expert.py
@@ -46,7 +46,7 @@ class NationalCERTContactCertATExpertBot(Bot):
             if key in event:
                 parameters = {
                     'ip': event[key],
-                    'bFilter': 'on' if self.parameters.filter else 'off',
+                    'bFilter': 'on' if self.filter else 'off',
                     'bShowNationalCERT': 'on',
                     'sep': 'semicolon',
                 }
@@ -58,7 +58,7 @@ class NationalCERTContactCertATExpertBot(Bot):
                 response = req.text.strip().split(';')
 
                 ccfield = '{}.geolocation.cc'.format(section)
-                if self.parameters.overwrite_cc or ccfield not in event:
+                if self.overwrite_cc or ccfield not in event:
                     event.add(ccfield, response[1])
 
                 if abuse in event:

--- a/intelmq/bots/experts/national_cert_contact_certat/expert.py
+++ b/intelmq/bots/experts/national_cert_contact_certat/expert.py
@@ -29,6 +29,11 @@ URL = 'https://contacts.cert.at/cgi-bin/abuse-nationalcert.pl'
 
 
 class NationalCERTContactCertATExpertBot(Bot):
+    """Add country and abuse contact information from the CERT.at national CERT Contact Database. Set filter to true if you want to filter out events for Austria. Set overwrite_cc to true if you want to overwrite an existing country code value"""
+    filter: bool = False
+    http_verify_cert: bool = True
+    overwrite_cc: bool = False
+
     def init(self):
         if requests is None:
             raise MissingDependencyError("requests")

--- a/intelmq/bots/experts/recordedfuture_iprisk/expert.py
+++ b/intelmq/bots/experts/recordedfuture_iprisk/expert.py
@@ -17,6 +17,10 @@ from intelmq.bin.intelmqctl import IntelMQController
 
 
 class RecordedFutureIPRiskExpertBot(Bot):
+    """Adds the Risk Score from RecordedFuture IPRisk associated with source.ip or destination.ip with a local database"""
+    api_token: str = "<insert Recorded Future IPRisk API token>"
+    database: str = "/opt/intelmq/var/lib/bots/recordedfuture_iprisk/rfiprisk.dat"  # TODO: should be pathlib.Path
+    overwrite: bool = False
 
     _database = dict()
 
@@ -31,8 +35,6 @@ class RecordedFutureIPRiskExpertBot(Bot):
 
         except IOError:
             raise ValueError("Recorded future risklist not defined or failed on open.")
-
-        self.overwrite = getattr(self, 'overwrite', False)
 
     def process(self):
         event = self.receive_message()

--- a/intelmq/bots/experts/recordedfuture_iprisk/expert.py
+++ b/intelmq/bots/experts/recordedfuture_iprisk/expert.py
@@ -18,21 +18,21 @@ from intelmq.bin.intelmqctl import IntelMQController
 
 class RecordedFutureIPRiskExpertBot(Bot):
 
-    database = dict()
+    _database = dict()
 
     def init(self):
         self.logger.info("Loading recorded future risk list.")
 
         try:
-            with open(self.parameters.database) as fp:
+            with open(self.database) as fp:
                 rfreader = csv.DictReader(fp)
                 for row in rfreader:
-                    self.database[row['Name']] = int(row['Risk'])
+                    self._database[row['Name']] = int(row['Risk'])
 
         except IOError:
             raise ValueError("Recorded future risklist not defined or failed on open.")
 
-        self.overwrite = getattr(self.parameters, 'overwrite', False)
+        self.overwrite = getattr(self, 'overwrite', False)
 
     def process(self):
         event = self.receive_message()
@@ -40,9 +40,9 @@ class RecordedFutureIPRiskExpertBot(Bot):
         for key in ["source", "destination"]:
             if key + '.ip' in event:
                 if "extra.rf_iprisk." + key not in event:
-                    event.add("extra.rf_iprisk." + key, self.database.get(event.get(key + '.ip'), 0))
+                    event.add("extra.rf_iprisk." + key, self._database.get(event.get(key + '.ip'), 0))
                 elif "extra.rf_iprisk." + key in event and self.overwrite:
-                    event.change("extra.rf_iprisk." + key, self.database.get(event.get(key + '.ip'), 0))
+                    event.change("extra.rf_iprisk." + key, self._database.get(event.get(key + '.ip'), 0))
 
         self.send_message(event)
         self.acknowledge_message()

--- a/intelmq/bots/experts/reverse_dns/expert.py
+++ b/intelmq/bots/experts/reverse_dns/expert.py
@@ -22,19 +22,19 @@ class InvalidPTRResult(ValueError):
 class ReverseDnsExpertBot(Bot):
 
     def init(self):
-        self.cache = Cache(self.parameters.redis_cache_host,
-                           self.parameters.redis_cache_port,
-                           self.parameters.redis_cache_db,
-                           self.parameters.redis_cache_ttl,
-                           getattr(self.parameters, "redis_cache_password",
+        self.cache = Cache(self.redis_cache_host,
+                           self.redis_cache_port,
+                           self.redis_cache_db,
+                           self.redis_cache_ttl,
+                           getattr(self, "redis_cache_password",
                                    None)
                            )
 
-        if not hasattr(self.parameters, 'overwrite'):
+        if not hasattr(self, 'overwrite'):
             self.logger.warning("Parameter 'overwrite' is not given, assuming 'True'. "
                                 "Please set it explicitly, default will change to "
                                 "'False' in version 3.0.0'.")
-        self.overwrite = getattr(self.parameters, 'overwrite', True)
+        self.overwrite = getattr(self, 'overwrite', True)
 
     def process(self):
         event = self.receive_message()
@@ -81,7 +81,7 @@ class ReverseDnsExpertBot(Bot):
                 except (dns.exception.DNSException, InvalidPTRResult) as e:
                     # Set default TTL for 'DNS query name does not exist' error
                     ttl = None if isinstance(e, dns.resolver.NXDOMAIN) else \
-                        getattr(self.parameters, "cache_ttl_invalid_response",
+                        getattr(self, "cache_ttl_invalid_response",
                                 60)
                     self.cache.set(cache_key, DNS_EXCEPTION_VALUE, ttl)
                     result = None

--- a/intelmq/bots/experts/rfc1918/expert.py
+++ b/intelmq/bots/experts/rfc1918/expert.py
@@ -41,6 +41,9 @@ ASNS = ASN16 + ASN32
 
 
 class RFC1918ExpertBot(Bot):
+    """Removes fields or discard events if an IP address or domain is invalid as defined in standards like RFC 1918 (invalid, local, reserved, documentation). IP address, FQDN and URL fields are supported"""
+    fields: str = "destination.ip,source.ip,source.url"  # TODO: could be List[str]
+    policy: str = "del,drop,drop"  # TODO: detto
 
     def init(self):
         self.fields = self.fields.lower().strip().split(",")

--- a/intelmq/bots/experts/rfc1918/expert.py
+++ b/intelmq/bots/experts/rfc1918/expert.py
@@ -43,8 +43,8 @@ ASNS = ASN16 + ASN32
 class RFC1918ExpertBot(Bot):
 
     def init(self):
-        self.fields = self.parameters.fields.lower().strip().split(",")
-        self.policy = self.parameters.policy.lower().strip().split(",")
+        self.fields = self.fields.lower().strip().split(",")
+        self.policy = self.policy.lower().strip().split(",")
 
         if len(self.fields) != len(self.policy):
             raise ValueError("Length of parameters 'fields' (%d) and 'policy' (%d) is unequal."

--- a/intelmq/bots/experts/ripe/expert.py
+++ b/intelmq/bots/experts/ripe/expert.py
@@ -63,13 +63,13 @@ class RIPEExpertBot(Bot):
         if requests is None:
             raise MissingDependencyError("requests")
 
-        self.__mode = getattr(self.parameters, 'mode', 'append')
+        self.__mode = getattr(self, 'mode', 'append')
         self.__query = {
-            "db_asn": getattr(self.parameters, 'query_ripe_db_asn', True),
-            "db_ip": getattr(self.parameters, 'query_ripe_db_ip', True),
-            "stat_asn": getattr(self.parameters, 'query_ripe_stat_asn', True),
-            "stat_ip": getattr(self.parameters, 'query_ripe_stat_ip', True),
-            "stat_geo": getattr(self.parameters, 'query_ripe_stat_geolocation', True)
+            "db_asn": getattr(self, 'query_ripe_db_asn', True),
+            "db_ip": getattr(self, 'query_ripe_db_ip', True),
+            "stat_asn": getattr(self, 'query_ripe_stat_asn', True),
+            "stat_ip": getattr(self, 'query_ripe_stat_ip', True),
+            "stat_geo": getattr(self, 'query_ripe_stat_geolocation', True)
         }
 
         self.__initialize_http_session()
@@ -80,13 +80,13 @@ class RIPEExpertBot(Bot):
         self.http_session = utils.create_request_session(self)
 
     def __initialize_cache(self):
-        cache_host = getattr(self.parameters, 'redis_cache_host')
-        cache_port = getattr(self.parameters, 'redis_cache_port')
-        cache_db = getattr(self.parameters, 'redis_cache_db')
-        cache_ttl = getattr(self.parameters, 'redis_cache_ttl')
+        cache_host = getattr(self, 'redis_cache_host')
+        cache_port = getattr(self, 'redis_cache_port')
+        cache_db = getattr(self, 'redis_cache_db')
+        cache_ttl = getattr(self, 'redis_cache_ttl')
         if cache_host and cache_port and cache_db and cache_ttl:
             self.__cache = Cache(cache_host, cache_port, cache_db, cache_ttl,
-                                 getattr(self.parameters, "redis_cache_password", None))
+                                 getattr(self, "redis_cache_password", None))
 
     def process(self):
         event = self.receive_message()

--- a/intelmq/bots/experts/ripe/expert.py
+++ b/intelmq/bots/experts/ripe/expert.py
@@ -38,6 +38,19 @@ def clean_geo(geo_data):
 
 
 class RIPEExpertBot(Bot):
+    """Fetch abuse contact and/or geolocation information for the source and/or destination IP addresses and/or ASNs of the events"""
+    mode: str = "append"
+    query_ripe_db_asn: bool = True
+    query_ripe_db_ip: bool = True
+    query_ripe_stat_asn: bool = True
+    query_ripe_stat_geolocation: bool = True
+    query_ripe_stat_ip: bool = True
+    redis_cache_db: int = 10
+    redis_cache_host: str = "127.0.0.1"  # TODO: should be ipaddress
+    redis_cache_password: str = None
+    redis_cache_port: int = 6379
+    redis_cache_ttl: int = 86400
+
     QUERY = {
         'db_ip': 'https://rest.db.ripe.net/abuse-contact/{}.json',
         'db_asn': 'https://rest.db.ripe.net/abuse-contact/as{}.json',
@@ -63,13 +76,13 @@ class RIPEExpertBot(Bot):
         if requests is None:
             raise MissingDependencyError("requests")
 
-        self.__mode = getattr(self, 'mode', 'append')
+        self.__mode = self.mode
         self.__query = {
-            "db_asn": getattr(self, 'query_ripe_db_asn', True),
-            "db_ip": getattr(self, 'query_ripe_db_ip', True),
-            "stat_asn": getattr(self, 'query_ripe_stat_asn', True),
-            "stat_ip": getattr(self, 'query_ripe_stat_ip', True),
-            "stat_geo": getattr(self, 'query_ripe_stat_geolocation', True)
+            "db_asn": self.query_ripe_db_asn,
+            "db_ip": self.query_ripe_db_ip,
+            "stat_asn": self.query_ripe_stat_asn,
+            "stat_ip": self.query_ripe_stat_ip,
+            "stat_geo": self.query_ripe_stat_geolocation,
         }
 
         self.__initialize_http_session()
@@ -80,13 +93,12 @@ class RIPEExpertBot(Bot):
         self.http_session = utils.create_request_session(self)
 
     def __initialize_cache(self):
-        cache_host = getattr(self, 'redis_cache_host')
-        cache_port = getattr(self, 'redis_cache_port')
-        cache_db = getattr(self, 'redis_cache_db')
-        cache_ttl = getattr(self, 'redis_cache_ttl')
+        cache_host = self.redis_cache_host
+        cache_port = self.redis_cache_port
+        cache_db = self.redis_cache_db
+        cache_ttl = self.redis_cache_ttl
         if cache_host and cache_port and cache_db and cache_ttl:
-            self.__cache = Cache(cache_host, cache_port, cache_db, cache_ttl,
-                                 getattr(self, "redis_cache_password", None))
+            self.__cache = Cache(cache_host, cache_port, cache_db, cache_ttl, self.redis_cache_password)
 
     def process(self):
         event = self.receive_message()

--- a/intelmq/bots/experts/sieve/expert.py
+++ b/intelmq/bots/experts/sieve/expert.py
@@ -37,6 +37,7 @@ class SieveExpertBot(Bot):
     _message_processed_verb = 'Forwarded'
 
     harmonization = None
+    file = None
 
     def init(self):
         if not SieveExpertBot.harmonization:
@@ -44,7 +45,7 @@ class SieveExpertBot(Bot):
             SieveExpertBot.harmonization = harmonization_config['event']
 
         self.metamodel = SieveExpertBot.init_metamodel()
-        self.sieve = SieveExpertBot.read_sieve_file(self.parameters.file, self.metamodel)
+        self.sieve = SieveExpertBot.read_sieve_file(self.file, self.metamodel)
 
     @staticmethod
     def init_metamodel():

--- a/intelmq/bots/experts/sieve/expert.py
+++ b/intelmq/bots/experts/sieve/expert.py
@@ -34,10 +34,11 @@ class Procedure:
 
 
 class SieveExpertBot(Bot):
+    """Filter and modify events based on a sieve-based language"""
     _message_processed_verb = 'Forwarded'
 
     harmonization = None
-    file = None
+    file: str = "/opt/intelmq/var/lib/bots/sieve/filter.sieve"  # TODO: should be pathlib.Path
 
     def init(self):
         if not SieveExpertBot.harmonization:

--- a/intelmq/bots/experts/taxonomy/expert.py
+++ b/intelmq/bots/experts/taxonomy/expert.py
@@ -65,6 +65,7 @@ TAXONOMY = {
 
 
 class TaxonomyExpertBot(Bot):
+    """Apply the eCSIRT Taxonomy to all events"""
 
     def process(self):
         event = self.receive_message()

--- a/intelmq/bots/experts/threshold/expert.py
+++ b/intelmq/bots/experts/threshold/expert.py
@@ -54,24 +54,28 @@ from intelmq.lib.exceptions import ConfigurationError
 
 
 class ThresholdExpertBot(Bot):
+    """Check if the number of similar messages during a specified time interval exceeds a set value"""
+    add_keys = {}
+    filter_keys = ["raw", "time.observation"]
+    filter_type: str = "blacklist"
+    redis_cache_db: int = 11
+    redis_cache_host: str = "127.0.0.1"  # TODO: could be ipaddress
+    redis_cache_password: str = None
+    redis_cache_port: int = 6379
+    threshold: int = 100
+    timeout: int = 3600
 
     _message_processed_verb = 'Forwarded'
 
     is_multithreadable = False
-    filter_keys = []
-    filter_type = "whitelist"
     bypass = False
-    timeout = -1
-    threshold = -1
-    add_keys = {}
 
     def init(self):
         self.cache = Cache(self.redis_cache_host,
                            self.redis_cache_port,
                            self.redis_cache_db,
                            self.timeout,
-                           getattr(self, "redis_cache_password",
-                                   None)
+                           self.redis_cache_password
                            )
         if self.timeout <= 0:
             raise ConfigurationError('Timeout', 'Invalid timeout specified, use positive integer seconds.')

--- a/intelmq/bots/experts/threshold/expert.py
+++ b/intelmq/bots/experts/threshold/expert.py
@@ -58,25 +58,25 @@ class ThresholdExpertBot(Bot):
     _message_processed_verb = 'Forwarded'
 
     is_multithreadable = False
+    filter_keys = []
+    filter_type = "whitelist"
+    bypass = False
+    timeout = -1
+    threshold = -1
+    add_keys = {}
 
     def init(self):
-        self.cache = Cache(self.parameters.redis_cache_host,
-                           self.parameters.redis_cache_port,
-                           self.parameters.redis_cache_db,
-                           self.parameters.timeout,
-                           getattr(self.parameters, "redis_cache_password",
+        self.cache = Cache(self.redis_cache_host,
+                           self.redis_cache_port,
+                           self.redis_cache_db,
+                           self.timeout,
+                           getattr(self, "redis_cache_password",
                                    None)
                            )
-        self.filter_keys = getattr(self.parameters, "filter_keys", [])
-        self.filter_type = getattr(self.parameters, "filter_type", "whitelist")
-        self.bypass = getattr(self.parameters, "bypass", False)
-        self.timeout = getattr(self.parameters, "timeout", -1)
         if self.timeout <= 0:
             raise ConfigurationError('Timeout', 'Invalid timeout specified, use positive integer seconds.')
-        self.threshold = getattr(self.parameters, "threshold", -1)
         if self.threshold <= 0:
             raise ConfigurationError('Threshold', 'Invalid threshold specified, use positive integer count.')
-        self.add_keys = getattr(self.parameters, "add_keys", {})
 
     def process(self):
         message = self.receive_message()

--- a/intelmq/bots/experts/tor_nodes/expert.py
+++ b/intelmq/bots/experts/tor_nodes/expert.py
@@ -15,25 +15,25 @@ from intelmq.bin.intelmqctl import IntelMQController
 
 class TorExpertBot(Bot):
 
-    database = set()
+    _database = set()
 
     def init(self):
         self.logger.info("Loading TOR exit node IPs.")
 
         try:
-            with open(self.parameters.database) as fp:
+            with open(self.database) as fp:
                 for line in fp:
                     line = line.strip()
 
                     if len(line) == 0 or line[0] == "#":
                         continue
 
-                    self.database.add(line)
+                    self._database.add(line)
 
         except IOError:
             raise ValueError("TOR rule not defined or failed on open.")
 
-        self.overwrite = getattr(self.parameters, 'overwrite', False)
+        self.overwrite = getattr(self, 'overwrite', False)
 
     def process(self):
         event = self.receive_message()
@@ -41,10 +41,10 @@ class TorExpertBot(Bot):
         for key in ["source.", "destination."]:
             if key + 'ip' in event:
                 if key + 'tor_node' not in event:
-                    if event.get(key + 'ip') in self.database:
+                    if event.get(key + 'ip') in self._database:
                         event.add(key + 'tor_node', True)
                 elif key + 'tor_node' in event and self.overwrite:
-                    if event.get(key + 'ip') in self.database:
+                    if event.get(key + 'ip') in self._database:
                         event.change(key + 'tor_node', True)
 
         self.send_message(event)

--- a/intelmq/bots/experts/tor_nodes/expert.py
+++ b/intelmq/bots/experts/tor_nodes/expert.py
@@ -14,6 +14,9 @@ from intelmq.bin.intelmqctl import IntelMQController
 
 
 class TorExpertBot(Bot):
+    """Check if the IP address is a Tor Exit Node based on a local database of TOR nodes"""
+    database: str = "/opt/intelmq/var/lib/bots/tor_nodes/tor_nodes.dat"  # TODO: pathlib.Path
+    overwrite: bool = False
 
     _database = set()
 
@@ -32,8 +35,6 @@ class TorExpertBot(Bot):
 
         except IOError:
             raise ValueError("TOR rule not defined or failed on open.")
-
-        self.overwrite = getattr(self, 'overwrite', False)
 
     def process(self):
         event = self.receive_message()

--- a/intelmq/bots/experts/url2fqdn/expert.py
+++ b/intelmq/bots/experts/url2fqdn/expert.py
@@ -7,7 +7,7 @@ from intelmq.lib.bot import Bot
 class Url2fqdnExpertBot(Bot):
 
     def init(self):
-        self.overwrite = getattr(self.parameters, 'overwrite', False)
+        self.overwrite = getattr(self, 'overwrite', False)
 
     def process(self):
         event = self.receive_message()

--- a/intelmq/bots/experts/url2fqdn/expert.py
+++ b/intelmq/bots/experts/url2fqdn/expert.py
@@ -5,9 +5,8 @@ from intelmq.lib.bot import Bot
 
 
 class Url2fqdnExpertBot(Bot):
-
-    def init(self):
-        self.overwrite = getattr(self, 'overwrite', False)
+    """Parse the FQDN from the URL"""
+    overwrite = False
 
     def process(self):
         event = self.receive_message()

--- a/intelmq/bots/experts/wait/expert.py
+++ b/intelmq/bots/experts/wait/expert.py
@@ -14,16 +14,16 @@ from intelmq.lib.bot import Bot
 class WaitExpertBot(Bot):
     def init(self):
         self.mode = None
-        self.queue_name = getattr(self.parameters, 'queue_name', None)
-        self.sleep_time = getattr(self.parameters, 'sleep_time', None)
+        self.queue_name = getattr(self, 'queue_name', None)
+        self.sleep_time = getattr(self, 'sleep_time', None)
         if self.queue_name:
             self.mode = 'queue'
-            self.queue_db = int(getattr(self.parameters, 'queue_db', 2))
-            self.queue_host = getattr(self.parameters, 'queue_host', 'localhost')
-            self.queue_password = getattr(self.parameters, 'queue_password', None)
-            self.queue_polling_interval = float(getattr(self.parameters, 'queue_polling_interval', 0.05))
-            self.queue_port = int(getattr(self.parameters, 'queue_port', 6379))
-            self.queue_size = int(getattr(self.parameters, 'queue_size', 0))
+            self.queue_db = int(getattr(self, 'queue_db', 2))
+            self.queue_host = getattr(self, 'queue_host', 'localhost')
+            self.queue_password = getattr(self, 'queue_password', None)
+            self.queue_polling_interval = float(getattr(self, 'queue_polling_interval', 0.05))
+            self.queue_port = int(getattr(self, 'queue_port', 6379))
+            self.queue_size = int(getattr(self, 'queue_size', 0))
             self.connect_redis()
         elif self.sleep_time:
             self.mode = 'sleep'

--- a/intelmq/bots/experts/wait/expert.py
+++ b/intelmq/bots/experts/wait/expert.py
@@ -12,18 +12,20 @@ from intelmq.lib.bot import Bot
 
 
 class WaitExpertBot(Bot):
+    """Wait for a some time or until a queue size is lower than a given number"""
+    queue_db: int = 2
+    queue_host: str = "localhost"
+    queue_name: str = None
+    queue_password: str = None
+    queue_polling_interval: float = 0.05
+    queue_port: int = 6379
+    queue_size: int = 0
+    sleep_time: int = None
+
     def init(self):
         self.mode = None
-        self.queue_name = getattr(self, 'queue_name', None)
-        self.sleep_time = getattr(self, 'sleep_time', None)
         if self.queue_name:
             self.mode = 'queue'
-            self.queue_db = int(getattr(self, 'queue_db', 2))
-            self.queue_host = getattr(self, 'queue_host', 'localhost')
-            self.queue_password = getattr(self, 'queue_password', None)
-            self.queue_polling_interval = float(getattr(self, 'queue_polling_interval', 0.05))
-            self.queue_port = int(getattr(self, 'queue_port', 6379))
-            self.queue_size = int(getattr(self, 'queue_size', 0))
             self.connect_redis()
         elif self.sleep_time:
             self.mode = 'sleep'

--- a/intelmq/bots/outputs/amqptopic/output.py
+++ b/intelmq/bots/outputs/amqptopic/output.py
@@ -11,22 +11,29 @@ except ImportError:
 
 
 class AMQPTopicOutputBot(OutputBot):
-    connection = None
-    connection_heartbeat = None
-    delivery_mode = None
-    content_type = None
-    exchange_name = None
-    require_confirmation = None
-    exchange_durable = None
-    exchange_type = None
-    connection_host = None
-    connection_port = None
-    connection_vhost = None
-    username = None
-    password = None
+    """Send events to an AMQP topic exchange. Requires the pika python library"""
+    connection_attempts: int = 3
+    connection_heartbeat: int = 3600
+    connection_host: str = "127.0.0.1"  # TODO: could be ipaddress
+    connection_port: int = 5672
+    connection_vhost: str = None
+    content_type: str = "application/json"
+    delivery_mode: int = 2
+    exchange_durable: bool = True
+    exchange_name: str = None
+    exchange_type: str = "topic"
+    keep_raw_field: bool = False  # TODO: legacy? not used..
+    message_hierarchical_output: bool = False
+    message_jsondict_as_string: bool = False
+    message_with_type: bool = False
+    password: str = None
+    require_confirmation: bool = True
+    routing_key: str = None
+    single_key: bool = False
     use_ssl = False
-    connection_attempts = None
-    routing_key = None
+    username = None
+
+    connection = None
     format_routing_key = False
 
     def init(self):

--- a/intelmq/bots/outputs/blackhole/output.py
+++ b/intelmq/bots/outputs/blackhole/output.py
@@ -3,6 +3,7 @@ from intelmq.lib.bot import Bot
 
 
 class BlackholeOutputBot(Bot):
+    "Discard messages"
 
     def process(self):
         self.receive_message()

--- a/intelmq/bots/outputs/elasticsearch/output.py
+++ b/intelmq/bots/outputs/elasticsearch/output.py
@@ -52,15 +52,19 @@ def get_event_date(event_dict: dict) -> datetime.date:
 
 
 class ElasticsearchOutputBot(Bot):
-    elastic_host = '127.0.0.1'
-    elastic_port = '9200'
-    elastic_index = 'intelmq'
-    rotate_index = False
-    use_ssl = False
-    ssl_ca_certificate = None
-    ssl_show_warnings = True
-    replacement_char = None
+    """Send events to an Elasticsearch database server"""
+    elastic_host: str = '127.0.0.1'  # TODO: could be ipadd
+    elastic_index: str = 'intelmq'
+    elastic_port: int = 9200
     flatten_fields = ['extra']
+    http_password: str = None
+    http_username: str = None
+    http_verify_cert: bool = False
+    replacement_char = None
+    rotate_index: str = 'never'
+    ssl_ca_certificate: str = None  # TODO: could be pathlib.Path
+    ssl_show_warnings: bool = True
+    use_ssl: bool = False
 
     def init(self):
         if Elasticsearch is None:

--- a/intelmq/bots/outputs/elasticsearch/output.py
+++ b/intelmq/bots/outputs/elasticsearch/output.py
@@ -52,29 +52,20 @@ def get_event_date(event_dict: dict) -> datetime.date:
 
 
 class ElasticsearchOutputBot(Bot):
+    elastic_host = '127.0.0.1'
+    elastic_port = '9200'
+    elastic_index = 'intelmq'
+    rotate_index = False
+    use_ssl = False
+    ssl_ca_certificate = None
+    ssl_show_warnings = True
+    replacement_char = None
+    flatten_fields = ['extra']
 
     def init(self):
         if Elasticsearch is None:
             raise MissingDependencyError('elasticsearch', version='>=5.0.0,<6.0.0')
 
-        self.elastic_host = getattr(self.parameters,
-                                    'elastic_host', '127.0.0.1')
-        self.elastic_port = getattr(self.parameters,
-                                    'elastic_port', '9200')
-        self.elastic_index = getattr(self.parameters,
-                                     'elastic_index', 'intelmq')
-        self.rotate_index = getattr(self.parameters,
-                                    'rotate_index', False)
-        self.use_ssl = getattr(self.parameters,
-                               'use_ssl', False)
-        self.ssl_ca_certificate = getattr(self.parameters,
-                                          'ssl_ca_certificate', None)
-        self.ssl_show_warnings = getattr(self.parameters,
-                                         'ssl_show_warnings', True)
-        self.replacement_char = getattr(self.parameters,
-                                        'replacement_char', None)
-        self.flatten_fields = getattr(self.parameters,
-                                      'flatten_fields', ['extra'])
         if isinstance(self.flatten_fields, str):
             self.flatten_fields = self.flatten_fields.split(',')
 

--- a/intelmq/bots/outputs/file/output.py
+++ b/intelmq/bots/outputs/file/output.py
@@ -8,26 +8,28 @@ from intelmq.lib.bot import OutputBot
 
 
 class FileOutputBot(OutputBot):
-    file = None
+    _file = None
     is_multithreadable = False
+    file = None
+    format_filename = False
+    encoding_errors_mode = 'strict'
 
     def init(self):
         # needs to be done here, because in process() FileNotFoundError handling we call init(),
         # otherwise the file would not be opened again
-        self.file = None
+        self._file = None
 
-        self.logger.debug("Opening %r file.", self.parameters.file)
-        self.format_filename = getattr(self.parameters, 'format_filename', False)
-        self.errors = getattr(self.parameters, 'encoding_errors_mode', 'strict')
+        self.logger.debug("Opening %r file.", self.file)
+        self.errors = self.encoding_errors_mode
         if not self.format_filename:
-            self.open_file(self.parameters.file)
-        self.logger.info("File %r is open.", self.parameters.file)
+            self.open_file(self.file)
+        self.logger.info("File %r is open.", self.file)
 
     def open_file(self, filename: str = None):
-        if self.file is not None:
-            self.file.close()
+        if self._file is not None:
+            self._file.close()
         try:
-            self.file = open(filename, mode='at', encoding='utf-8', errors=self.errors)
+            self._file = open(filename, mode='at', encoding='utf-8', errors=self.errors)
         except FileNotFoundError:  # directory does not exist
             path = Path(os.path.dirname(filename))
             try:
@@ -36,7 +38,7 @@ class FileOutputBot(OutputBot):
                 self.logger.exception('Directory %r could not be created.', path)
                 self.stop()
             else:
-                self.file = open(filename, mode='at', encoding='utf-8', errors=self.errors)
+                self._file = open(filename, mode='at', encoding='utf-8', errors=self.errors)
 
     def process(self):
         event = self.receive_message()
@@ -58,24 +60,24 @@ class FileOutputBot(OutputBot):
                 except ValueError:
                     ev['time.source'] = datetime.datetime.strptime(ev['time.source'],
                                                                    '%Y-%m-%dT%H:%M:%S.%f+00:00')
-            filename = self.parameters.file.format(event=ev)
-            if not self.file or filename != self.file.name:
+            filename = self.file.format(event=ev)
+            if not self._file or filename != self._file.name:
                 self.open_file(filename)
 
         event_data = self.export_event(event, return_type=str)
 
         try:
-            self.file.write(event_data)
-            self.file.write("\n")
-            self.file.flush()
+            self._file.write(event_data)
+            self._file.write("\n")
+            self._file.flush()
         except FileNotFoundError:
             self.init()
         else:
             self.acknowledge_message()
 
     def shutdown(self):
-        if self.file:
-            self.file.close()
+        if self._file:
+            self._file.close()
 
     @staticmethod
     def check(parameters):

--- a/intelmq/bots/outputs/file/output.py
+++ b/intelmq/bots/outputs/file/output.py
@@ -8,11 +8,17 @@ from intelmq.lib.bot import OutputBot
 
 
 class FileOutputBot(OutputBot):
+    """Write events to a file"""
     _file = None
-    is_multithreadable = False
-    file = None
-    format_filename = False
     encoding_errors_mode = 'strict'
+    file: str = "/opt/intelmq/var/lib/bots/file-output/events.txt"  # TODO: should be pathlib.Path
+    format_filename: bool = False
+    hierarchical_output: bool = False
+    keep_raw_field: bool = False
+    message_jsondict_as_string: bool = False
+    message_with_type: bool = False
+    single_key: bool = False
+    is_multithreadable = False
 
     def init(self):
         # needs to be done here, because in process() FileNotFoundError handling we call init(),

--- a/intelmq/bots/outputs/files/output.py
+++ b/intelmq/bots/outputs/files/output.py
@@ -10,10 +10,13 @@ from intelmq.lib.exceptions import ConfigurationError
 
 
 class FilesOutputBot(OutputBot):
+    tmp = None
+    dir = None
+    suffix = None
 
     def init(self):
-        self.tmp = self._ensure_path(self.parameters.tmp)
-        self.dir = self._ensure_path(self.parameters.dir)
+        self.tmp = self._ensure_path(self.tmp)
+        self.dir = self._ensure_path(self.dir)
         if os.stat(self.tmp).st_dev != os.stat(self.dir).st_dev:    # pragma: no cover (hard to test)
             raise ConfigurationError(
                 "bot setup",
@@ -33,7 +36,7 @@ class FilesOutputBot(OutputBot):
         """ Creates unique filename (Maildir inspired) """
         (inode, device) = os.fstat(fd)[1:3] if fd else (0, 0)
         return "%s.%d.%f.%d.%d%s" % (
-            self.hostname, self.pid, time.time(), device, inode, self.parameters.suffix)
+            self.hostname, self.pid, time.time(), device, inode, self.suffix)
 
     def create_unique_file(self):
         """ Safely creates machine-wide uniquely named file in tmp dir. """

--- a/intelmq/bots/outputs/files/output.py
+++ b/intelmq/bots/outputs/files/output.py
@@ -10,9 +10,15 @@ from intelmq.lib.exceptions import ConfigurationError
 
 
 class FilesOutputBot(OutputBot):
-    tmp = None
-    dir = None
-    suffix = None
+    """Write events lockfree into separate files"""
+    dir: str = "/opt/intelmq/var/lib/bots/files-output/incoming"  # TODO: could be path
+    hierarchical_output: bool = False
+    keep_raw_field: bool = False
+    message_jsondict_as_string: bool = False
+    message_with_type: bool = False
+    single_key: bool = False
+    suffix: str = ".json"
+    tmp: str = "/opt/intelmq/var/lib/bots/files-output/tmp"  # TODO: could be path
 
     def init(self):
         self.tmp = self._ensure_path(self.tmp)

--- a/intelmq/bots/outputs/mcafee/output_esm_ip.py
+++ b/intelmq/bots/outputs/mcafee/output_esm_ip.py
@@ -21,6 +21,12 @@ except ImportError:
 
 
 class ESMIPOutputBot(Bot):
+    """Write events to the McAfee Enterprise Security Manager (ESM)"""
+    esm_ip: str = "1.2.3.4"  # TODO: should be ipaddress
+    esm_password: str = None
+    esm_user: str = "NGCP"
+    esm_watchlist: str = None
+    field: str = "source.ip"
 
     def init(self):
         if ESM is None:

--- a/intelmq/bots/outputs/misp/output_api.py
+++ b/intelmq/bots/outputs/misp/output_api.py
@@ -78,6 +78,18 @@ MISPOBJECT_NAME = 'intelmq_event'
 
 
 class MISPAPIOutputBot(OutputBot):
+    """Insert events into a MISP instance"""
+    add_feed_name_as_tag: bool = True
+    add_feed_provider_as_tag: bool = True
+    misp_additional_correlation_fields = []
+    misp_additional_tags = []
+    misp_key: str = None
+    misp_publish: bool = False
+    misp_tag_for_bot: str = None
+    misp_to_ids_fields = []
+    misp_url: str = None
+    significant_fields: str = None
+
     is_multithreadable = False
 
     def init(self):

--- a/intelmq/bots/outputs/misp/output_feed.py
+++ b/intelmq/bots/outputs/misp/output_feed.py
@@ -26,11 +26,12 @@ except SyntaxError:
 
 
 class MISPFeedOutputBot(OutputBot):
-    is_multithreadable = False
+    """Generate an output in the MISP Feed format"""
+    interval_event: str = "1 hour"
     misp_org_name = None
     misp_org_uuid = None
-    output_dir = None
-    interval_event = None
+    output_dir: str = "/opt/intelmq/var/lib/bots/mispfeed-output"  # TODO: should be path
+    is_multithreadable: bool = False
 
     @staticmethod
     def check_output_dir(dirname):

--- a/intelmq/bots/outputs/misp/output_feed.py
+++ b/intelmq/bots/outputs/misp/output_feed.py
@@ -27,6 +27,10 @@ except SyntaxError:
 
 class MISPFeedOutputBot(OutputBot):
     is_multithreadable = False
+    misp_org_name = None
+    misp_org_uuid = None
+    output_dir = None
+    interval_event = None
 
     @staticmethod
     def check_output_dir(dirname):
@@ -47,16 +51,16 @@ class MISPFeedOutputBot(OutputBot):
         self.current_event = None
 
         self.misp_org = MISPOrganisation()
-        self.misp_org.name = self.parameters.misp_org_name
-        self.misp_org.uuid = self.parameters.misp_org_uuid
+        self.misp_org.name = self.misp_org_name
+        self.misp_org.uuid = self.misp_org_uuid
 
-        self.output_dir = Path(self.parameters.output_dir)
+        self.output_dir = Path(self.output_dir)
         MISPFeedOutputBot.check_output_dir(self.output_dir)
 
-        if not hasattr(self.parameters, 'interval_event'):
+        if self.interval_event is None:
             self.timedelta = datetime.timedelta(hours=1)
         else:
-            self.timedelta = datetime.timedelta(minutes=parse_relative(self.parameters.interval_event))
+            self.timedelta = datetime.timedelta(minutes=parse_relative(self.interval_event))
 
         if (self.output_dir / '.current').exists():
             with (self.output_dir / '.current').open() as f:

--- a/intelmq/bots/outputs/mongodb/output.py
+++ b/intelmq/bots/outputs/mongodb/output.py
@@ -16,6 +16,17 @@ except ImportError:
 
 class MongoDBOutputBot(Bot):
     client = None
+    replacement_char = '_'
+    username = None
+    db_user = None
+    password = None
+    db_pass = None
+    port = 27017
+    host = None
+    database = None
+    collection = None
+    _collection = None
+    hierarchical_output = False
 
     def init(self):
         if pymongo is None:
@@ -24,13 +35,11 @@ class MongoDBOutputBot(Bot):
         self.pymongo_3 = pymongo.version_tuple >= (3, )
         self.pymongo_35 = pymongo.version_tuple >= (3, 5)
 
-        self.replacement_char = getattr(self.parameters, 'replacement_char', '_')
         if self.replacement_char == '.':
             raise ValueError('replacement_char should be different than .')
 
-        self.username = getattr(self.parameters, "db_user", None)
-        self.password = getattr(self.parameters, "db_pass", None)
-        self.port = int(getattr(self.parameters, "port", 27017))
+        self.username = self.db_user
+        self.password = self.db_pass
         if not self.password:  # checking for username is sufficient then
             self.username = None
 
@@ -38,39 +47,39 @@ class MongoDBOutputBot(Bot):
 
     def connect(self):
         self.logger.debug('Getting server info.')
-        server_info = pymongo.MongoClient(self.parameters.host, self.port).server_info()
+        server_info = pymongo.MongoClient(self.host, self.port).server_info()
         server_version = server_info['version']
         server_version_split = tuple(server_version.split('.'))
         self.logger.debug('Connecting to MongoDB server version %s.',
                           server_version)
         try:
             if self.pymongo_35 and self.username and server_version_split >= ('3', '4'):
-                self.client = pymongo.MongoClient(self.parameters.host,
+                self.client = pymongo.MongoClient(self.host,
                                                   self.port,
                                                   username=self.username,
                                                   password=self.password)
             else:
-                self.client = pymongo.MongoClient(self.parameters.host,
+                self.client = pymongo.MongoClient(self.host,
                                                   self.port)
         except pymongo.errors.ConnectionFailure:
             raise ValueError('Connection to MongoDB server failed.')
         else:
-            db = self.client[self.parameters.database]
+            db = self.client[self.database]
             if self.username and not self.pymongo_35 or server_version_split < ('3', '4'):
                 self.logger.debug('Trying to authenticate to database %s.',
-                                  self.parameters.database)
+                                  self.database)
                 try:
-                    db.authenticate(name=self.parameters.db_user,
-                                    password=self.parameters.db_pass)
+                    db.authenticate(name=self.db_user,
+                                    password=self.db_pass)
                 except pymongo.errors.OperationFailure:
-                    raise ValueError('Authentication to database {} failed'.format(self.parameters.database))
-            self.collection = db[self.parameters.collection]
+                    raise ValueError('Authentication to database {} failed'.format(self.database))
+            self._collection = db[self.collection]
             self.logger.info('Successfully connected to MongoDB server.')
 
     def process(self):
         event = self.receive_message()
 
-        if self.parameters.hierarchical_output:
+        if self.hierarchical_output:
             tmp_dict = event.to_dict(hierarchical=True)
             if "time" in tmp_dict:
                 if "observation" in tmp_dict["time"]:
@@ -90,9 +99,9 @@ class MongoDBOutputBot(Bot):
 
         try:
             if self.pymongo_3:
-                self.collection.insert_one(tmp_dict)
+                self._collection.insert_one(tmp_dict)
             else:
-                self.collection.insert(tmp_dict)
+                self._collection.insert(tmp_dict)
         except pymongo.errors.AutoReconnect:
             self.logger.error('Connection Lost. Connecting again.')
             self.connect()

--- a/intelmq/bots/outputs/mongodb/output.py
+++ b/intelmq/bots/outputs/mongodb/output.py
@@ -15,18 +15,20 @@ except ImportError:
 
 
 class MongoDBOutputBot(Bot):
-    client = None
-    replacement_char = '_'
-    username = None
-    db_user = None
-    password = None
-    db_pass = None
-    port = 27017
-    host = None
-    database = None
+    """Send events to a MongoDB database"""
     collection = None
+    database = None
+    db_pass = None
+    db_user = None
+    hierarchical_output: bool = False
+    host: str = "localhost"
+    port: int = 27017
+    replacement_char = '_'
+
+    client = None
+    username = None
+    password = None
     _collection = None
-    hierarchical_output = False
 
     def init(self):
         if pymongo is None:

--- a/intelmq/bots/outputs/postgresql/output.py
+++ b/intelmq/bots/outputs/postgresql/output.py
@@ -7,13 +7,14 @@ from intelmq.bots.outputs.sql.output import SQLOutputBot
 
 
 class PostgreSQLOutputBot(SQLOutputBot):
+    engine = 'postgresql'
+
     def init(self):
         self.logger.warning("The output bot 'intelmq.bots.outputs.postgresql.output' "
                             "is deprecated and replaced by "
                             "'intelmq.bots.outputs.sql.output' with the parameter "
                             "'engine' = 'postgresql'. "
                             "The fallback compatibility will be removed in version 3.0.")
-        self.parameters.engine = 'postgresql'
         super().init()
 
 

--- a/intelmq/bots/outputs/redis/output.py
+++ b/intelmq/bots/outputs/redis/output.py
@@ -6,13 +6,14 @@ from intelmq.lib.bot import Bot
 
 
 class RedisOutputBot(Bot):
-    redis_server_ip = None
-    redis_server_port = None
-    redis_db = None
-    redis_queue = None
-    redis_password = None
-    redis_timeout = None
+    """Send events to a Redis database"""
     hierarchical_output = False
+    redis_db: int = 2
+    redis_password: str = None
+    redis_queue: str = None
+    redis_server_ip = "127.0.0.1"
+    redis_server_port = 6379
+    redis_timeout = 5000
     with_type = True
 
     def init(self):

--- a/intelmq/bots/outputs/redis/output.py
+++ b/intelmq/bots/outputs/redis/output.py
@@ -6,17 +6,22 @@ from intelmq.lib.bot import Bot
 
 
 class RedisOutputBot(Bot):
+    redis_server_ip = None
+    redis_server_port = None
+    redis_db = None
+    redis_queue = None
+    redis_password = None
+    redis_timeout = None
+    hierarchical_output = False
+    with_type = True
 
     def init(self):
-        self.host = self.parameters.redis_server_ip
-        self.port = int(self.parameters.redis_server_port)
-        self.db = int(self.parameters.redis_db)
-        self.queue = self.parameters.redis_queue
-        self.password = self.parameters.redis_password
-        self.timeout = int(self.parameters.redis_timeout)
-        self.hierarchical_output = getattr(self.parameters,
-                                           "hierarchical_output", False)
-        self.with_type = getattr(self.parameters, "with_type", True)  # backwards compat
+        self.host = self.redis_server_ip
+        self.port = int(self.redis_server_port)
+        self.db = int(self.redis_db)
+        self.queue = self.redis_queue
+        self.password = self.redis_password
+        self.timeout = int(self.redis_timeout)
 
         redis_version = tuple(int(x) for x in redis.__version__.split('.'))
         if redis_version >= (3, 0, 0):

--- a/intelmq/bots/outputs/restapi/output.py
+++ b/intelmq/bots/outputs/restapi/output.py
@@ -11,13 +11,14 @@ from intelmq.lib.exceptions import MissingDependencyError
 
 
 class RestAPIOutputBot(Bot):
-    auth_token_name = None
-    auth_token = None
+    """Send events to a REST API listener through HTTP POST"""
+    auth_token_name: str = None
+    auth_token: str = None
     auth_type = None
+    hierarchical_output: bool = False
+    host: str = None
+    use_json: bool = True
     auth = None
-    use_json = None
-    host = None
-    hierarchical_output = None
 
     def init(self):
         if requests is None:

--- a/intelmq/bots/outputs/restapi/output.py
+++ b/intelmq/bots/outputs/restapi/output.py
@@ -11,6 +11,13 @@ from intelmq.lib.exceptions import MissingDependencyError
 
 
 class RestAPIOutputBot(Bot):
+    auth_token_name = None
+    auth_token = None
+    auth_type = None
+    auth = None
+    use_json = None
+    host = None
+    hierarchical_output = None
 
     def init(self):
         if requests is None:
@@ -18,12 +25,12 @@ class RestAPIOutputBot(Bot):
 
         self.set_request_parameters()
 
-        if self.parameters.auth_token_name and self.parameters.auth_token:
-            if self.parameters.auth_type == 'http_header':
+        if self.auth_token_name and self.auth_token:
+            if self.auth_type == 'http_header':
                 self.http_header.update(
-                    {self.parameters.auth_token_name: self.parameters.auth_token})
-            elif self.parameters.auth_type == 'http_basic_auth':
-                self.auth = self.parameters.auth_token_name, self.parameters.auth_token
+                    {self.auth_token_name: self.auth_token})
+            elif self.auth_type == 'http_basic_auth':
+                self.auth = self.auth_token_name, self.auth_token
         self.http_header.update({"Content-Type":
                                  "application/json; charset=utf-8"})
 
@@ -32,16 +39,16 @@ class RestAPIOutputBot(Bot):
 
     def process(self):
         event = self.receive_message()
-        if self.parameters.use_json:
-            kwargs = {'json': event.to_dict(hierarchical=self.parameters.hierarchical_output)}
+        if self.use_json:
+            kwargs = {'json': event.to_dict(hierarchical=self.hierarchical_output)}
         else:
-            kwargs = {'data': event.to_dict(hierarchical=self.parameters.hierarchical_output)}
+            kwargs = {'data': event.to_dict(hierarchical=self.hierarchical_output)}
 
         timeoutretries = 0
         req = None
         while timeoutretries < self.http_timeout_max_tries and req is None:
             try:
-                req = self.session.post(self.parameters.host,
+                req = self.session.post(self.host,
                                         timeout=self.http_timeout_sec,
                                         **kwargs)
             except requests.exceptions.Timeout:

--- a/intelmq/bots/outputs/smtp/output.py
+++ b/intelmq/bots/outputs/smtp/output.py
@@ -10,21 +10,25 @@ from intelmq.lib.bot import Bot
 
 
 class SMTPOutputBot(Bot):
-    ssl = True
-    starttls = False
-    fieldnames = None
+    """Send single events as CSV attachment in dynamically formatted e-mails via SMTP"""
+    fieldnames: str = "classification.taxonomy,classification.type,classification.identifier,source.ip,source.asn,source.port"
+    mail_from: str = "cert@localhost"
+    mail_to: str = "{ev[source.abuse_contact]}"
+    smtp_host: str = "localhost"
+    smtp_password: str = None
+    smtp_port: int = None
+    smtp_username: str = None
+    ssl: bool = False
+    starttls: bool = False
+    subject: str = "Incident in your AS {ev[source.asn]}"
+    text: str = "Dear network owner,\\n\\nWe have been informed that the following device might have security problems.\\n\\nYour localhost CERT"
+
     username = None
     password = None
     http_verify_cert = True
-    smtp_host = None
-    smtp_port = None
-    text = None
-    subject = None
-    mail_from = None
-    mail_to = None
 
     def init(self):
-        if getattr(self, 'ssl', False):
+        if self.ssl:
             self.smtp_class = smtplib.SMTP_SSL
         else:
             self.smtp_class = smtplib.SMTP

--- a/intelmq/bots/outputs/smtp/output.py
+++ b/intelmq/bots/outputs/smtp/output.py
@@ -10,20 +10,26 @@ from intelmq.lib.bot import Bot
 
 
 class SMTPOutputBot(Bot):
+    ssl = True
+    starttls = False
+    fieldnames = None
+    username = None
+    password = None
+    http_verify_cert = True
+    smtp_host = None
+    smtp_port = None
+    text = None
+    subject = None
+    mail_from = None
+    mail_to = None
 
     def init(self):
-        if getattr(self.parameters, 'ssl', False):
+        if getattr(self, 'ssl', False):
             self.smtp_class = smtplib.SMTP_SSL
         else:
             self.smtp_class = smtplib.SMTP
-        self.starttls = getattr(self.parameters, 'starttls', False)
-        self.fieldnames = getattr(self.parameters, 'fieldnames')
         if isinstance(self.fieldnames, str):
             self.fieldnames = self.fieldnames.split(',')
-        self.username = getattr(self.parameters, 'smtp_username', None)
-        self.password = getattr(self.parameters, 'smtp_password', None)
-        self.http_verify_cert = getattr(self.parameters, 'http_verify_cert',
-                                        True)
 
     def process(self):
         event = self.receive_message()
@@ -42,8 +48,7 @@ class SMTPOutputBot(Bot):
         else:
             kwargs = {}
 
-        with self.smtp_class(self.parameters.smtp_host, self.parameters.smtp_port,
-                             **kwargs) as smtp:
+        with self.smtp_class(self.smtp_host, self.smtp_port, **kwargs) as smtp:
             if self.starttls:
                 if self.http_verify_cert:
                     smtp.starttls(context=ssl.create_default_context())
@@ -52,16 +57,16 @@ class SMTPOutputBot(Bot):
             if self.username and self.password:
                 smtp.login(user=self.username, password=self.password)
             msg = MIMEMultipart()
-            if self.parameters.text:
-                msg.attach(MIMEText(self.parameters.text.format(ev=event)))
+            if self.text is not None:
+                msg.attach(MIMEText(self.text.format(ev=event)))
             msg.attach(MIMEText(attachment, 'csv'))
-            msg['Subject'] = self.parameters.subject.format(ev=event)
-            msg['From'] = self.parameters.mail_from.format(ev=event)
-            msg['To'] = self.parameters.mail_to.format(ev=event)
+            msg['Subject'] = self.subject.format(ev=event)
+            msg['From'] = self.mail_from.format(ev=event)
+            msg['To'] = self.mail_to.format(ev=event)
             recipients = [recipient
                           for recipient
-                          in self.parameters.mail_to.format(ev=event).split(',')]
-            smtp.send_message(msg, from_addr=self.parameters.mail_from,
+                          in self.mail_to.format(ev=event).split(',')]
+            smtp.send_message(msg, from_addr=self.mail_from,
                               to_addrs=recipients)
 
         self.acknowledge_message()

--- a/intelmq/bots/outputs/sql/output.py
+++ b/intelmq/bots/outputs/sql/output.py
@@ -13,11 +13,19 @@ from intelmq.lib.bot import SQLBot
 
 
 class SQLOutputBot(SQLBot):
+    autocommit = True
+    database = "intelmq-events"
+    engine = None
+    host = "localhost"
+    jsondict_as_string = True
+    password = None
+    port = "5432"
+    sslmode = "require"
+    table = 'events'
+    user = "intelmq"
 
     def init(self):
         super().init()
-        self.table = self.parameters.table
-        self.jsondict_as_string = getattr(self.parameters, 'jsondict_as_string', True)
 
     def process(self):
         event = self.receive_message().to_dict(jsondict_as_string=self.jsondict_as_string)

--- a/intelmq/bots/outputs/sql/output.py
+++ b/intelmq/bots/outputs/sql/output.py
@@ -13,6 +13,7 @@ from intelmq.lib.bot import SQLBot
 
 
 class SQLOutputBot(SQLBot):
+    """Send events to a PostgreSQL or SQLite database"""
     autocommit = True
     database = "intelmq-events"
     engine = None

--- a/intelmq/bots/outputs/stomp/output.py
+++ b/intelmq/bots/outputs/stomp/output.py
@@ -12,27 +12,27 @@ except ImportError:
 
 
 class StompOutputBot(OutputBot):
+    """Send events to a STMOP server"""
     """ main class for the STOMP protocol output bot """
+    exchange: str = "/exchange/_push"
+    heartbeat: int = 60000
+    http_verify_cert = True
+    keep_raw_field: bool = False
+    message_hierarchical_output: bool = False
+    message_jsondict_as_string: bool = False
+    message_with_type: bool = False
+    port: int = 61614
+    server: str = "127.0.0.1"  # TODO: could be ip address
+    single_key: bool = False
+    ssl_ca_certificate: str = 'ca.pem'  # TODO: could be pathlib.Path
+    ssl_client_certificate: str = 'client.pem'  # TODO: pathlib.Path
+    ssl_client_certificate_key: str = 'client.key'  # TODO: patlib.Path
 
     conn = None
 
     def init(self):
         if stomp is None:
             raise MissingDependencyError("stomp")
-
-        self.server = getattr(self.parameters, 'server', '127.0.0.1')
-        self.port = getattr(self.parameters, 'port', 61614)
-        self.exchange = getattr(self.parameters, 'exchange', '/exchange/_push')
-        self.heartbeat = getattr(self.parameters, 'heartbeat', 60000)
-        self.ssl_ca_cert = getattr(self.parameters, 'ssl_ca_certificate',
-                                   'ca.pem')
-        self.ssl_cl_cert = getattr(self.parameters, 'ssl_client_certificate',
-                                   'client.pem')
-        self.ssl_cl_cert_key = getattr(self.parameters,
-                                       'ssl_client_certificate_key',
-                                       'client.key')
-        self.http_verify_cert = getattr(self.parameters,
-                                        'http_verify_cert', True)
 
         # check if certificates exist
         for f in [self.ssl_ca_cert, self.ssl_cl_cert, self.ssl_cl_cert_key]:

--- a/intelmq/bots/outputs/tcp/output.py
+++ b/intelmq/bots/outputs/tcp/output.py
@@ -18,10 +18,10 @@ class TCPOutputBot(Bot):
     is_multithreadable = False
 
     def init(self):
-        self.to_intelmq = getattr(self.parameters, "counterpart_is_intelmq", False)
+        self.to_intelmq = getattr(self, "counterpart_is_intelmq", False)
 
-        self.address = (self.parameters.ip, int(self.parameters.port))
-        self.separator = utils.encode(self.parameters.separator) if (hasattr(self.parameters, "separator")) else None
+        self.address = (self.ip, int(self.port))
+        self.separator = utils.encode(self.separator) if (hasattr(self, "separator")) else None
         self.connect()
 
     def recvall(self, conn, n):
@@ -37,7 +37,7 @@ class TCPOutputBot(Bot):
     def process(self):
         event = self.receive_message()
 
-        data = event.to_json(hierarchical=self.parameters.hierarchical_output)
+        data = event.to_json(hierarchical=self.hierarchical_output)
         try:
             while True:
                 if self.separator:

--- a/intelmq/bots/outputs/tcp/output.py
+++ b/intelmq/bots/outputs/tcp/output.py
@@ -14,14 +14,20 @@ from intelmq.lib.bot import Bot
 
 
 class TCPOutputBot(Bot):
+    """Send events to a TCP server as Splunk, ElasticSearch or another IntelMQ etc"""
+    counterpart_is_intelmq: bool = True
+    hierarchical_output: bool = False
+    ip: str = None  # TODO: could ip ipaddress type
+    port: int = None
+    separator: str = None
 
     is_multithreadable = False
 
     def init(self):
-        self.to_intelmq = getattr(self, "counterpart_is_intelmq", False)
+        self.to_intelmq = self.counterpart_is_intelmq
 
         self.address = (self.ip, int(self.port))
-        self.separator = utils.encode(self.separator) if (hasattr(self, "separator")) else None
+        self.separator = utils.encode(self.separator) if self.separator is not None else None
         self.connect()
 
     def recvall(self, conn, n):

--- a/intelmq/bots/outputs/touch/output.py
+++ b/intelmq/bots/outputs/touch/output.py
@@ -11,11 +11,12 @@ from intelmq.lib.bot import Bot
 
 class TouchOutputBot(Bot):
     file = None
+    path = None
 
     def process(self):
         self.receive_message()
         ctime = time.time()
-        os.utime(self.parameters.path, times=(ctime, ctime))
+        os.utime(self.path, times=(ctime, ctime))
         self.acknowledge_message()
 
 

--- a/intelmq/bots/outputs/touch/output.py
+++ b/intelmq/bots/outputs/touch/output.py
@@ -10,6 +10,7 @@ from intelmq.lib.bot import Bot
 
 
 class TouchOutputBot(Bot):
+    """Touch a file for every event received"""
     file = None
     path = None
 

--- a/intelmq/bots/outputs/udp/output.py
+++ b/intelmq/bots/outputs/udp/output.py
@@ -7,17 +7,22 @@ from intelmq.lib.bot import Bot
 
 
 class UDPOutputBot(Bot):
+    """Send events to a UDP server, e.g. a syslog daemon"""
+    field_delimiter: str = "|"
+    format: str = None
+    header: str = "<header text>"
+    keep_raw_field: bool = False
+    udp_host: str = "localhost"
+    udp_port: int = None
 
     is_multithreadable = False
 
     def init(self):
-        self.delimiter = self.parameters.field_delimiter
-        self.header = self.parameters.header
-        self.udp_host = socket.gethostbyname(self.parameters.udp_host)
-        self.upd_address = (self.udp_host, self.parameters.udp_port)
+        self.delimiter = self.field_delimiter
+        self.udp_host = socket.gethostbyname(self.udp_host)
+        self.upd_address = (self.udp_host, self.udp_port)
         self.udp = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-        self.keep_raw_field = bool(self.parameters.keep_raw_field)
-        self.format = self.parameters.format.lower()
+        self.format = self.format.lower()
         if self.format not in ['json', 'delimited']:
             raise ValueError('Unknown format %r given. Check your configuration.' % self.format)
 
@@ -48,7 +53,7 @@ class UDPOutputBot(Bot):
             self.udp.sendto(data, self.upd_address)
         except Exception:
             self.logger.exception('Failed to send message to %s:%s!',
-                                  self.udp_host, self.parameters.udp_port)
+                                  self.udp_host, self.udp_port)
         else:
             self.acknowledge_message()
 

--- a/intelmq/bots/outputs/xmpp/output.py
+++ b/intelmq/bots/outputs/xmpp/output.py
@@ -77,6 +77,18 @@ except ImportError:
 
 
 class XMPPOutputBot(Bot):
+    """Send events to an XMPP server"""
+    ca_certs: str = "/etc/ssl/certs/ca-certificates.crt"
+    hierarchical_output: bool = False
+    use_muc: bool = False
+    xmpp_password: str = "<xmpp password>"
+    xmpp_room: str = None
+    xmpp_room_nick: str = None
+    xmpp_room_password: str = None
+    xmpp_server: str = None
+    xmpp_to_server: str = "<destination server>"
+    xmpp_to_user: str = "<destination username>"
+    xmpp_user: str = None
 
     xmpp = None
 
@@ -88,24 +100,15 @@ class XMPPOutputBot(Bot):
         if sleekxmpp is None:
             raise MissingDependencyError("sleekxmpp")
 
-        # Retrieve Parameters from configuration
-        xmpp_user = getattr(self.parameters, "xmpp_user", None)
-        xmpp_server = getattr(self.parameters, "xmpp_server", None)
-        xmpp_password = getattr(self.parameters, "xmpp_password", None)
-
         if None in (xmpp_user, xmpp_server, xmpp_password):
             raise ValueError('No User / Password provided.')
         else:
             xmpp_login = xmpp_user + '@' + xmpp_server
 
-        self.muc = getattr(self.parameters, "use_muc", None)
-        xmpp_to_user = getattr(self.parameters, "xmpp_to_user", None)
-        xmpp_to_server = getattr(self.parameters, "xmpp_to_server", None)
-        xmpp_room = getattr(self.parameters, "xmpp_room", None) if self.muc else None
-        xmpp_room_nick = getattr(self.parameters, "xmpp_room_nick", None) if self.muc else None
-        xmpp_room_password = getattr(self.parameters, "xmpp_room_password", None) if self.muc else None
-
-        ca_certs = getattr(self.parameters, "ca_certs", None)
+        self.muc = self.use_muc
+        xmpp_room = self.xmpp_room if self.muc else None
+        xmpp_room_nick = self.xmpp_room_nick if self.muc else None
+        xmpp_room_password = self.xmpp_room_password if self.muc else None
 
         # Be sure the receiver was set up
         if not self.muc and None in (xmpp_to_user, xmpp_to_server):
@@ -145,8 +148,7 @@ class XMPPOutputBot(Bot):
     def process(self):
         event = self.receive_message()
 
-        jevent = event.to_json(hierarchical=self.parameters.hierarchical_output,
-                               with_type=True)
+        jevent = event.to_json(hierarchical=self.hierarchical_output, with_type=True)
 
         try:
             # TODO: proper error handling.

--- a/intelmq/bots/parsers/abusech/parser_domain.py
+++ b/intelmq/bots/parsers/abusech/parser_domain.py
@@ -20,6 +20,7 @@ SOURCE_FEEDS = {'https://feodotracker.abuse.ch/blocklist/?download=domainblockli
 
 
 class AbusechDomainParserBot(ParserBot):
+    """Parse Abuse.ch domain feeds"""
     lastgenerated = None
 
     def parse_line(self, line, report):

--- a/intelmq/bots/parsers/abusech/parser_ip.py
+++ b/intelmq/bots/parsers/abusech/parser_ip.py
@@ -32,6 +32,7 @@ FEEDS = {
 
 
 class AbusechIPParserBot(ParserBot):
+    """Parse Abuse.ch IP address feeds"""
     __last_generated_date = None
     __is_comment_line_regex = re.compile(r'^#+.*')
     __date_regex = re.compile(r'[0-9]{4}.[0-9]{2}.[0-9]{2}.[0-9]{2}.[0-9]{2}.[0-9]{2}( UTC)?')

--- a/intelmq/bots/parsers/alienvault/parser.py
+++ b/intelmq/bots/parsers/alienvault/parser.py
@@ -14,6 +14,7 @@ CLASSIFICATION = {
 
 
 class AlienVaultParserBot(ParserBot):
+    """Parse data from the AlienVault API"""
 
     def parse_line(self, row, report):
         values = row.split("#")

--- a/intelmq/bots/parsers/alienvault/parser_otx.py
+++ b/intelmq/bots/parsers/alienvault/parser_otx.py
@@ -19,6 +19,7 @@ HASHES = {
 
 
 class AlienVaultOTXParserBot(ParserBot):
+    """Parse data from the AlienVault OTX API"""
     parse = ParserBot.parse_json
     recover_line = ParserBot.recover_line_json
 

--- a/intelmq/bots/parsers/anubisnetworks/parser.py
+++ b/intelmq/bots/parsers/anubisnetworks/parser.py
@@ -26,11 +26,10 @@ MAP_geo_env_remote_addr = {"country_code": 'source.geolocation.cc',
 
 
 class AnubisNetworksParserBot(Bot):
+    use_malware_familiy_as_classification_identifier = True
 
     def init(self):
-        self.malware_as_identifier = getattr(self.parameters,
-                                             'use_malware_familiy_as_classification_identifier',
-                                             True)
+        self.malware_as_identifier = self.use_malware_familiy_as_classification_identifier
 
     def process(self):
         report = self.receive_message()

--- a/intelmq/bots/parsers/anubisnetworks/parser.py
+++ b/intelmq/bots/parsers/anubisnetworks/parser.py
@@ -26,6 +26,7 @@ MAP_geo_env_remote_addr = {"country_code": 'source.geolocation.cc',
 
 
 class AnubisNetworksParserBot(Bot):
+    """Parse single JSON-events from AnubisNetworks Cyberfeed stream"""
     use_malware_familiy_as_classification_identifier = True
 
     def init(self):

--- a/intelmq/bots/parsers/autoshun/parser.py
+++ b/intelmq/bots/parsers/autoshun/parser.py
@@ -15,6 +15,7 @@ TAXONOMY = {
 
 
 class AutoshunParserBot(ParserBot):
+    """Parse the Autoshun feed"""
 
     def parse(self, report):
         raw_report = utils.base64_decode(report.get("raw"))

--- a/intelmq/bots/parsers/blocklistde/parser.py
+++ b/intelmq/bots/parsers/blocklistde/parser.py
@@ -68,6 +68,7 @@ MAPPING = {
 
 
 class BlockListDEParserBot(ParserBot):
+    "Parse the Blocklist.DE feeds"
 
     def parse_line(self, line, report):
         path = urlparse(report['feed.url']).path

--- a/intelmq/bots/parsers/blueliv/parser_crimeserver.py
+++ b/intelmq/bots/parsers/blueliv/parser_crimeserver.py
@@ -18,6 +18,7 @@ TYPES = {
 
 
 class BluelivCrimeserverParserBot(Bot):
+    """Parse data from the Blueliv Crimeserver API"""
 
     def process(self):
         report = self.receive_message()

--- a/intelmq/bots/parsers/calidog/parser_certstream.py
+++ b/intelmq/bots/parsers/calidog/parser_certstream.py
@@ -10,6 +10,7 @@ from intelmq.lib.utils import base64_decode
 
 
 class CertStreamParserBot(ParserBot):
+    """Parse the CertStream feed"""
 
     def parse(self, report):
         raw = base64_decode(report['raw'])

--- a/intelmq/bots/parsers/cert_eu/parser_csv.py
+++ b/intelmq/bots/parsers/cert_eu/parser_csv.py
@@ -15,6 +15,7 @@ from intelmq.lib.harmonization import DateTime
 
 
 class CertEUCSVParserBot(ParserBot):
+    """Parse CSV data of the CERT-EU feed"""
 
     abuse_to_intelmq = defaultdict(lambda: "other", {
         "backdoor": "backdoor",

--- a/intelmq/bots/parsers/ci_army/parser.py
+++ b/intelmq/bots/parsers/ci_army/parser.py
@@ -5,6 +5,7 @@ from intelmq.lib.bot import Bot
 
 
 class CIArmyParserBot(Bot):
+    """Parse the CI Army feed"""
 
     def process(self):
 

--- a/intelmq/bots/parsers/cleanmx/parser.py
+++ b/intelmq/bots/parsers/cleanmx/parser.py
@@ -69,6 +69,7 @@ VIRUS = OrderedDict([
 
 
 class CleanMXParserBot(ParserBot):
+    """Parse the CleanMX feeds"""
 
     def get_mapping_and_type(self, url):
 

--- a/intelmq/bots/parsers/cymru/parser_cap_program.py
+++ b/intelmq/bots/parsers/cymru/parser_cap_program.py
@@ -48,6 +48,7 @@ DESTINATION_PORT_NUMBERS_TOTAL = re.compile(r' \(total_count:\d+\)$')
 
 
 class CymruCAPProgramParserBot(ParserBot):
+    """Parse the Cymru CAP Program feed"""
 
     def parse(self, report):
         lines = utils.base64_decode(report.get("raw")).splitlines()

--- a/intelmq/bots/parsers/cymru/parser_full_bogons.py
+++ b/intelmq/bots/parsers/cymru/parser_full_bogons.py
@@ -6,6 +6,7 @@ from intelmq.lib.bot import ParserBot
 
 
 class CymruFullBogonsParserBot(ParserBot):
+    """Parse the Cymru Full Bogons feed"""
 
     def parse(self, report):
         raw_report = utils.base64_decode(report.get("raw")).strip()

--- a/intelmq/bots/parsers/cznic/parser_haas.py
+++ b/intelmq/bots/parsers/cznic/parser_haas.py
@@ -5,6 +5,7 @@ from intelmq.lib.bot import ParserBot
 
 
 class CZNICHaasParserBot(ParserBot):
+    """CZ.NIC HaaS Parser is the bot responsible to parse the report and sanitize the information"""
 
     parse = ParserBot.parse_json
     recover_line = ParserBot.recover_line_json

--- a/intelmq/bots/parsers/cznic/parser_proki.py
+++ b/intelmq/bots/parsers/cznic/parser_proki.py
@@ -6,6 +6,7 @@ from intelmq.lib.bot import ParserBot
 
 
 class CZNICProkiParserBot(ParserBot):
+    """Parse the feed from malicious IP addresses on Czech networks"""
 
     recover_line = ParserBot.recover_line_json
 

--- a/intelmq/bots/parsers/danger_rulez/parser.py
+++ b/intelmq/bots/parsers/danger_rulez/parser.py
@@ -9,6 +9,7 @@ REGEX_TIMESTAMP = "# ([^ \t]+ [^ \t]+)"
 
 
 class BruteForceBlockerParserBot(Bot):
+    """Parse the Danger Rulez feed"""
 
     def process(self):
         report = self.receive_message()

--- a/intelmq/bots/parsers/dataplane/parser.py
+++ b/intelmq/bots/parsers/dataplane/parser.py
@@ -6,6 +6,7 @@ from intelmq.lib.message import Event
 
 
 class DataplaneParserBot(ParserBot):
+    """Parse the Dataplane feeds"""
     CATEGORY = {
         'sipquery': {
             'classification.type': 'brute-force',

--- a/intelmq/bots/parsers/dshield/parser_asn.py
+++ b/intelmq/bots/parsers/dshield/parser_asn.py
@@ -18,6 +18,7 @@ from intelmq.lib.bot import Bot
 
 
 class DShieldASNParserBot(Bot):
+    """Parse the DShield AS"""
 
     def process(self):
         report = self.receive_message()

--- a/intelmq/bots/parsers/dshield/parser_block.py
+++ b/intelmq/bots/parsers/dshield/parser_block.py
@@ -27,6 +27,7 @@ from intelmq.lib.bot import Bot
 
 
 class DshieldBlockParserBot(Bot):
+    """Parse the DShield Block feed"""
 
     def process(self):
         report = self.receive_message()

--- a/intelmq/bots/parsers/dshield/parser_domain.py
+++ b/intelmq/bots/parsers/dshield/parser_domain.py
@@ -18,6 +18,7 @@ from intelmq.lib.bot import Bot
 
 
 class DshieldDomainParserBot(Bot):
+    """Parse the DShield Suspicious Domains feed"""
 
     def process(self):
         report = self.receive_message()

--- a/intelmq/bots/parsers/dyn/parser.py
+++ b/intelmq/bots/parsers/dyn/parser.py
@@ -12,6 +12,7 @@ from intelmq.lib.bot import Bot
 
 
 class DynParserBot(Bot):
+    """Parse the DynDNS ponmocup feed"""
 
     def init(self):
         self.TZOFFSETS = {'PST': -8 * 60 * 60,

--- a/intelmq/bots/parsers/eset/parser.py
+++ b/intelmq/bots/parsers/eset/parser.py
@@ -12,6 +12,7 @@ message_taxonomy_map = {
 
 
 class ESETParserBot(ParserBot):
+    """Parse data collected from ESET's TAXII API"""
     def init(self):
         self.f_map = {
             'ei.urls (json)': self.urls_parse,

--- a/intelmq/bots/parsers/fraunhofer/parser_dga.py
+++ b/intelmq/bots/parsers/fraunhofer/parser_dga.py
@@ -18,6 +18,7 @@ __all__ = ['FraunhoferDGAParserBot']
 
 
 class FraunhoferDGAParserBot(Bot):
+    """Parse the Fraunhofer DGA feed"""
 
     def process(self):
         report = self.receive_message()

--- a/intelmq/bots/parsers/generic/parser_csv.py
+++ b/intelmq/bots/parsers/generic/parser_csv.py
@@ -34,19 +34,20 @@ DOCS = "https://intelmq.readthedocs.io/en/latest/guides/Bots.html#generic-csv-pa
 
 
 class GenericCsvParserBot(ParserBot):
-    columns = None
-    type_translation = {}
-    data_type = None
+    """Parse generic CSV data. Ignoring lines starting with character #. URLs without protocol can be prefixed with a default value."""
     column_regex_search = None
-    time_format = None
+    columns = None
+    compose_fields = {}
+    columns_required = None
+    data_type = None
+    default_url_protocol = ''
+    delimiter = ''
     filter_text = None
     filter_type = None
-    columns_required = None
-    compose_fields = {}
-    skip_header = False
-    delimiter = ''
-    default_url_protocol = ''
+    time_format = None
     type = None
+    type_translation = {}
+    skip_header = False
 
     def init(self):
         # convert columns to an array

--- a/intelmq/bots/parsers/github_feed/parser.py
+++ b/intelmq/bots/parsers/github_feed/parser.py
@@ -24,6 +24,7 @@ HASH_VALIDATORS = {
 
 
 class GithubFeedParserBot(Bot):
+    """Parse known GitHub feeds"""
 
     def init(self):
         if validators is None:

--- a/intelmq/bots/parsers/hibp/parser_callback.py
+++ b/intelmq/bots/parsers/hibp/parser_callback.py
@@ -12,6 +12,7 @@ from intelmq.lib.utils import base64_decode
 
 
 class HIBPCallbackParserBot(ParserBot):
+    """Parse reports of the 'Have I Been Pwned' Callback for Enterprise Subscribers"""
     def recover_line(self, line):
         return json.dumps(line, sort_keys=True)
 

--- a/intelmq/bots/parsers/html_table/parser.py
+++ b/intelmq/bots/parsers/html_table/parser.py
@@ -31,6 +31,7 @@ except ImportError:
 
 
 class HTMLTableParserBot(Bot):
+    """Parse HTML table data"""
     attribute_name = ""
     attribute_value = ""
     columns = ["", "source.fqdn"]

--- a/intelmq/bots/parsers/json/parser.py
+++ b/intelmq/bots/parsers/json/parser.py
@@ -12,6 +12,7 @@ from intelmq.lib.utils import base64_decode
 
 
 class JSONParserBot(Bot):
+    """Parse IntelMQ-JSON data"""
     splitlines = False
 
     def process(self):

--- a/intelmq/bots/parsers/json/parser.py
+++ b/intelmq/bots/parsers/json/parser.py
@@ -12,10 +12,11 @@ from intelmq.lib.utils import base64_decode
 
 
 class JSONParserBot(Bot):
+    splitlines = False
 
     def process(self):
         report = self.receive_message()
-        if getattr(self.parameters, 'splitlines', False):
+        if self.splitlines:
             lines = base64_decode(report['raw']).splitlines()
         else:
             lines = [base64_decode(report['raw'])]

--- a/intelmq/bots/parsers/key_value/parser.py
+++ b/intelmq/bots/parsers/key_value/parser.py
@@ -39,14 +39,14 @@ from dateutil.parser import parse
 
 
 class KeyValueParserBot(ParserBot):
+    pair_separator = ' '
+    kv_separator = '='
+    keys = {}
+    strip_quotes = True
 
     def init(self):
-        self.pair_separator = getattr(self.parameters, 'pair_separator', ' ')
-        self.kv_separator = getattr(self.parameters, 'kv_separator', '=')
-        self.keys = getattr(self.parameters, 'keys', {})
         if not self.keys:
             raise ConfigurationError('Key extraction', 'No keys specified.')
-        self.strip_quotes = getattr(self.parameters, "strip_quotes", True)
 
     def parse_line(self, row, report):
         event = self.new_event(report)

--- a/intelmq/bots/parsers/key_value/parser.py
+++ b/intelmq/bots/parsers/key_value/parser.py
@@ -39,10 +39,12 @@ from dateutil.parser import parse
 
 
 class KeyValueParserBot(ParserBot):
-    pair_separator = ' '
-    kv_separator = '='
+    """Parse key=value strings"""
     keys = {}
+    kv_separator = '='
+    pair_separator = ' '
     strip_quotes = True
+    timestamp_key = None  # TODO: that seems to be legacy
 
     def init(self):
         if not self.keys:

--- a/intelmq/bots/parsers/malc0de/parser.py
+++ b/intelmq/bots/parsers/malc0de/parser.py
@@ -7,6 +7,7 @@ from intelmq.lib.bot import ParserBot
 
 
 class Malc0deParserBot(ParserBot):
+    """Parse the Malc0de IP feed in either IP Blacklist, Windows Format or Bind format"""
 
     WINDOWS_FORMAT = {'http://malc0de.com/bl/BOOT',
                       'https://malc0de.com/bl/BOOT'}

--- a/intelmq/bots/parsers/malwaredomainlist/parser.py
+++ b/intelmq/bots/parsers/malwaredomainlist/parser.py
@@ -5,6 +5,7 @@ from intelmq.lib.bot import ParserBot
 
 
 class MalwareDomainListParserBot(ParserBot):
+    """Parse the Malware Domain List feed"""
     def add_http(self, url):
         """
         We can assume here, that everything is http by default if not given.

--- a/intelmq/bots/parsers/malwaredomains/parser.py
+++ b/intelmq/bots/parsers/malwaredomains/parser.py
@@ -11,6 +11,7 @@ from intelmq.lib.bot import Bot
 
 
 class MalwareDomainsParserBot(Bot):
+    """Parse the Malware Domains feed"""
 
     def is_valid_date(self, strd):
         try:

--- a/intelmq/bots/parsers/malwarepatrol/parser_dansguardian.py
+++ b/intelmq/bots/parsers/malwarepatrol/parser_dansguardian.py
@@ -6,6 +6,7 @@ from intelmq.lib.bot import ParserBot
 
 
 class DansParserBot(ParserBot):
+    """Parse the MalwarePatrol Dans Guardian feed"""
     sourcetime = None
 
     def parse(self, report):

--- a/intelmq/bots/parsers/malwareurl/parser.py
+++ b/intelmq/bots/parsers/malwareurl/parser.py
@@ -26,6 +26,7 @@ parser = MyHTMLParser()
 
 
 class MalwareurlParserBot(Bot):
+    """Parse the MalwareURL feed"""
     def process(self):
         report = self.receive_message()
         raw_report = utils.base64_decode(report["raw"])

--- a/intelmq/bots/parsers/mcafee/parser_atd.py
+++ b/intelmq/bots/parsers/mcafee/parser_atd.py
@@ -19,6 +19,7 @@ from intelmq.lib.bot import Bot
 
 
 class ATDParserBot(Bot):
+    verdict_severity = None
 
     ATD_TYPE_MAPPING = {
         'domain': 'source.fqdn',
@@ -43,7 +44,7 @@ class ATDParserBot(Bot):
         subject_sha256 = atd_event['Summary']['Subject']['sha-256']
         verdict_severity = int(atd_event['Summary']['Verdict']['Severity'])
 
-        if (verdict_severity >= int(self.parameters.verdict_severity)):
+        if (verdict_severity >= int(self.verdict_severity)):
 
             # forward initial sample hashes
             event = self.new_event(report)

--- a/intelmq/bots/parsers/mcafee/parser_atd.py
+++ b/intelmq/bots/parsers/mcafee/parser_atd.py
@@ -19,6 +19,7 @@ from intelmq.lib.bot import Bot
 
 
 class ATDParserBot(Bot):
+    """Parse IoCs from McAfee Advanced Threat Defense reports (hash, IP, URL)"""
     verdict_severity = None
 
     ATD_TYPE_MAPPING = {

--- a/intelmq/bots/parsers/microsoft/parser_bingmurls.py
+++ b/intelmq/bots/parsers/microsoft/parser_bingmurls.py
@@ -25,6 +25,7 @@ MAPPING = {"Attributable": "extra.attributable",
 
 
 class MicrosoftCTIPParserBot(ParserBot):
+    """Parse JSON data from Microsoft's Bing Malicious URLs list"""
 
     parse = ParserBot.parse_json
 

--- a/intelmq/bots/parsers/microsoft/parser_ctip.py
+++ b/intelmq/bots/parsers/microsoft/parser_ctip.py
@@ -170,6 +170,7 @@ CONFIDENCE = {
 
 
 class MicrosoftCTIPParserBot(ParserBot):
+    """Parse JSON data from Microsoft's CTIP program"""
 
     def parse(self, report):
         raw_report = utils.base64_decode(report.get("raw"))

--- a/intelmq/bots/parsers/misp/parser.py
+++ b/intelmq/bots/parsers/misp/parser.py
@@ -8,6 +8,7 @@ from intelmq.lib.bot import Bot
 
 
 class MISPParserBot(Bot):
+    """Parse MISP events"""
 
     # Taxonomy library from ecsirt (default in MISP)
     # Mapping to the IntelMQ taxonomy

--- a/intelmq/bots/parsers/n6/parser_n6stomp.py
+++ b/intelmq/bots/parsers/n6/parser_n6stomp.py
@@ -66,6 +66,7 @@ mapping['other']        = {"taxonomy": "other",
 
 
 class N6StompParserBot(Bot):
+    """Parse CERT.pl's n6 feed"""
 
     def process(self):
         report = self.receive_message()

--- a/intelmq/bots/parsers/netlab_360/parser.py
+++ b/intelmq/bots/parsers/netlab_360/parser.py
@@ -6,6 +6,7 @@ from intelmq.lib.harmonization import DateTime
 
 
 class Netlab360ParserBot(ParserBot):
+    """Parse the Netlab 360 DGA, Hajime, Magnitude and Mirai feeds"""
     DGA_FEED = {'http://data.netlab.360.com/feeds/dga/dga.txt',
                 'https://data.netlab.360.com/feeds/dga/dga.txt'}
     MAGNITUDE_FEED = {'http://data.netlab.360.com/feeds/ek/magnitude.txt',

--- a/intelmq/bots/parsers/openphish/parser.py
+++ b/intelmq/bots/parsers/openphish/parser.py
@@ -5,6 +5,7 @@ from intelmq.lib.bot import Bot
 
 
 class OpenPhishParserBot(Bot):
+    """Parse the OpenPhish feed"""
 
     def process(self):
         report = self.receive_message()

--- a/intelmq/bots/parsers/openphish/parser_commercial.py
+++ b/intelmq/bots/parsers/openphish/parser_commercial.py
@@ -7,6 +7,7 @@ from intelmq.lib.bot import Bot
 
 
 class OpenPhishCommercialParserBot(Bot):
+    """Parse the OpenPhish feed"""
 
     def process(self):
         report = self.receive_message()

--- a/intelmq/bots/parsers/phishtank/parser.py
+++ b/intelmq/bots/parsers/phishtank/parser.py
@@ -7,6 +7,7 @@ from intelmq.lib.bot import Bot
 
 
 class PhishTankParserBot(Bot):
+    """Parse the PhishTank feed"""
 
     def process(self):
         report = self.receive_message()

--- a/intelmq/bots/parsers/shadowserver/parser.py
+++ b/intelmq/bots/parsers/shadowserver/parser.py
@@ -26,6 +26,7 @@ from intelmq.lib.exceptions import InvalidKey, InvalidValue
 
 
 class ShadowserverParserBot(ParserBot):
+    """Parse all ShadowServer feeds"""
 
     recover_line = ParserBot.recover_line_csv_dict
     csv_params = {'dialect': 'unix'}

--- a/intelmq/bots/parsers/shadowserver/parser.py
+++ b/intelmq/bots/parsers/shadowserver/parser.py
@@ -33,10 +33,10 @@ class ShadowserverParserBot(ParserBot):
     sparser_config = None
     feedname = None
     mode = None
+    overwrite = False
 
     def init(self):
-        if getattr(self.parameters, 'feedname', None):
-            self.feedname = self.parameters.feedname
+        if self.feedname is not None:
             self.sparser_config = config.get_feed_by_feedname(self.feedname)
             if self.sparser_config:
                 self.logger.info('Using fixed feed name %r for parsing reports.' % self.feedname)
@@ -48,13 +48,6 @@ class ShadowserverParserBot(ParserBot):
                 self.mode = 'detect'
         else:
             self.mode = 'detect'
-
-        # Set a switch if the parser shall reset the feed.name,
-        #  for this event
-        self.overwrite = False
-        if hasattr(self.parameters, 'overwrite'):
-            if self.parameters.overwrite:
-                self.overwrite = True
 
     def parse(self, report):
         if self.mode == 'fixed':

--- a/intelmq/bots/parsers/shadowserver/parser_json.py
+++ b/intelmq/bots/parsers/shadowserver/parser_json.py
@@ -14,7 +14,7 @@ import intelmq.lib.message as libmessage
 
 
 class ShadowserverJSONParserBot(ParserBot):
-    """
+    """Parse all Shadowserver feeds in JSON format (data coming from the reports API)
     Shadowserver JSON Parser
 
     Parameters
@@ -28,6 +28,7 @@ class ShadowserverJSONParserBot(ParserBot):
     feedname = None
     sparser_config = None
     recover_line = ParserBot.recover_line_json
+    overwrite = True
 
     def init(self):
         if self.feedname is not None:

--- a/intelmq/bots/parsers/shadowserver/parser_json.py
+++ b/intelmq/bots/parsers/shadowserver/parser_json.py
@@ -30,8 +30,8 @@ class ShadowserverJSONParserBot(ParserBot):
     recover_line = ParserBot.recover_line_json
 
     def init(self):
-        if getattr(self.parameters, 'feedname', None):
-            feedname = self.parameters.feedname
+        if self.feedname is not None:
+            feedname = self.feedname
             self.sparser_config = config.get_feed_by_feedname(feedname)
             if self.sparser_config:
                 self.logger.info('Using fixed feed name %r for parsing reports.', feedname)

--- a/intelmq/bots/parsers/shodan/parser.py
+++ b/intelmq/bots/parsers/shodan/parser.py
@@ -138,6 +138,7 @@ CONVERSIONS = {
 
 
 class ShodanParserBot(Bot):
+    """Parse Shodan data collected via the Shodan API"""
     ignore_errors = True
     minimal_mode = False
 

--- a/intelmq/bots/parsers/shodan/parser.py
+++ b/intelmq/bots/parsers/shodan/parser.py
@@ -138,16 +138,8 @@ CONVERSIONS = {
 
 
 class ShodanParserBot(Bot):
-
-    def init(self):
-        if getattr(self.parameters, 'ignore_errors', True):
-            self.ignore_errors = True
-        else:
-            self.ignore_errors = False
-        if getattr(self.parameters, 'minimal_mode', False):
-            self.minimal_mode = True
-        else:
-            self.minimal_mode = False
+    ignore_errors = True
+    minimal_mode = False
 
     def apply_mapping(self, mapping, data):
         self.logger.debug('Applying mapping %r to data %r.', mapping, data)

--- a/intelmq/bots/parsers/spamhaus/parser_cert.py
+++ b/intelmq/bots/parsers/spamhaus/parser_cert.py
@@ -30,6 +30,7 @@ __all__ = ['SpamhausCERTParserBot']
 
 
 class SpamhausCERTParserBot(ParserBot):
+    """Parse the Spamhaus CERT feed"""
 
     def parse_line(self, row, report):
         if not len(row) or row.startswith(';'):

--- a/intelmq/bots/parsers/spamhaus/parser_drop.py
+++ b/intelmq/bots/parsers/spamhaus/parser_drop.py
@@ -7,6 +7,7 @@ from intelmq.lib.bot import ParserBot
 
 
 class SpamhausDropParserBot(ParserBot):
+    """Parse the Spamhaus DROP, EDROP, DROPv6, and ASN-DROP feeds"""
     """ Spamhaus Drop Parser Bot """
 
     NETWORK_DROP_URLS = {'https://www.spamhaus.org/drop/edrop.txt',

--- a/intelmq/bots/parsers/sucuri/parser.py
+++ b/intelmq/bots/parsers/sucuri/parser.py
@@ -22,6 +22,7 @@ remove_comments = re.compile(r"<!--(.|\s|\n)*?-->")
 
 
 class SucuriParserBot(Bot):
+    """Parse the Sucuri Malware Hidden Iframes and Conditional redirections feeds"""
     def process(self):
         report = self.receive_message()
         raw_report = utils.base64_decode(report["raw"])  # decoding

--- a/intelmq/bots/parsers/surbl/parser.py
+++ b/intelmq/bots/parsers/surbl/parser.py
@@ -4,6 +4,7 @@ from intelmq.lib.bot import Bot
 
 
 class SurblParserBot(Bot):
+    """Parse the Surbl feed"""
     def process(self):
         report = self.receive_message()
         raw_report = utils.base64_decode(report["raw"])  # decoding

--- a/intelmq/bots/parsers/taichung/parser.py
+++ b/intelmq/bots/parsers/taichung/parser.py
@@ -30,6 +30,7 @@ CLASSIFICATION = {
 
 
 class TaichungNetflowRecentParserBot(ParserBot):
+    """Parse the Taichung feed"""
 
     def get_type(self, value):
         value = value.lower()

--- a/intelmq/bots/parsers/threatminer/parser.py
+++ b/intelmq/bots/parsers/threatminer/parser.py
@@ -24,6 +24,7 @@ parser = MyHTMLParser()
 
 
 class ThreatminerParserBot(Bot):
+    """Parse the Threatminer feed"""
     def process(self):
         report = self.receive_message()
         raw_report = utils.base64_decode(report["raw"])

--- a/intelmq/bots/parsers/turris/parser.py
+++ b/intelmq/bots/parsers/turris/parser.py
@@ -7,6 +7,7 @@ from intelmq.lib.bot import Bot
 
 
 class TurrisGreylistParserBot(Bot):
+    """Parse the Turris Greylist feed"""
 
     def process(self):
         report = self.receive_message()

--- a/intelmq/bots/parsers/twitter/parser.py
+++ b/intelmq/bots/parsers/twitter/parser.py
@@ -41,6 +41,7 @@ except ImportError:
 
 
 class TwitterParserBot(Bot):
+    """Parse tweets and extract IoC data. Currently only URLs are supported, a whitelist of safe domains can be provided"""
     access_token_key = ""
     access_token_secret = ""
     consumer_key = ""

--- a/intelmq/bots/parsers/vxvault/parser.py
+++ b/intelmq/bots/parsers/vxvault/parser.py
@@ -6,6 +6,7 @@ from intelmq.lib.bot import ParserBot
 
 
 class VXVaultParserBot(ParserBot):
+    """Parse the VXVault feed"""
 
     def parse(self, report):
         report_split = utils.base64_decode(report["raw"]).strip().splitlines()

--- a/intelmq/bots/parsers/webinspektor/parser.py
+++ b/intelmq/bots/parsers/webinspektor/parser.py
@@ -22,6 +22,7 @@ parser = MyHTMLParser()
 
 
 class WebinspektorParserBot(Bot):
+    """Parse the Web Inspektor"""
     def process(self):
         report = self.receive_message()
         raw_report = utils.base64_decode(report["raw"])

--- a/intelmq/bots/parsers/zoneh/parser.py
+++ b/intelmq/bots/parsers/zoneh/parser.py
@@ -8,6 +8,7 @@ from intelmq.lib.bot import ParserBot
 
 
 class ZoneHParserBot(ParserBot):
+    """Parse the ZoneH CSV feed"""
     recover_line = ParserBot.recover_line
     parse = ParserBot.parse_csv_dict
 

--- a/intelmq/lib/bot.py
+++ b/intelmq/lib/bot.py
@@ -1163,6 +1163,7 @@ class CollectorBot(Bot):
     """
 
     is_multithreadable = False
+    provider = None
 
     def __init__(self, bot_id: str, start: bool = False, sighup_event=None,
                  disable_multithreading: bool = None):

--- a/intelmq/tests/bots/collectors/tcp/test_collector.py
+++ b/intelmq/tests/bots/collectors/tcp/test_collector.py
@@ -133,7 +133,7 @@ class TestTCPCollectorBot(test.BotTestCase, unittest.TestCase):
 
         def chunked_process_replacement(self):
             event = self.receive_message()
-            data = event.to_json(hierarchical=self.parameters.hierarchical_output)
+            data = event.to_json(hierarchical=self.hierarchical_output)
             d = utils.encode(data)
             msg = struct.pack('>I', len(d)) + d
             chunk_length = 40

--- a/intelmq/tests/lib/test_bot_output.py
+++ b/intelmq/tests/lib/test_bot_output.py
@@ -24,7 +24,7 @@ class DummyOutputBot(OutputBot):
 
     def process(self):
         event = self.receive_message()
-        self.result = self.export_event(event, return_type=self.parameters.return_type)
+        self.result = self.export_event(event, return_type=self.return_type)
 
 
 class TestDummyOutputBot(BotTestCase, TestCase):

--- a/intelmq/tests/lib/test_collector_bot.py
+++ b/intelmq/tests/lib/test_collector_bot.py
@@ -26,7 +26,7 @@ class DummyCollectorBot(bot.CollectorBot):
 
     def process(self):
         report = self.new_report()
-        if self.parameters.raw:
+        if self.raw:
             report['raw'] = 'test'
         self.send_message(report)
 

--- a/intelmq/tests/lib/test_parser_bot.py
+++ b/intelmq/tests/lib/test_parser_bot.py
@@ -74,7 +74,7 @@ class DummyParserBot(bot.ParserBot):
     """
 
     def parse_line(self, line, report):
-        if getattr(self.parameters, 'raise_warning', False):
+        if getattr(self, 'raise_warning', False):
             warnings.warn('This is a warning test.')
         if line.startswith('#'):
             self.logger.info('Lorem ipsum dolor sit amet.')

--- a/intelmq/tests/lib/test_pipeline.py
+++ b/intelmq/tests/lib/test_pipeline.py
@@ -32,11 +32,9 @@ class Parameters(object):
 class TestPipeline(unittest.TestCase):
 
     def setUp(self):
-        params = Parameters()
         logger = logging.getLogger('foo')
         logger.addHandler(logging.NullHandler())
-        self.pipe = pipeline.PipelineFactory.create(params,
-                                                    logger=logger)
+        self.pipe = pipeline.PipelineFactory.create(logger=logger)
         self.pipe.set_queues('test-bot-input', 'source')
 
     def test_creation_from_string(self):
@@ -60,12 +58,9 @@ class TestPipeline(unittest.TestCase):
 class TestPythonlist(unittest.TestCase):
 
     def setUp(self):
-        params = Parameters()
-        params.broker = 'Pythonlist'
         logger = logging.getLogger('foo')
         logger.addHandler(logging.NullHandler())
-        self.pipe = pipeline.PipelineFactory.create(params,
-                                                    logger=logger)
+        self.pipe = pipeline.PipelineFactory.create(logger=logger, broker='Pythonlist')
         self.pipe.set_queues('test-bot-input', 'source')
         self.pipe.set_queues('test-bot-output', 'destination')
 
@@ -142,7 +137,6 @@ class TestRedis(unittest.TestCase):
 
     def setUp(self):
         params = Parameters()
-        params.broker = 'Redis'
         setattr(params, 'source_pipeline_host', os.getenv('INTELMQ_PIPELINE_HOST', 'localhost'))
         setattr(params, 'source_pipeline_password', os.getenv('INTELMQ_TEST_REDIS_PASSWORD'))
         setattr(params, 'source_pipeline_db', 4)
@@ -151,8 +145,7 @@ class TestRedis(unittest.TestCase):
         setattr(params, 'destination_pipeline_db', 4)
         logger = logging.getLogger('foo')
         logger.addHandler(logging.NullHandler())
-        self.pipe = pipeline.PipelineFactory.create(params,
-                                                    logger)
+        self.pipe = pipeline.PipelineFactory.create(logger, broker='Redis', pipeline_args=params)
         self.pipe.set_queues('test', 'source')
         self.pipe.set_queues('test', 'destination')
         self.pipe.connect()
@@ -217,12 +210,9 @@ class TestRedis(unittest.TestCase):
 class TestAmqp(unittest.TestCase):
 
     def setUp(self):
-        params = Parameters()
-        params.broker = 'Amqp'
         logger = logging.getLogger('foo')
         logger.addHandler(logging.NullHandler())
-        self.pipe = pipeline.PipelineFactory.create(params,
-                                                    logger=logger)
+        self.pipe = pipeline.PipelineFactory.create(logger=logger, broker='Amqp')
         self.pipe.set_queues('test', 'source')
         self.pipe.set_queues('test', 'destination')
         self.pipe.connect()


### PR DESCRIPTION
These commits replace the 'parameters' dict that was used to handle the configuration of bots. The values are now set using class variables and the defaults are set in the relevant parts of the code, but can be easily overridden using environment variables or configuration file.
The followup commits move the values from the `BOTS` file to the respective bot classes.

(I'll try to rebase once in a while)