### PR TITLE
Insert date when email was received

### DIFF
--- a/intelmq/bots/collectors/mail/collector_mail_body.py
+++ b/intelmq/bots/collectors/mail/collector_mail_body.py
@@ -29,6 +29,7 @@ class MailBodyCollectorBot(MailCollectorBot):
                 report["extra.email_subject"] = message.subject
                 report["extra.email_from"] = ','.join(x['email'] for x in message.sent_from)
                 report["extra.email_message_id"] = message.message_id
+                report["extra.email_received"] = message.date
 
                 self.send_message(report)
 

--- a/intelmq/bots/collectors/mail/collector_mail_body.py
+++ b/intelmq/bots/collectors/mail/collector_mail_body.py
@@ -29,7 +29,7 @@ class MailBodyCollectorBot(MailCollectorBot):
                 report["extra.email_subject"] = message.subject
                 report["extra.email_from"] = ','.join(x['email'] for x in message.sent_from)
                 report["extra.email_message_id"] = message.message_id
-                report["extra.email_received"] = message.date
+                report["extra.email_date"] = message.date
 
                 self.send_message(report)
 


### PR DESCRIPTION
Sometimes we receive email reports like `this is happening right now` and there is no date/time included. So if we process emails once per hour - we don't have info about event time. Additional field `extra.email_received` in the mail body collector would help.
