### PR TITLE
FIX: the pipeline factory expects a dict, not simply a list

### DIFF
--- a/intelmq/lib/bot.py
+++ b/intelmq/lib/bot.py
@@ -551,7 +551,7 @@ class Bot(object):
         self.stop()
 
     def __connect_pipelines(self):
-        pipeline_args = sorted(i for i in dir(self) if not inspect.ismethod(i) and (i.startswith('source_pipeline_') or i.startswith('destination_pipeline')))
+        pipeline_args = {key: getattr(self, key) for key in dir(self) if not inspect.ismethod(key) and (key.startswith('source_pipeline_') or key.startswith('destination_pipeline'))}
         if self.__source_queues:
             self.logger.debug("Loading source pipeline and queue %r.", self.__source_queues)
             self.__source_pipeline = PipelineFactory.create(logger=self.logger,

--- a/intelmq/lib/pipeline.py
+++ b/intelmq/lib/pipeline.py
@@ -37,9 +37,9 @@ class PipelineFactory(object):
                                              expected=["destination", "source"])
 
         if direction == 'source' and 'source_pipeline_broker' in pipeline_args:
-            broker = source_pipeline_broker.title()
+            broker = pipeline_args['source_pipeline_broker'].title()
         if direction == 'destination' and 'destination_pipeline_broker' in pipeline_args:
-            broker = destination_pipeline_broker.title()
+            broker = pipeline_args['destination_pipeline_broker'].title()
         elif (getattr(pipeline_args, 'source_pipeline_broker', None) == getattr(pipeline_args, 'destination_pipeline_broker', None) and
               getattr(pipeline_args, 'source_pipeline_broker', None) is not None):
             broker = pipeline_args['source_pipeline_broker'].title()


### PR DESCRIPTION
The `pipeline_args` argument of the pipeline factory should contain a
dict with the relevant attributes and their values instead of simply a
list containing the keys of the attributes.
Also the method itself has to get the values from the dict.

@schacht-certat  slaps @schacht-certat  around with a large trout.