### PR TITLE
docs: faq redis socket: less permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ CHANGELOG
 - Add missing newlines at end of `docs/_static/intelmq-manager/*.png.license` files (PR#1785 by Sebastian Wagner, fixes #1777).
 - Ecosystem: Revise sections on intelmq-cb-mailgen and fody (PR#1792 by Bernhard Reiter).
 - intelmq-api: Add documentation about necessary write permission for the session database file (PR#1798 by Birger Schacht, fixes intelmq-api#23).
+- FAQ: Section on redis socket permissions: set only minimal necessary permissions (PR#1809 by Sebastian Wagner).
 
 ### Packaging
 

--- a/docs/user/FAQ.rst
+++ b/docs/user/FAQ.rst
@@ -16,11 +16,23 @@ Permission denied when using Redis Unix socket
 
 If you get an error like this:
 
-``intelmq.lib.exceptions.PipelineError: pipeline failed - ConnectionError('Error 13 connecting to unix socket: /var/run/redis/redis.sock. Permission denied.',)``
+.. code-block::
 
-make sure the permissions for the socket are set accordingly in ``/etc/redis/redis.conf`` (or wherever your configuration is), e.g.:
+   intelmq.lib.exceptions.PipelineError: pipeline failed - ConnectionError('Error 13 connecting to unix socket: /var/run/redis/redis.sock. Permission denied.',)
 
-``unixsocketperm 777``
+Make sure the intelmq user as sufficient permissions for the socket.
+
+In ``/etc/redis/redis.conf`` (or wherever your configuration is), check the permissions and set it for example to group-writeable:
+
+.. code-block::
+
+   unixsocketperm 770
+
+And add the user intelmq to the redis-group:
+
+.. code-block:: bash
+
+   usermod -aG redis intelmq
 
 Why is the time invalid?
 -------------------------------------------------------------------


### PR DESCRIPTION
socket permission 777 are not necessary, use only 770 plus group
membership