### PR TITLE
shadowserver collector: more debug logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ CHANGELOG
 
 ### Bots
 #### Collectors
+- `intelmq.bots.collectors.shadowserver.collector_reports_api`: Added debug logging to show number of downloaded reports and download size (PR#1826 by Sebastian Wagner, partly addresses #1688 and #1823).
 
 #### Parsers
 - `intelmq.bots.parsers.cymru.parser_cap_program`:

--- a/intelmq/bots/collectors/shadowserver/collector_reports_api.py
+++ b/intelmq/bots/collectors/shadowserver/collector_reports_api.py
@@ -121,6 +121,8 @@ class ShadowServerAPICollectorBot(CollectorBot):
         reportslist = self._reports_list()
         self.logger.debug('Reports list contains %s entries after filtering.', len(reportslist))
 
+        reports_downloaded = 0
+
         for item in reportslist:
             filename = item['file']
             filename_fixed = FILENAME_PATTERN.sub('.json', filename, count=1)
@@ -131,10 +133,13 @@ class ShadowServerAPICollectorBot(CollectorBot):
             reportdata = self._report_download(item['id'])
             report = self.new_report()
             report.add('extra.file_name', filename_fixed)
-            report.add('raw', str(reportdata))
+            report.add('raw', reportdata)
             self.send_message(report)
             self.cache.set(filename, 1)
-            self.logger.debug('Sent report: %r (fixed: %r).', filename, filename_fixed)
+            self.logger.debug('Sent report: %r (fixed: %r, size: %.3g KiB).', filename, filename_fixed,
+                              len(reportdata) / 1024)  # TODO: Replace by a generic size-conversion function
+            reports_downloaded += 1
+        self.logger.info('Downloaded %d of %d available reports.', reports_downloaded, len(reportslist))
 
 
 BOT = ShadowServerAPICollectorBot

--- a/intelmq/tests/bots/collectors/shadowserver/test_collector_reports_api.py
+++ b/intelmq/tests/bots/collectors/shadowserver/test_collector_reports_api.py
@@ -76,7 +76,7 @@ class TestShadowServerAPICollectorBot(test.BotTestCase, unittest.TestCase):
         self.cache.flushdb()
         prepare_mocker(mocker)
         self.run_bot(iterations=1, parameters=PARAMETERS)
-        self.assertAnyLoglineEqual("Sent report: '2020-08-02-cisco_smart_install-anarres-geo.csv' (fixed: '2020-08-02-cisco_smart_install-anarres-geo.json').", 'DEBUG')
+        self.assertAnyLoglineEqual("Sent report: '2020-08-02-cisco_smart_install-anarres-geo.csv' (fixed: '2020-08-02-cisco_smart_install-anarres-geo.json', size: 0.00195 KiB).", 'DEBUG')
 
     def test_report_content(self, mocker):
         self.cache.flushdb()


### PR DESCRIPTION
Added debug logging to show number of downloaded reports and download size
partly addresses #1688 and #1823