### PR TITLE
FIX: Adds somewhat dirty fix for #1765.

### DIFF
--- a/intelmq/lib/bot.py
+++ b/intelmq/lib/bot.py
@@ -326,6 +326,15 @@ class Bot(object):
 
                 message_to_dump = exc.object
 
+            except exceptions.InvalidValue as exc:
+                self.logger.exception('Found an invalid value that violates the harmonization rules.')
+
+                # ensure that we do not re-process the faulty message
+                self.__error_retries_counter = self.error_max_retries + 1
+                error_on_message = sys.exc_info()
+
+                message_to_dump = exc.object
+
             except Exception as exc:
                 # in case of serious system issues, exit immediately
                 if isinstance(exc, MemoryError):

--- a/intelmq/lib/exceptions.py
+++ b/intelmq/lib/exceptions.py
@@ -74,10 +74,11 @@ class IntelMQHarmonizationException(IntelMQException):
 
 class InvalidValue(IntelMQHarmonizationException):
 
-    def __init__(self, key: str, value: str, reason: Any = None):
+    def __init__(self, key: str, value: str, reason: Any = None, object: bytes = None):
         message = ("invalid value {value!r} ({type}) for key {key!r}{reason}"
                    "".format(value=value, type=type(value), key=key,
                              reason=': ' + reason if reason else ''))
+        self.object = object
         super().__init__(message)
 
 

--- a/intelmq/lib/message.py
+++ b/intelmq/lib/message.py
@@ -117,12 +117,12 @@ class Message(dict):
 
         super().__init__()
         if isinstance(message, dict):
-            iterable = message.items()
+            self.iterable = message
         elif isinstance(message, tuple):
-            iterable = message
+            self.iterable = dict(message)
         else:
             raise ValueError("Type %r of message can't be handled, must be dict or tuple.", type(message))
-        for key, value in iterable:
+        for key, value in self.iterable.items():
             if not self.add(key, value, sanitize=False, raise_failure=False):
                 self.add(key, value, sanitize=True)
 
@@ -246,14 +246,14 @@ class Message(dict):
             value = self.__sanitize_value(key, value)
             if value is None:
                 if raise_failure:
-                    raise exceptions.InvalidValue(key, old_value)
+                    raise exceptions.InvalidValue(key, old_value, object=bytes(json.dumps(self.iterable), 'utf-8'))
                 else:
                     return False
 
         valid_value = self.__is_valid_value(key, value)
         if not valid_value[0]:
             if raise_failure:
-                raise exceptions.InvalidValue(key, value, reason=valid_value[1])
+                raise exceptions.InvalidValue(key, value, reason=valid_value[1], object=bytes(json.dumps(self.iterable), 'utf-8'))
             else:
                 return False
 

--- a/intelmq/tests/lib/test_bot.py
+++ b/intelmq/tests/lib/test_bot.py
@@ -50,7 +50,7 @@ class TestDummyParserBot(test.BotTestCase, unittest.TestCase):
         self.prepare_bot()
         self.assertEqual(self.bot.group, 'Parser')
 
-    def test_invalid_input_message(self):
+    def test_encoding_error_on_input_message(self):
         """
         Test if the bot is dumping / not retrying a message which is impossible to parse.
         https://github.com/certtools/intelmq/issues/1494
@@ -58,6 +58,18 @@ class TestDummyParserBot(test.BotTestCase, unittest.TestCase):
         self.input_message = b'foo\xc9bar'
         self.run_bot(iterations=1, allowed_error_count=1)
         self.assertLogMatches('.*intelmq\.lib\.exceptions\.DecodingError:.*')
+        self.assertEqual(self.pipe.state['test-bot-input-internal'], [])
+        self.assertEqual(self.pipe.state['test-bot-input'], [])
+        self.assertEqual(self.pipe.state['test-bot-output'], [])
+
+    def test_invalid_value_on_input_message(self):
+        """
+        Test if the bot is dumping / not retrying a message which is impossible to parse.
+        https://github.com/certtools/intelmq/issues/1765
+        """
+        self.input_message = b'{"source.asn": 0, "__type": "Event"}'
+        self.run_bot(iterations=1, allowed_error_count=1)
+        self.assertLogMatches(r'.*intelmq\.lib\.exceptions\.InvalidValue:.*')
         self.assertEqual(self.pipe.state['test-bot-input-internal'], [])
         self.assertEqual(self.pipe.state['test-bot-input'], [])
         self.assertEqual(self.pipe.state['test-bot-output'], [])


### PR DESCRIPTION
# Description

This fixes #1765.

It adds dump object to InvalidValue exception so that the code below has some meaningful data to dump and can just move on (the last two lines that acknowledge the message if there is a message to dump).

https://github.com/certtools/intelmq/blob/b7ba19ceaba219e6aa87a37784164dbdf0b3e680/intelmq/lib/bot.py#L372-L384

