### PR TITLE
BUG: lib/bot and lib/test: fix pipeline parameter check

### DIFF
--- a/intelmq/lib/bot.py
+++ b/intelmq/lib/bot.py
@@ -551,7 +551,7 @@ class Bot(object):
         self.stop()
 
     def __connect_pipelines(self):
-        pipeline_args = {key: getattr(self, key) for key in dir(self) if not inspect.ismethod(key) and (key.startswith('source_pipeline_') or key.startswith('destination_pipeline'))}
+        pipeline_args = {key: getattr(self, key) for key in dir(self) if not inspect.ismethod(getattr(self, key)) and (key.startswith('source_pipeline_') or key.startswith('destination_pipeline'))}
         if self.__source_queues:
             self.logger.debug("Loading source pipeline and queue %r.", self.__source_queues)
             self.__source_pipeline = PipelineFactory.create(logger=self.logger,

--- a/intelmq/lib/test.py
+++ b/intelmq/lib/test.py
@@ -229,7 +229,7 @@ class BotTestCase(object):
                 self.bot = self.bot_reference(self.bot_id)
         self.bot._Bot__stats_cache = None
 
-        pipeline_args = sorted(i for i in dir(self) if not inspect.ismethod(i) and (i.startswith('source_pipeline_') or i.startswith('destination_pipeline')))
+        pipeline_args = {key: getattr(self, key) for key in dir(self) if not inspect.ismethod(getattr(self, key)) and (key.startswith('source_pipeline_') or key.startswith('destination_pipeline'))}
         self.pipe = pipeline.Pythonlist(logger=self.logger, pipeline_args=pipeline_args, load_balance=self.bot.load_balance, is_multithreaded=self.bot.is_multithreaded)
         self.pipe.set_queues(parameters.source_queue, "source")
         self.pipe.set_queues(parameters.destination_queues, "destination")


### PR DESCRIPTION
the pipeline arguments are extracted from `self` by iterating over the
attributes, using dir(). But dir only returns the name of the variable,
not the value. Therefore, the check for ismethod needs to be done using
getattr, not the variable name.