### PR TITLE
PKG: remove BOTS file from Debian package

### DIFF
--- a/debian/conffiles
+++ b/debian/conffiles
@@ -1,5 +1,4 @@
 /etc/intelmq/harmonization.conf
-/etc/intelmq/BOTS
 /etc/intelmq/pipeline.conf
 /etc/intelmq/defaults.conf
 /etc/intelmq/runtime.conf

--- a/debian/intelmq.install
+++ b/debian/intelmq.install
@@ -4,4 +4,3 @@ contrib/bash-completion/intelmqctl usr/share/bash-completion/completions/
 contrib/bash-completion/intelmqdump usr/share/bash-completion/completions/
 intelmq/bots/experts/modify/examples/* usr/share/doc/intelmq/bots/experts/modify/examples/
 intelmq/etc/* etc/intelmq/
-intelmq/bots/BOTS etc/intelmq/

--- a/debian/intelmq.maintscript
+++ b/debian/intelmq.maintscript
@@ -1,0 +1,1 @@
+rm_conffile /etc/intelmq/BOTS 3.0.0-1~ intelmq

--- a/debian/rules
+++ b/debian/rules
@@ -35,7 +35,7 @@ override_dh_auto_build:
 override_dh_auto_install: $(BOTDOCS)
 	rm intelmq/bin/rewrite_config_files.py
 	sed -i -e '/#!\/usr\/bin\//d' intelmq/bin/*.py
-	sed -i -f debian/sedfile intelmq/bots/BOTS intelmq/etc/* docs/user/intelmqctl.rst docs/user/bots.rst setup.py contrib/logrotate/intelmq contrib/logcheck/logcheck.logfiles
+	sed -i -f debian/sedfile intelmq/etc/* docs/user/intelmqctl.rst docs/user/bots.rst setup.py contrib/logrotate/intelmq contrib/logcheck/logcheck.logfiles
 	python3 setup.py install --root=debian/intelmq --prefix=/usr
 	# these are already in /usr/bin/
 	#rm %{buildroot}/%{python3_sitelib}/intelmq/bots/experts/maxmind_geoip/update-geoip-data


### PR DESCRIPTION
This removes any traces of the BOTS file from the Debian package rules
file, the intelmq.install file and the d/conffiles listing. It also adds
a intelmq.maintscript to remove the BOTS file on upgrade to 3.0.0.
