### PR TITLE
ENH: Refactor some of the Sieve expert, extend the Sieve DSL

### DIFF
--- a/docs/user/bots.rst
+++ b/docs/user/bots.rst
@@ -2607,8 +2607,11 @@ Each rule specifies on or more expressions to match an event based on its keys
 and values. Event keys are specified as strings without quotes. String values
 must be enclosed in single quotes. Numeric values can be specified as integers
 or floats and are unquoted. IP addresses and network ranges (IPv4 and IPv6) are
-specified with quotes. Expression statements can be combined and chained using
-parenthesis and the boolean operators ``&&`` and ``||``.
+specified with quotes. List values for use with list/set operators are specified
+as string, float, int, bool and string literals separated by commas and enclosed
+in square brackets.
+Expression statements can be combined and chained using
+parentheses and the boolean operators ``&&`` and ``||``.
 The following operators may be used to match events:
 
  * `:exists` and `:notexists` match if a given key exists, for example:
@@ -2642,6 +2645,25 @@ The following operators may be used to match events:
 
   Events with values like `8.8.8.8` or `8.8.4.4` will match, as they are always unequal to the other value.
   **Attention:** The result is *not* that the field must be unequal to all given values.
+
+ * `:equals` tests for equality between lists, including order. Its result can be inverted by using `! :equals`. Example for checking a hostname-port pair:
+   ``if extra.host_tuple :equals ['dns.google', 53] { ... }``
+ * `:setequals` tests for set-based equality (ignoring duplicates and value order) between a list of given values. Example for checking for the first nameserver of two domains, regardless of the order they are given in the list:
+   ``if extra.hostnames :setequals ['ns1.example.com', 'ns1.example.mx'] { ... }``
+
+ * `:overlaps` tests if there is at least one element in common between the list specified by a key and a list of values. Example for checking if at least one of the ICS, database or vulnerable tags is given:
+   ``if extra.tags :overlaps ['ics', 'database', 'vulnerable'] { ... } ``
+
+ * `:subsetof` tests if the list of values from the given key only contains values from a set of values specified as the argument. Example for checking for a host that has only ns1.example.com and/or ns2.[...] as its apparent hostname:
+   ``if extra.hostnames :subsetof ['ns1.example.com', 'ns2.example.com'] { ... }``
+
+ * `:supersetof` tests if the list of values from the given key is a superset of the values specified as the argument. Example for matching hosts with at least the IoT and vulnerable tags:
+   ``if extra.tags :supersetof ['iot', 'vulnerable'] { ... }``
+
+ * The results of the list operators (`:equals`, `:setequals`, `:overlaps`, `:subsetof` and `:supersetof`) can be inverted with a prepended exclamation mark, such as `! :overlaps`. Note that in case there is no value with the given key or it is a non-list value, the result will always be false, regardless of negation. The existence of the key can be checked for separately.
+
+ * Boolean values can be matched with `==` or `!=` followed by `true` or `false`. Example:
+   ``if extra.has_known_vulns == true { ... }``
 
  * The combination of multiple expressions can be done using parenthesis and boolean operators:
 

--- a/intelmq/bots/experts/sieve/sieve.tx
+++ b/intelmq/bots/experts/sieve/sieve.tx
@@ -17,6 +17,8 @@ Condition:
     | match=NumericMatch
     | match=IpRangeMatch
     | match=ExistMatch
+    | match=ListMatch
+    | match=BoolMatch
     | ( '(' match=Expression ')' )
 ;
 
@@ -49,6 +51,24 @@ IpRangeList: '[' values+=SingleIpRange[','] ']' ;
 ExistMatch: op=ExistOperator key=Key;
 ExistOperator: ':exists' | ':notexists';
 
+ListMatch: key=Key neg=Negation? op=ListOperator value=ListValue;
+ListOperator:
+  ':equals'           // lists are equal, including order
+  | ':setequals'      // lists contain the same elements, ignoring order and repeating values
+  | ':overlaps'       // lists contain one or more common values
+  | ':subsetof'       // key is a proper subset of value
+  | ':supersetof'     // key is a proper superset of value
+;
+
+BoolMatch: key=Key op=BoolOperator value=BOOL;
+BoolOperator: '==' | '!=';
+
+
+Negation: '!';
+
+TypedValue: STRICTFLOAT | INT | BOOL | STRING;
+ListValue: '[' values+=TypedValue[','] ']' ;
+
 Key: /[a-z0-9_\.]+/;
 
 StringValue: SingleStringValue | StringValueList ;
