### PR TITLE
BUG TST: test_datetime_convert: skip if not UTC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ CHANGELOG
 
 ### Tests
 - Add missing newlines at end of various test input files (PR#1785 by Sebastian Wagner, fixes #1777).
+- `intelmq.tests.lib.test_harmonization.test_datetime_convert`: Only run this test in timezone UTC (PR#1825 by Sebastian Wagner).
 
 ### Tools
 - `intelmqsetup`:

--- a/intelmq/tests/lib/test_harmonization.py
+++ b/intelmq/tests/lib/test_harmonization.py
@@ -4,6 +4,7 @@ Testing harmonization classes
 """
 import datetime
 import ipaddress
+import time
 import unittest
 
 import intelmq.lib.harmonization as harmonization
@@ -244,6 +245,7 @@ class TestHarmonization(unittest.TestCase):
         with self.assertRaises(TypeError):
             harmonization.DateTime.from_timestamp('1441008970')
 
+    @unittest.skipIf(time.timezone != 0, 'Test only works with UTC')
     def test_datetime_convert(self):
         self.assertEqual('2019-07-01T15:15:15+00:00',
                          harmonization.DateTime.convert('15 15 15 07 01 2019',


### PR DESCRIPTION
This test fails if any other timezone than UTC is in use and causes
frequent but unnessary test fails.
So we can just skip it, if UTC is not in use on the system.