### PR TITLE
MAINT: drop unused copyright file

### DIFF
--- a/intelmq/bots/collectors/alienvault_otx/COPYRIGHT.md
+++ b/intelmq/bots/collectors/alienvault_otx/COPYRIGHT.md
@@ -1,2 +1,0 @@
-Contents of the file "OTXv2.py" are licensed under the Apache license and originally taken from AlienVault Labs: https://github.com/AlienVault-Labs/OTX-Python-SDK
-Complete license TERMS AND CONDITIONS: https://github.com/AlienVault-Labs/OTX-Python-SDK/blob/master/LICENSE


### PR DESCRIPTION
The OTXv2.py file is not shipped with IntelMQ anymore, therefore its
copyright file should not be part of IntelMQ, too.