@@ -76,6 +96,8 @@ Action: action=DropAction
         | action=AddForceAction
         | action=UpdateAction
         | action=RemoveAction
+        | action=AppendAction
+        | action=AppendForceAction
       );
 DropAction: 'drop';
 KeepAction: 'keep';
@@ -84,5 +106,7 @@ AddAction: 'add' key=Key operator=AssignOperator value=STRING;              // a
 AddForceAction: 'add!' key=Key operator=AssignOperator value=STRING;        // add key/value, overwriting existing key
 UpdateAction: 'update' key=Key operator=AssignOperator value=STRING;        // update key/value, do not create if not exists
 RemoveAction: 'remove' key=Key;
-
+AppendAction: 'append' key=Key value=TypedValue;                            // append an element to a list if it exists
+AppendForceAction: 'append!' key=Key value=TypedValue;                      // append an element to a list; converts a single item to a list with one element
+                                                                            // or creates a new list if the key is not included yet
 Comment: /(#|\/\/).*$/ ;

--- a/intelmq/tests/bots/experts/sieve/test_expert.py
+++ b/intelmq/tests/bots/experts/sieve/test_expert.py
@@ -1093,6 +1093,400 @@ class TestSieveExpertBot(test.BotTestCase, unittest.TestCase):
         self.run_bot()
         self.assertMessageEqual(0, event)
 
+    def test_list_equals_match(self):
+        """ Test list-based :equals match """
+        self.sysconfig['file'] = os.path.join(os.path.dirname(__file__), 'test_sieve_files/test_list_equals_match.sieve')
+
+        base = EXAMPLE_INPUT.copy()
+        base['extra.list'] = ['a', 'b', 'c']
+
+        # positive test
+        event = base.copy()
+        event['comment'] = 'match1'
+        expected = base.copy()
+        expected['comment'] = 'changed1'
+
+        self.input_message = event
+        self.run_bot()
+        self.assertMessageEqual(0, expected)
+
+        # negative test
+        event = base.copy()
+        event['comment'] = 'match2'
+        expected = event.copy()
+
+        self.input_message = event
+        self.run_bot()
+        self.assertMessageEqual(0, expected)
+
+        # positive test with negation (!)
+        event = base.copy()
+        event['comment'] = 'match3'
+        expected = base.copy()
+        expected['comment'] = 'changed3'
+
+        self.input_message = event
+        self.run_bot()
+        self.assertMessageEqual(0, expected)
+
+        # negative test with negation (!)
+        event = base.copy()
+        event['comment'] = 'match4'
+        expected = event.copy()
+
+        self.input_message = event
+        self.run_bot()
+        self.assertMessageEqual(0, expected)
+
+    def test_list_setequals_match(self):
+        """ Test list/set-based :setequals match """
+        self.sysconfig['file'] = os.path.join(os.path.dirname(__file__), 'test_sieve_files/test_list_setequals_match.sieve')
+
+        base = EXAMPLE_INPUT.copy()
+        base['extra.list'] = ['a', 'b', 'c']
+
+        # positive test
+        event = base.copy()
+        event['comment'] = 'match1'
+        expected = base.copy()
+        expected['comment'] = 'changed1'
+
+        self.input_message = event
+        self.run_bot()
+        self.assertMessageEqual(0, expected)
+
+        # negative test
+        event = base.copy()
+        event['comment'] = 'match2'
+        expected = event.copy()
+
+        self.input_message = event
+        self.run_bot()
+        self.assertMessageEqual(0, expected)
+
+        # positive test with negation (!)
+        event = base.copy()
+        event['comment'] = 'match3'
+        expected = base.copy()
+        expected['comment'] = 'changed3'
+
+        self.input_message = event
+        self.run_bot()
+        self.assertMessageEqual(0, expected)
+
+        # negative test with negation (!)
+        event = base.copy()
+        event['comment'] = 'match4'
+        expected = event.copy()
+
+        self.input_message = event
+        self.run_bot()
+        self.assertMessageEqual(0, expected)
+
+    def test_list_overlaps_match(self):
+        """ Test list/set-based :overlaps match """
+        self.sysconfig['file'] = os.path.join(os.path.dirname(__file__), 'test_sieve_files/test_list_overlaps_match.sieve')
+
+        base = EXAMPLE_INPUT.copy()
+        base['extra.list'] = ['a', 'b', 'c']
+
+        # positive test
+        event = base.copy()
+        event['comment'] = 'match1'
+        expected = base.copy()
+        expected['comment'] = 'changed1'
+
+        self.input_message = event
+        self.run_bot()
+        self.assertMessageEqual(0, expected)
+
+        # negative test
+        event = base.copy()
+        event['comment'] = 'match2'
+        expected = event.copy()
+
+        self.input_message = event
+        self.run_bot()
+        self.assertMessageEqual(0, expected)
+
+        # positive test with negation (!)
+        event = base.copy()
+        event['comment'] = 'match3'
+        expected = base.copy()
+        expected['comment'] = 'changed3'
+
+        self.input_message = event
+        self.run_bot()
+        self.assertMessageEqual(0, expected)
+
+        # negative test with negation (!)
+        event = base.copy()
+        event['comment'] = 'match4'
+        expected = event.copy()
+
+        self.input_message = event
+        self.run_bot()
+        self.assertMessageEqual(0, expected)
+
+    def test_list_subsetof_match(self):
+        """ Test list/set-based :subsetof match """
+        self.sysconfig['file'] = os.path.join(os.path.dirname(__file__), 'test_sieve_files/test_list_subsetof_match.sieve')
+
+        base = EXAMPLE_INPUT.copy()
+        base['extra.list'] = ['a', 'b', 'c']
+
+        # positive test
+        event = base.copy()
+        event['comment'] = 'match1'
+        expected = base.copy()
+        expected['comment'] = 'changed1'
+
+        self.input_message = event
+        self.run_bot()
+        self.assertMessageEqual(0, expected)
+
+        # negative test
+        event = base.copy()
+        event['comment'] = 'match2'
+        expected = event.copy()
+
+        self.input_message = event
+        self.run_bot()
+        self.assertMessageEqual(0, expected)
+
+        # positive test with negation (!)
+        event = base.copy()
+        event['comment'] = 'match3'
+        expected = base.copy()
+        expected['comment'] = 'changed3'
+
+        self.input_message = event
+        self.run_bot()
+        self.assertMessageEqual(0, expected)
+
+        # negative test with negation (!)
+        event = base.copy()
+        event['comment'] = 'match4'
+        expected = event.copy()
+
+        self.input_message = event
+        self.run_bot()
+        self.assertMessageEqual(0, expected)
+
+    def test_list_supersetof_match(self):
+        """ Test list/set-based :supersetof match """
+        self.sysconfig['file'] = os.path.join(os.path.dirname(__file__), 'test_sieve_files/test_list_supersetof_match.sieve')
+
+        base = EXAMPLE_INPUT.copy()
+        base['extra.list'] = ['a', 'b', 'c']
+
+        # positive test
+        event = base.copy()
+        event['comment'] = 'match1'
+        expected = base.copy()
+        expected['comment'] = 'changed1'
+
+        self.input_message = event
+        self.run_bot()
+        self.assertMessageEqual(0, expected)
+
+        # negative test
+        event = base.copy()
+        event['comment'] = 'match2'
+        expected = event.copy()
+
+        self.input_message = event
+        self.run_bot()
+        self.assertMessageEqual(0, expected)
+
+        # positive test with negation (!)
+        event = base.copy()
+        event['comment'] = 'match3'
+        expected = base.copy()
+        expected['comment'] = 'changed3'
+
+        self.input_message = event
+        self.run_bot()
+        self.assertMessageEqual(0, expected)
+
+        # negative test with negation (!)
+        event = base.copy()
+        event['comment'] = 'match4'
+        expected = event.copy()
+
+        self.input_message = event
+        self.run_bot()
+        self.assertMessageEqual(0, expected)
+
+    def test_bool_match(self):
+        ''' Test bool match '''
+        self.sysconfig['file'] = os.path.join(os.path.dirname(__file__), 'test_sieve_files/test_bool_match.sieve')
+        base = EXAMPLE_INPUT.copy()
+        base['extra.truthy'] = True
+        base['extra.falsy'] = False
+
+        # positive test with true == true
+        event = base.copy()
+        event['comment'] = 'match1'
+        expected = base.copy()
+        expected['comment'] = 'changed1'
+
+        self.input_message = event
+        self.run_bot()
+        self.assertMessageEqual(0, expected)
+
+        # positive test with false == false
+        event = base.copy()
+        event['comment'] = 'match2'
+        expected = base.copy()
+        expected['comment'] = 'changed2'
+
+        self.input_message = event
+        self.run_bot()
+        self.assertMessageEqual(0, expected)
+
+        # positive test with true != false
+        event = base.copy()
+        event['comment'] = 'match3'
+        expected = base.copy()
+        expected['comment'] = 'changed3'
+
+        self.input_message = event
+        self.run_bot()
+        self.assertMessageEqual(0, expected)
+
+        # positive test with false != true
+        event = base.copy()
+        event['comment'] = 'match4'
+        expected = base.copy()
+        expected['comment'] = 'changed4'
+
+        self.input_message = event
+        self.run_bot()
+        self.assertMessageEqual(0, expected)
+
+
+        # negative test with true == false
+        event = base.copy()
+        event['comment'] = 'match5'
+        expected = event.copy()
+
+        self.input_message = event
+        self.run_bot()
+        self.assertMessageEqual(0, expected)
+
+        # negative test with false == true
+        event = base.copy()
+        event['comment'] = 'match6'
+        expected = event.copy()
+
+        self.input_message = event
+        self.run_bot()
+        self.assertMessageEqual(0, expected)
+
+        # negative test with true != true
+        event = base.copy()
+        event['comment'] = 'match7'
+        expected = event.copy()
+
+        self.input_message = event
+        self.run_bot()
+        self.assertMessageEqual(0, expected)
+
+        # negative test with false != false
+        event = base.copy()
+        event['comment'] = 'match8'
+        expected = event.copy()
+
+        self.input_message = event
+        self.run_bot()
+        self.assertMessageEqual(0, expected)
+
+    def test_typed_values(self):
+        ''' Test typed values '''
+        self.sysconfig['file'] = os.path.join(os.path.dirname(__file__), 'test_sieve_files/test_typed_values.sieve')
+        event = EXAMPLE_INPUT.copy()
+        event['extra.list'] = [True, 2.0, 'three', 4]
+        event['comment'] = 'match'
+
+        expected = event.copy()
+        expected['comment'] = 'changed'
+
+        self.input_message = event
+        self.run_bot()
+        self.assertMessageEqual(0, expected)
+
+    def test_append(self):
+        ''' Test append action '''
+        self.sysconfig['file'] = os.path.join(os.path.dirname(__file__), 'test_sieve_files/test_append.sieve')
+
+        # positive test
+        event = EXAMPLE_INPUT.copy()
+        event['comment'] = 'match1'
+        expected = event.copy()
+        event['extra.list'] = ['a', 'b']
+        expected['extra.list'] = ['a', 'b', 'c']
+
+        self.input_message = event
+        self.run_bot()
+        self.assertMessageEqual(0, expected)
+
+        # negative test - non-list value
+        event = EXAMPLE_INPUT.copy()
+        event['comment'] = 'match2'
+        event['extra.single'] = 'something'
+        expected = event.copy()
+
+        self.input_message = event
+        self.run_bot()
+        self.assertMessageEqual(0, expected)
+
+        # negative test - nonexistent value
+        event = EXAMPLE_INPUT.copy()
+        event['comment'] = 'match3'
+        expected = event.copy()
+        expected['extra.nonexistent'] = ['new']
+
+        self.input_message = event
+        self.run_bot()
+        self.assertMessageEqual(0, expected)
+
+    def test_force_append(self):
+        ''' Test force append action '''
+        self.sysconfig['file'] = os.path.join(os.path.dirname(__file__), 'test_sieve_files/test_force_append.sieve')
+
+        # positive test with list
+        event = EXAMPLE_INPUT.copy()
+        event['comment'] = 'match1'
+        expected = event.copy()
+        event['extra.list'] = ['a', 'b']
+        expected['extra.list'] = ['a', 'b', 'c']
+
+        self.input_message = event
+        self.run_bot()
+        self.assertMessageEqual(0, expected)
+
+        # positive test - with non-list value
+        event = EXAMPLE_INPUT.copy()
+        event['comment'] = 'match2'
+        expected = event.copy()
+        event['extra.single'] = 'something'
+        expected['extra.single'] = ['something', 'more']
+
+        self.input_message = event
+        self.run_bot()
+        self.assertMessageEqual(0, expected)
+
+        # positive test with nonexistent value
+        event = EXAMPLE_INPUT.copy()
+        event['comment'] = 'match3'
+        expected = event.copy()
+        expected['extra.nonexistent'] = ['something']
+
+        self.input_message = event
+        self.run_bot()
+        self.assertMessageEqual(0, expected)
+
 
 if __name__ == '__main__':  # pragma: no cover
     unittest.main()

--- a/intelmq/tests/bots/experts/sieve/test_sieve_files/test_append.sieve
+++ b/intelmq/tests/bots/experts/sieve/test_sieve_files/test_append.sieve
@@ -1,0 +1,11 @@
+if comment == 'match1' {
+	append extra.list 'c'
+}
+
+if comment == 'match2' {
+	append extra.single 'unappendable'
+}
+
+if comment == 'match3' {
+	append extra.nonexistent 'new'
+}

--- a/intelmq/tests/bots/experts/sieve/test_sieve_files/test_bool_match.sieve
+++ b/intelmq/tests/bots/experts/sieve/test_sieve_files/test_bool_match.sieve
@@ -1,0 +1,31 @@
+if comment == 'match1' && extra.truthy == true {
+	update comment = 'changed1'
+}
+
+if comment == 'match2' && extra.falsy == false {
+	update comment = 'changed2'
+}
+
+if comment == 'match3' && extra.truthy != false {
+	update comment = 'changed3'
+}
+
+if comment == 'match4' && extra.falsy != true {
+	update comment = 'changed4'
+}
+
+if comment == 'match5' && extra.truthy == false {
+	update comment = 'unreachable'
+}
+
+if comment == 'match6' && extra.falsy == true {
+	update comment = 'unreachable'
+}
+
+if comment == 'match7' && extra.truthy != true {
+	update comment = 'unreachable'
+}
+
+if comment == 'match8' && extra.falsy != false {
+	update comment = 'unreachable'
+}

--- a/intelmq/tests/bots/experts/sieve/test_sieve_files/test_force_append.sieve
+++ b/intelmq/tests/bots/experts/sieve/test_sieve_files/test_force_append.sieve
@@ -1,0 +1,11 @@
+if comment == 'match1' {
+	append! extra.list 'c'
+}
+
+if comment == 'match2' {
+	append! extra.single 'more'
+}
+
+if comment == 'match3' {
+	append! extra.nonexistent 'something'
+}

--- a/intelmq/tests/bots/experts/sieve/test_sieve_files/test_list_equals_match.sieve
+++ b/intelmq/tests/bots/experts/sieve/test_sieve_files/test_list_equals_match.sieve
@@ -1,0 +1,15 @@
+if comment == 'match1' && extra.list :equals ['a', 'b', 'c'] {
+	update comment = 'changed1'
+}
+
+if comment == 'match2' && extra.list :equals ['d', 'e', 'f'] {
+	update comment = 'unreachable'
+}
+
+if comment == 'match3' && extra.list ! :equals ['d', 'e', 'f'] {
+	update comment = 'changed3'
+}
+
+if comment == 'match4' && extra.list ! :equals ['a', 'b', 'c'] {
+	update comment = 'unreachable'
+}

--- a/intelmq/tests/bots/experts/sieve/test_sieve_files/test_list_overlaps_match.sieve
+++ b/intelmq/tests/bots/experts/sieve/test_sieve_files/test_list_overlaps_match.sieve
@@ -1,0 +1,15 @@
+if comment == 'match1' && extra.list :overlaps ['a', 'b', 'd'] {
+	update comment = 'changed1'
+}
+
+if comment == 'match2' && extra.list :overlaps ['d', 'e', 'f'] {
+	update comment = 'unreachable'
+}
+
+if comment == 'match3' && extra.list ! :overlaps ['d', 'e', 'f'] {
+	update comment = 'changed3'
+}
+
+if comment == 'match4' && extra.list ! :overlaps ['a', 'b', 'd'] {
+	update comment = 'unreachable'
+}

--- a/intelmq/tests/bots/experts/sieve/test_sieve_files/test_list_setequals_match.sieve
+++ b/intelmq/tests/bots/experts/sieve/test_sieve_files/test_list_setequals_match.sieve
@@ -1,0 +1,15 @@
+if comment == 'match1' && extra.list :setequals ['a', 'c', 'b', 'a'] {
+	update comment = 'changed1'
+}
+
+if comment == 'match2' && extra.list :setequals ['a', 'b', 'c', 'd'] {
+	update comment = 'unreachable'
+}
+
+if comment == 'match3' && extra.list ! :setequals ['a', 'b', 'c', 'd'] {
+	update comment = 'changed3'
+}
+
+if comment == 'match4' && extra.list ! :setequals ['c', 'b', 'a'] {
+	update comment = 'unreachable'
+}

--- a/intelmq/tests/bots/experts/sieve/test_sieve_files/test_list_subsetof_match.sieve
+++ b/intelmq/tests/bots/experts/sieve/test_sieve_files/test_list_subsetof_match.sieve
@@ -1,0 +1,15 @@
+if comment == 'match1' && extra.list :subsetof ['a', 'b', 'c', 'd'] {
+	update comment = 'changed1'
+}
+
+if comment == 'match2' && extra.list :subsetof ['b', 'c', 'd', 'e'] {
+	update comment = 'unreachable'
+}
+
+if comment == 'match3' && extra.list ! :subsetof ['b', 'c', 'd', 'e'] {
+	update comment = 'changed3'
+}
+
+if comment == 'match4' && extra.list ! :subsetof ['a', 'b', 'c', 'd'] {
+	update comment = 'unreachable'
+}

--- a/intelmq/tests/bots/experts/sieve/test_sieve_files/test_list_supersetof_match.sieve
+++ b/intelmq/tests/bots/experts/sieve/test_sieve_files/test_list_supersetof_match.sieve
@@ -1,0 +1,15 @@
+if comment == 'match1' && extra.list :supersetof ['a', 'b'] {
+	update comment = 'changed1'
+}
+
+if comment == 'match2' && extra.list :supersetof ['a', 'b', 'c', 'd'] {
+	update comment = 'unreachable'
+}
+
+if comment == 'match3' && extra.list ! :supersetof ['a', 'b', 'c', 'd'] {
+	update comment = 'changed3'
+}
+
+if comment == 'match4' && extra.list ! :supersetof ['a', 'b'] {
+	update comment = 'unreachable'
+}

--- a/intelmq/tests/bots/experts/sieve/test_sieve_files/test_typed_values.sieve
+++ b/intelmq/tests/bots/experts/sieve/test_sieve_files/test_typed_values.sieve
@@ -1,0 +1,3 @@
+if extra.list :equals [true, 2.0, 'three', 4] {
+	update comment = 'changed'
+}


### PR DESCRIPTION
This PR refactors some of the Sieve expert and extends the Sieve DSL. In particular, it adds:
* for the below items, a generic `TypedValue` type was added, which can be any of a float, int, bool or str, as well as `ListValue`, which can contain any of the above
* some methods of operating on list objects, like `:equals` for exact matching of lists, and `:setequals`, `:overlaps`, `:subsetof` and `:supersetof` for set-based operations, along with negated counterparts if `!` is specified before the operator (i.e `! :overlaps` would match if the two sets are disjoint)
* matching on bool values with == or !=
* appending to a list value, or force-appending, which appends to lists normally, coerces non-lists into lists with one element and initializes nonexisting lists
* unit tests for all of the above

Feedback is welcome.