### PR TITLE
[FIX] HTTP Stream Collector better error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,9 @@ IntelMQ no longer supports Python 3.5 (and thus Debian 9 and Ubuntu 16.04), the 
   - If status code is not 2xx, the request's and response's headers and body are logged in debug logging level (#1615).
 - `intelmq.bots.collectors.kafka.collector`: Added (PR#1654 by Birger Schacht, closes #1634)
 - `intelmq.bots.collectors.xmpp.collector`: Marked as deprecated, see https://lists.cert.at/pipermail/intelmq-users/2020-October/000177.html (#1614, PR#1685 by Birger Schacht).
-- `intelmq.bots.collectors.shadowserver.collector_api`: Added (PR#1700 by Birger Schacht, closes #1683)
+- `intelmq.bots.collectors.shadowserver.collector_api`: Added (PR#1700 by Birger Schacht, closes #1683).
+- `intelmq.bots.collectors.http.collector_http_stream`: Retry on common connection issues without raising exceptions (#1435, PR#1747 by Sebastian Waldbauer and Sebastian Wagner).
+- `intelmq.bots.collectors.shodan.collector_stream`: Retry on common connection issues without raising exceptions (#1435, PR#1747 by Sebastian Waldbauer and Sebastian Wagner).
 
 #### Parsers
 - `intelmq.bots.parsers.eset.parser`: Added (PR#1554 by Mikk Margus Möll).

--- a/docs/user/bots.rst
+++ b/docs/user/bots.rst
@@ -210,7 +210,10 @@ Generic URL Stream Fetcher
 * **HTTP parameters** (see above)
 * `strip_lines`: boolean, if single lines should be stripped (removing whitespace from the beginning and the end of the line)
 
-If the stream is interrupted, the connection will be aborted using the timeout parameter. Then, an error will be thrown and rate_limit applies if not null.
+If the stream is interrupted, the connection will be aborted using the timeout parameter.
+No error will be logged if the number of consecutive connection fails does not reach the parameter `error_max_retries`. Instead of errors, an INFO message is logged. This is a measurement against too frequent ERROR logging messages. The consecutive connection fails are reset if a data line has been successfully transferred.
+If the consecutive connection fails reaches the parameter `error_max_retries`, an exception will be thrown and `rate_limit` applies, if not null.
+
 The parameter `http_timeout_max_tries` is of no use in this collector.
 
 
@@ -621,6 +624,10 @@ Requires the shodan library to be installed:
 * **Feed parameters** (see above)
 * **HTTP parameters** (see above). Only the proxy is used (requires `shodan-python > 1.8.1`). Certificate is always verified.
 * `countries`: A list of countries to query for. If it is a string, it will be spit by `,`.
+
+If the stream is interrupted, the connection will be aborted using the timeout parameter.
+No error will be logged if the number of consecutive connection fails does not reach the parameter `error_max_retries`. Instead of errors, an INFO message is logged. This is a measurement against too frequent ERROR logging messages. The consecutive connection fails are reset if a data line has been successfully transferred.
+If the consecutive connection fails reaches the parameter `error_max_retries`, an exception will be thrown and `rate_limit` applies, if not null.
 
 TCP
 ^^^

--- a/intelmq/bots/collectors/http/collector_http_stream.py
+++ b/intelmq/bots/collectors/http/collector_http_stream.py
@@ -20,7 +20,7 @@ except ImportError:
     requests = None
 
 from http.client import IncompleteRead
-from urllib3.exceptions import ProtocolError
+from urllib3.exceptions import ProtocolError, ReadTimeoutError
 
 from intelmq.lib.bot import CollectorBot
 from intelmq.lib.utils import decode, create_request_session
@@ -37,9 +37,8 @@ class HTTPStreamCollectorBot(CollectorBot):
 
         self.set_request_parameters()
         self.session = create_request_session(self)
-        if(not self.parameters.max_error_retries):
-            self.parameters.max_error_retries = 3
-        self.err_count = 0
+
+        self.__error_count = 0
 
     def process(self):
         self.logger.info("Connecting to stream at %r.", self.parameters.http_url)
@@ -63,28 +62,25 @@ class HTTPStreamCollectorBot(CollectorBot):
                         # filter out keep-alive new lines and empty lines
                         continue
 
-                    self.err_count = 0
+                    self.__error_count = 0
 
                     report = self.new_report()
                     report.add("raw", decode(line))
                     report.add("feed.url", self.parameters.http_url)
                     self.send_message(report)
-            except requests.exceptions.ChunkedEncodingError:
-                self.err_count = self.err_count + 1
-                if(self.err_count >= self.parameters.error_max_retries):
-                    self.err_count = 0
-                    raise requests.exceptions.ChunkedEncodingError
-            except ProtocolError:
-                self.err_count = self.err_count + 1
-                if(self.err_count >= self.parameters.error_max_retries):
-                    self.err_count = 0
-                    raise ProtocolError
-            except IncompleteRead:
-                self.err_count = self.err_count + 1
-                if(self.err_count >= self.parameters.error_max_retries):
-                    self.err_count = 0
-                    raise IncompleteRead
-            
+                    self.__error_count = 0
+            except (requests.exceptions.ChunkedEncodingError,
+                    ProtocolError,
+                    IncompleteRead,
+                    ReadTimeoutError) as exc:
+                self.__error_count += 1
+                if (self.__error_count > self.parameters.error_max_retries):
+                    self.__error_count = 0
+                    raise
+                else:
+                    self.logger.info('Got exception %r, retrying (consecutive error count %d <= %d).',
+                                     exc, self.__error_count, self.parameters.error_max_retries)
+
             self.logger.info('Stream stopped.')
 
 

--- a/intelmq/bots/collectors/http/collector_http_stream.py
+++ b/intelmq/bots/collectors/http/collector_http_stream.py
@@ -19,6 +19,9 @@ try:
 except ImportError:
     requests = None
 
+from http.client import IncompleteRead
+from urllib3.exceptions import ProtocolError
+
 from intelmq.lib.bot import CollectorBot
 from intelmq.lib.utils import decode, create_request_session
 from intelmq.lib.exceptions import MissingDependencyError
@@ -34,6 +37,9 @@ class HTTPStreamCollectorBot(CollectorBot):
 
         self.set_request_parameters()
         self.session = create_request_session(self)
+        if(not self.parameters.max_error_retries):
+            self.parameters.max_error_retries = 3
+        self.err_count = 0
 
     def process(self):
         self.logger.info("Connecting to stream at %r.", self.parameters.http_url)
@@ -48,18 +54,37 @@ class HTTPStreamCollectorBot(CollectorBot):
                 raise ValueError('HTTP response status code was {}.'
                                  ''.format(req.status_code))
 
-            for line in req.iter_lines():
-                if self.parameters.strip_lines:
-                    line = line.strip()
+            try:
+                for line in req.iter_lines():
+                    if self.parameters.strip_lines:
+                        line = line.strip()
 
-                if not line:
-                    # filter out keep-alive new lines and empty lines
-                    continue
+                    if not line:
+                        # filter out keep-alive new lines and empty lines
+                        continue
 
-                report = self.new_report()
-                report.add("raw", decode(line))
-                report.add("feed.url", self.parameters.http_url)
-                self.send_message(report)
+                    self.err_count = 0
+
+                    report = self.new_report()
+                    report.add("raw", decode(line))
+                    report.add("feed.url", self.parameters.http_url)
+                    self.send_message(report)
+            except requests.exceptions.ChunkedEncodingError:
+                self.err_count = self.err_count + 1
+                if(self.err_count >= self.parameters.error_max_retries):
+                    self.err_count = 0
+                    raise requests.exceptions.ChunkedEncodingError
+            except ProtocolError:
+                self.err_count = self.err_count + 1
+                if(self.err_count >= self.parameters.error_max_retries):
+                    self.err_count = 0
+                    raise ProtocolError
+            except IncompleteRead:
+                self.err_count = self.err_count + 1
+                if(self.err_count >= self.parameters.error_max_retries):
+                    self.err_count = 0
+                    raise IncompleteRead
+            
             self.logger.info('Stream stopped.')
 
 


### PR DESCRIPTION
HTTP Stream collector should not raise a exception. Now we're able to define a threshold via `error_max_retries` as parameter.

**NOTE** This is a very "hacky" solution. Currently investigating the cause of this errors.

Closes #1435 