### PR TITLE
MAINT: workaround for new buildah release

### DIFF
--- a/.github/workflows/debian-package.yml
+++ b/.github/workflows/debian-package.yml
@@ -12,7 +12,8 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    # temporary fix for https://github.com/actions/virtual-environments/issues/3080
+    runs-on: ubuntu-18.04
     name: Build Debian packages
     strategy:
       matrix:


### PR DESCRIPTION
The github action virtual environment pulls a new buildah version that is not configured correctly, therefore for now using the older ubuntu-18.04 virtual environment, unitl https://github.com/actions/virtual-environments/issues/3080 is fixed