### PR TITLE
BUG: gethostbyname: fix handling null gaierrors_to_ignore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ CHANGELOG
 #### Experts
 - `intelmq.bots.experts.modify`:
   - Add a new rule to the example configuration to change the type of malicious-code events to `c2server` if the malware name indicates c2 (PR#1854 by Sebastian Wagner).
+- `intelmq.bots.experts.gethostbyname.expert`:
+  - Fix handling of parameter `gaierrors_to_ignore` with value `None` (PR#1890 by Sebastian Wagner, fixes #1886).
 
 #### Outputs
 - `intelmq.bots.outputs.elasticsearch`: Fix log message on required elasticsearch library message (by Sebastian Wagner).

--- a/intelmq/bots/experts/gethostbyname/expert.py
+++ b/intelmq/bots/experts/gethostbyname/expert.py
@@ -32,10 +32,10 @@ class GethostbynameExpertBot(Bot):
         self.fallback_to_url = getattr(self.parameters, 'fallback_to_url', False)
 
         ignore = getattr(self.parameters, 'gaierrors_to_ignore', ())
-        if not isinstance(ignore, (list, tuple)):
-            ignore = ignore.split(',')
-        elif not ignore:  # for null/None
+        if not ignore:  # for null/None/empty lists or strings
             ignore = ()
+        elif not isinstance(ignore, (list, tuple)):
+            ignore = ignore.split(',')
         # otherwise a string
         ignore = tuple(x.strip() for x in ignore)
         # check if every element is an integer:

--- a/intelmq/tests/bots/experts/gethostbyname/test_expert.py
+++ b/intelmq/tests/bots/experts/gethostbyname/test_expert.py
@@ -52,9 +52,19 @@ class TestGethostbynameExpertBot(test.BotTestCase, unittest.TestCase):
         cls.sysconfig = {'gaierrors_to_ignore': '-8,-9'}
 
     def test_existing(self):
+        """
+        Test bot with domains which exists
+        """
         self.input_message = EXAMPLE_INPUT
         self.run_bot()
         self.assertMessageEqual(0, EXAMPLE_OUTPUT)
+
+    def test_gaierrors_to_ignore_none(self):
+        """
+        Test parameter gaierrors_to_ignore with value none
+        """
+        self.input_message = EXAMPLE_INPUT
+        self.run_bot(parameters={'gaierrors_to_ignore': None})
 
     def test_non_existing(self):
         self.input_message = NONEXISTING_INPUT


### PR DESCRIPTION
the value null for the parameter gaierrors_to_ignore raised an error

this commit fixes this by handling it gracefully. actually was already
there, just in the wrong order

fixes certtools/intelmq#1886