### PR TITLE
Run the installation step only for the base tests

### DIFF
--- a/.github/workflows/nosetests.yml
+++ b/.github/workflows/nosetests.yml
@@ -64,6 +64,7 @@ jobs:
       run: pip install nose Cerberus pyyaml requests_mock coverage codecov
 
     - name: Install dependencies
+      if: ${{ matrix.type == 'basic' }}
       run: pip install -e .
 
     - name: Run basic testsuite


### PR DESCRIPTION
because for the full tests, it is already run during the setup-full.sh
script run.
