### PR TITLE
BUG: lib/pipeline: Ampq._get_qeues: ignore wrong vhost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ CHANGELOG
 ### Core
 - `intelmq.lib.utils`:
   - `log`: Handle null value for logging parameter `logging_max_size` (PR#1786 by Sebastian Wagner, fixes #1778).
+- `intelmq.lib.pipeline`:
+  - `Amqp._get_queues`: Check virtual host when retrieving queue sizes. Fixes output of `intelmqctl check` for orphaned queues if AMQP is used and the AMQP user has access to more virtual hosts (PR#1830 by Sebastian Wagner, fixes #1746).
 
 ### Development
 

--- a/intelmq/lib/pipeline.py
+++ b/intelmq/lib/pipeline.py
@@ -595,7 +595,7 @@ class Amqp(Pipeline):
         elif response.status_code != 200:
             raise ValueError("Unknown error %r.", response.text)
         try:
-            return {x['name']: x.get('messages', 0) for x in response.json()}
+            return {queue['name']: queue.get('messages', 0) for queue in response.json() if queue['vhost'] == self.virtual_host}
         except SyntaxError:
             self.logger.error("Unable to parse response from server as JSON: %r.", response.text)
             return {}


### PR DESCRIPTION
Check virtual host when retrieving queue sizes. Fixes output of `intelmqctl check` for orphaned queues if AMQP is used and the AMQP user has access to more virtual hosts
certtools/intelmq#1746