### PR TITLE
ENH: modify example configuration: add c2 malware rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ CHANGELOG
   - Added support for unique keys and verified vulns (PR#1835 by Mikk Margus Möll).
 
 #### Experts
+- `intelmq.bots.experts.modify`:
+  - Add a new rule to the example configuration to change the type of malicious-code events to `c2server` if the malware name indicates c2 (PR#1854 by Sebastian Wagner).
 
 #### Outputs
 - `intelmq.bots.outputs.elasticsearch`: Fix log message on required elasticsearch library message (by Sebastian Wagner).

--- a/intelmq/bots/experts/modify/examples/default.conf
+++ b/intelmq/bots/experts/modify/examples/default.conf
@@ -191,6 +191,16 @@
         }
     },
     {
+        "rulename": "malware name indicates c2",
+        "if": {
+            "malware.name": "-c2",
+            "classification.type": "infected-system"
+        },
+        "then": {
+            "classification.type": "c2server"
+        }
+    },
+    {
         "rulename": "default",
         "if": {
             "malware.name": ".*",


### PR DESCRIPTION
if the malware name indicates a c2 server, but type is wrong, set the
type accordingly

when merged into develop, c2server needs to be changed to c2-server