### PR TITLE
ENH: add http content expert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ Update allowed classification fields to 2020-01-28 version (#1409, #1476). Old n
 #### Experts
 - `intelmq.bots.experts.domain_suffix.expert`: Added `--update-database` option to update domain suffix database.
 - Added `intelmq.bots.experts.http.expert_status`: A bot that fetches the HTTP Status for a given URI and adds it to the message (PR#1789 by Birger Schacht, fixes #1047 partly).
+- Added `intelmq.bots.experts.http.expert_content`: A bot that fetches an HTTP resource and checks if it contains a specific string.
 
 #### Outputs
 - Remove `intelmq.bots.outputs.xmpp`: one of the dependencies of the bot was deprecated and according to a short survey on the IntelMQ

--- a/docs/user/bots.rst
+++ b/docs/user/bots.rst
@@ -2057,6 +2057,23 @@ Fetches the HTTP Status for a given URI
 * `success_status_codes:` A list of success status codes. If this parameter is omitted or the list is empty, successful status codes are the ones between 200 and 400.
 * `overwrite:` Specifies if an existing 'status' value should be overwritten.
 
+
+HTTP Content
+^^^^^^^^^^^^
+
+Fetches an HTTP resource and checks if it contains a specific string.
+
+**Information**
+
+* `name:` intelmq.bots.experts.http.expert_status
+* `description:` The bot fetches an HTTP resource and checks if it contains a specific string.
+
+**Configuration Parameters**
+
+* `field:` The name of the field containing the URL to be checked (defaults to `source.url`)
+* `needle:` The string that the content available on URL is checked for
+* `overwrite:` A boolean value that specifies if an existing 'status' value should be overwritten.
+
 IDEA Converter
 ^^^^^^^^^^^^^^
 

--- a/intelmq/bots/BOTS
+++ b/intelmq/bots/BOTS
@@ -853,6 +853,15 @@
                 "overwrite": false
             }
         },
+        "HTTP Content": {
+            "description": "Test if a given string is part of the content for a given URL",
+            "module": "intelmq.bots.experts.http.expert_content",
+            "parameters": {
+                "field": "source.url",
+                "needle": null,
+                "overwrite": true
+            }
+        },
         "IDEA Converter": {
             "description": "Convert events into the IDEA format.",
             "module": "intelmq.bots.experts.idea.expert",

--- a/intelmq/bots/experts/http/expert_content.py
+++ b/intelmq/bots/experts/http/expert_content.py
@@ -1,0 +1,60 @@
+"""
+HTTP Content Expert Bot
+
+SPDX-FileCopyrightText: 2021 Birger Schacht <schacht@cert.at>
+SPDX-License-Identifier: AGPL-3.0-or-later
+"""
+from typing import List
+
+from intelmq.lib.bot import Bot
+from intelmq.lib.utils import create_request_session
+
+
+class HttpContentExpertBot(Bot):
+    """
+    Test if a given string is part of the content for a given URL
+
+    Parameters
+    ----------
+    field: str
+        The name of the field containing the URL to be checked (defaults to 'source.url').
+    needle: str
+        The string that the content available on URL is checked for.
+    overwrite:
+        Specifies if an existing 'status' value should be overwritten.
+    """
+    field: str = "source.url"  # The field containing the URL
+    needle: str = None
+    overwrite: bool = True
+    __session = None
+
+    def init(self):
+        self.set_request_parameters()
+        self.__session = create_request_session(self)
+
+    def process(self):
+        event = self.receive_message()
+
+        if self.field in event and self.needle is not None:
+            try:
+                response = self.__session.get(event[self.field])
+                if response:
+                    if self.needle in response.text:
+                        event.add('status', 'online', overwrite=self.overwrite)
+                    else:
+                        event.add('status', 'offline', overwrite=self.overwrite)
+                        event.add('extra.reason', f'Text {self.needle} not found in response from {event[self.field]}')
+                else:
+                    event.add('status', 'offline', overwrite=self.overwrite)
+                    event.add('extra.reason', response.reason)
+            except Exception as exc:
+                event.add('status', 'offline', overwrite=self.overwrite)
+                event.add('extra.reason', str(exc))
+        else:
+            self.logger.debug('Field %s was not part of the message or search string is not set.', self.field)
+
+        self.send_message(event)
+        self.acknowledge_message()
+
+
+BOT = HttpContentExpertBot

--- a/intelmq/tests/bots/experts/http/test_expert_content.py
+++ b/intelmq/tests/bots/experts/http/test_expert_content.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+"""
+Testing HTTP Status expert
+"""
+import unittest
+import requests_mock
+
+import intelmq.lib.test as test
+import intelmq.lib.utils as utils
+from intelmq.bots.experts.http.expert_content import HttpContentExpertBot
+
+EXAMPLE_INPUT1 = {"__type": "Event",
+                 "source.url": "http://localhost/foo",
+                 }
+EXAMPLE_OUTPUT1 = {"__type": "Event",
+                 "source.url": "http://localhost/foo",
+                 "status": "online",
+                 }
+EXAMPLE_OUTPUT2 = {"__type": "Event",
+                 "extra.reason": "Text Nonexistent response not found in response from http://localhost/foo",
+                 "source.url": "http://localhost/foo",
+                 "status": "offline",
+                 }
+
+def prepare_mocker(mocker):
+    mocker.get('http://localhost/foo', text='Some response')
+
+
+@requests_mock.Mocker()
+class TestHTTPContentExpertBot(test.BotTestCase, unittest.TestCase):
+    """
+    A TestCase for HTTPStatusExpertBot.
+    """
+
+    @classmethod
+    def set_bot(cls):
+        cls.bot_reference = HttpContentExpertBot
+
+    def test_content_exists(self, mocker):
+        """Test with existing content."""
+        prepare_mocker(mocker)
+        self.input_message = EXAMPLE_INPUT1
+        self.prepare_bot(parameters={'needle': 'Some response'})
+        self.run_bot(prepare=False)
+        self.assertMessageEqual(0, EXAMPLE_OUTPUT1)
+
+    def test_content_does_not_exist(self, mocker):
+        """Test with content that does not exist."""
+        prepare_mocker(mocker)
+        self.input_message = EXAMPLE_INPUT1
+        self.prepare_bot(parameters={'needle': 'Nonexistent response'})
+        self.run_bot(prepare=False)
+        self.assertMessageEqual(0, EXAMPLE_OUTPUT2)
+
+if __name__ == '__main__':  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
This adds the module
intelmq.bots.experts.http.expert_content.HttpContentExpertBot and some
unit tests for the module.
It also adds a description in the documentation and a changelog entry
introducing the new bot.
