### PR TITLE
[FIX] SMTP Output can now send to multiple recipients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,7 @@ IntelMQ no longer supports Python 3.5 (and thus Debian 9 and Ubuntu 16.04), the 
 #### Outputs
 - `intelmq.bots.outputs.rt`: Added Request Tracker output bot (PR#1589 by Marius Urkis).
 - `intelmq.bots.outputs.xmpp.output`: Marked as deprecated, see https://lists.cert.at/pipermail/intelmq-users/2020-October/000177.html (#1614, PR#1685 by Birger Schacht).
+- `intelmq.bots.outputs.smtp.output`: Fix sending to multiple recipients when recipients are defined by event-data (#1759, PR#1760 by Sebastian Waldbauer and Sebastian Wagner).
 
 ### Documentation
 - Feeds:

--- a/docs/user/bots.rst
+++ b/docs/user/bots.rst
@@ -3318,6 +3318,7 @@ Sends a MIME Multipart message containing the text and the event as CSV for ever
 
 For several strings you can use values from the string using the `standard Python string format syntax <https://docs.python.org/3/library/string.html#format-string-syntax>`_.
 Access the event's values with `{ev[source.ip]}` and similar. Any not existing fields will result in `None`.
+For example, to set the recipient(s) to the value given in the event's `source.abuse_contact` field, use this as `mail_to` parameter: `{ev[source.abuse_contact]}`
 
 Authentication is optional. If both username and password are given, these
 mechanism are tried: CRAM-MD5, PLAIN, and LOGIN.

--- a/intelmq/bots/outputs/smtp/output.py
+++ b/intelmq/bots/outputs/smtp/output.py
@@ -58,9 +58,9 @@ class SMTPOutputBot(Bot):
             msg['Subject'] = self.parameters.subject.format(ev=event)
             msg['From'] = self.parameters.mail_from.format(ev=event)
             msg['To'] = self.parameters.mail_to.format(ev=event)
-            recipients = [recipient.format(ev=event)
+            recipients = [recipient
                           for recipient
-                          in self.parameters.mail_to.split(',')]
+                          in self.parameters.mail_to.format(ev=event).split(',')]
             smtp.send_message(msg, from_addr=self.parameters.mail_from,
                               to_addrs=recipients)
 

--- a/intelmq/tests/bots/outputs/smtp/test_output.py
+++ b/intelmq/tests/bots/outputs/smtp/test_output.py
@@ -26,7 +26,7 @@ class TestSMTPOutputBot(test.BotTestCase, unittest.TestCase):
                          "text": 'foobar',
                          "subject": "type: {ev[classification.type]}",
                          "mail_from": "myself",
-                         "mail_to": "you"}
+                         "mail_to": "you,yourself"}
 
     def test_event(self):
         self.input_message = EVENT
@@ -36,12 +36,12 @@ class TestSMTPOutputBot(test.BotTestCase, unittest.TestCase):
 
         self.assertEqual(SENT_MESSAGE[0]['Subject'], 'type: None')
         self.assertEqual(SENT_MESSAGE[0]['From'], 'myself')
-        self.assertEqual(SENT_MESSAGE[0]['To'], 'you')
+        self.assertEqual(SENT_MESSAGE[0]['To'], 'you,yourself')
         self.assertEqual(SENT_MESSAGE[0].get_payload()[0].get_payload(), 'foobar')
         self.assertEqual(SENT_MESSAGE[0].get_payload()[1].get_payload(), '''source.ip;time.source;source.url
 127.0.0.1;;http://example.com/
 ''')
-        self.assertEqual({'from_addr': 'myself', 'to_addrs': ['you']},
+        self.assertEqual({'from_addr': 'myself', 'to_addrs': ['you', 'yourself']},
                          SENT_MESSAGE[1])
 
 

--- a/intelmq/tests/bots/outputs/smtp/test_output.py
+++ b/intelmq/tests/bots/outputs/smtp/test_output.py
@@ -8,6 +8,8 @@ SENT_MESSAGE = None
 EVENT = {'__type': 'Event',
          'source.ip': '127.0.0.1',
          'source.url': 'http://example.com/'}
+EVENT1 = EVENT.copy()
+EVENT1['source.abuse_contact'] = 'one@example.com,two@example.com'
 
 
 def send_message(*pargs, **kwargs):
@@ -44,6 +46,26 @@ class TestSMTPOutputBot(test.BotTestCase, unittest.TestCase):
         self.assertEqual({'from_addr': 'myself', 'to_addrs': ['you', 'yourself']},
                          SENT_MESSAGE[1])
 
+    def test_multiple_recipients_event(self):
+        """
+        Test with multiple recipients which are given in the event itself.
+        https://github.com/certtools/intelmq/issues/1759
+        """
+        self.input_message = EVENT1
+
+        with unittest.mock.patch('smtplib.SMTP.send_message', new=send_message):
+            with unittest.mock.patch('smtplib.SMTP.close'):
+                self.run_bot(parameters={'mail_to': '{ev[source.abuse_contact]}'})
+
+        self.assertEqual(SENT_MESSAGE[0]['Subject'], 'type: None')
+        self.assertEqual(SENT_MESSAGE[0]['From'], 'myself')
+        self.assertEqual(SENT_MESSAGE[0]['To'], EVENT1['source.abuse_contact'])
+        self.assertEqual(SENT_MESSAGE[0].get_payload()[0].get_payload(), 'foobar')
+        self.assertEqual(SENT_MESSAGE[0].get_payload()[1].get_payload(), '''source.ip;time.source;source.url
+127.0.0.1;;http://example.com/
+''')
+        self.assertEqual({'from_addr': 'myself', 'to_addrs': ['one@example.com', 'two@example.com']},
+                         SENT_MESSAGE[1])
 
 if __name__ == '__main__':  # pragma: no cover
     unittest.main()


### PR DESCRIPTION
Tests and SMTP OutputBot is now able to send to multiple recipients.

Thanks to @xfors

Fixes #1759