### PR TITLE
Cymru CAP Parser: Adapt to new format of 'bruteforce' category

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ CHANGELOG
 #### Collectors
 
 #### Parsers
+- `intelmq.bots.parsers.cymru.parser_cap_program`:
+  - Adapt parser to new upstream format for events of category "bruteforce" (PR#1795 by Sebastian Wagner, fixes 1794).
 
 #### Experts
 

--- a/intelmq/bots/parsers/cymru/parser_cap_program.py
+++ b/intelmq/bots/parsers/cymru/parser_cap_program.py
@@ -228,6 +228,24 @@ class CymruCAPProgramParserBot(ParserBot):
         yield event
 
     def parse_line_new(self, line, report):
+        """
+        The format is two following:
+        category|address|asn|timestamp|optional_information|asninfo
+        Therefore very similar to CSV, just with the pipe as separator
+        category: the type (resulting in classification.*) and optional_information needs to be parsed differently per category
+        address: source.ip
+        asn: source.asn
+        timestamp: time.source
+        optional_information: needs special care.
+            For some categories it needs parsing, as it contains a mapping of keys to values, whereas the meaning of the keys can differ between the categories
+            For categories in MAPING_COMMENT, this field only contains one value.
+            For the category 'bruteforce' *both* situations apply.
+            Previously, the bruteforce events only had the protocol in the comment,
+            while most other categories had a mapping. Now, the bruteforce categories also uses
+            the type-value syntax. So we need to support both formats, the old and the new.
+            See also https://github.com/certtools/intelmq/issues/1794
+        asninfo: source.as_name
+        """
         category, ip, asn, timestamp, notes, asninfo = line.split('|')
 
         # to detect bogous lines like 'hostname: sub.example.comport: 80'

--- a/intelmq/tests/bots/parsers/cymru/certname_20190327.txt
+++ b/intelmq/tests/bots/parsers/cymru/certname_20190327.txt
@@ -33,3 +33,4 @@ scanner|172.16.0.21|64496|2020-07-09 03:40:15|username: pm;|Example AS Name, AT
 darknet|172.16.0.21|64496|2020-10-08 02:21:26|protocol: 47;|Example AS Name, AT
 darknet|172.16.0.21|64496|2020-10-15 09:22:10|protocol: 59;|Example AS Name, AT
 proxy|172.16.0.21|64496|2020-12-14 08:28:01|httpconnect-51915; additional_asns: 212682;|Example AS Name, AT
+bruteforce|172.16.0.21|64496|2021-03-09 00:11:21|destination_port_numbers: 22;port: 16794;protocol: 6;|Example AS Name, AT

--- a/intelmq/tests/bots/parsers/cymru/test_cap_program_new.py
+++ b/intelmq/tests/bots/parsers/cymru/test_cap_program_new.py
@@ -221,11 +221,17 @@ EVENTS = [{'time.source': '2019-03-22T11:18:52+00:00',
            'protocol.application': 'httpconnect',
            'source.port': 51915,
            },
+          {'classification.type': 'brute-force',
+           'protocol.transport': 'tcp',
+           'destination.port': 22,
+           'source.port': 16794,
+           'time.source': '2021-03-09T00:11:21+00:00',
+           },
           ]
 
 # The number of events a single line in the raw data produces
 NUM_EVENTS = (1, 1, 1, 1, 1, 2, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-              1, 1, 10, 1, 1, 1, 1, 1, 1, 1, 1)
+              1, 1, 10, 1, 1, 1, 1, 1, 1, 1, 1, 1)
 RAWS = []
 for i, line in enumerate(RAW_LINES[3:]):
     for count in range(NUM_EVENTS[i]):


### PR DESCRIPTION
Previously, the bruteforce events only had the protocol in the comment, while most other categories had a (more or less) clear type-value syntax. Now, the bruteforce categories also uses the type-value syntax. That makes the parser a bit more bloated, as it needs to support both formats, the old and the new. Whereas I don't even know if this is a real switch, or just an additional format.

Interestingly the data no longer contains the application protocol (SSH in the case of the example) :/

fixes #1794

@aleksejsv 