### PR TITLE
BUG: twitter collector: proper URL parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,9 @@ IntelMQ no longer supports Python 3.5 (and thus Debian 9 and Ubuntu 16.04), the 
 - `intelmq.bots.collectors.mail`: Add content of the email's `Date` header as `extra.email_date` to the report in all email collectors (PR#1749 by aleksejsv, Sebastian Wagner).
 - `intelmq.bots.collectors.http.collector_http_stream`: Retry on common connection issues without raising exceptions (#1435, PR#1747 by Sebastian Waldbauer and Sebastian Wagner).
 - `intelmq.bots.collectors.shodan.collector_stream`: Retry on common connection issues without raising exceptions (#1435, PR#1747 by Sebastian Waldbauer and Sebastian Wagner).
+- `intelmq.bots.collectors.twitter.collector_twitter`:
+  - Proper input validation in URLs using urllib. CWE-20, found by GitHub's CodeQL (PR#1754).
+  - Limit replacement ("pastebin.com", "pastebin.com/raw") to a maximum of one.
 
 #### Parsers
 - `intelmq.bots.parsers.eset.parser`: Added (PR#1554 by Mikk Margus Möll).

--- a/intelmq/bots/collectors/twitter/collector_twitter.py
+++ b/intelmq/bots/collectors/twitter/collector_twitter.py
@@ -33,6 +33,7 @@ To get api login data see: https://python-twitter.readthedocs.io/en/latest/getti
 """
 
 import time
+from urllib.parse import urlsplit
 
 from intelmq.lib.bot import CollectorBot
 from intelmq.lib.utils import create_request_session
@@ -80,11 +81,13 @@ class TwitterCollectorBot(CollectorBot):
         self.session = create_request_session(self)
 
     def get_text_from_url(self, url: str) -> str:
-        if "pastebin.com" in url:
+        # netloc could include the port explicityly, but we ignore that improbable case here
+        netloc = urlsplit(url).netloc
+        if netloc == "pastebin.com" or netloc.endswith('.pastebin.com'):
             self.logger.debug('Processing url %r.', url)
             if "raw" not in url:
                 request = self.session.get(
-                    url.replace("pastebin.com", "pastebin.com/raw"))
+                    url.replace("pastebin.com", "pastebin.com/raw", count=1))
             else:
                 request = self.session.get(url)
             return request.text


### PR DESCRIPTION
- Proper input validation in URLs using urllib. CWE-20, found by GitHub's CodeQL.
- Limit replacement ("pastebin.com", "pastebin.com/raw") to a maximum of one.

@hugeox (original author/maintainer) please review as well