### PR TITLE
FIX: intelmq.bots.experts.rdap evaluates http status codes

### DIFF
--- a/intelmq/bots/experts/rdap/expert.py
+++ b/intelmq/bots/experts/rdap/expert.py
@@ -99,6 +99,13 @@ class RDAPExpertBot(Bot):
                             raise NotImplementedError("Authentication type %r (configured for service %r) is not implemented" % (service['auth'], domain_suffix))
 
                     resp = self.__session.get("{0}domain/{1}".format(service['url'], url))
+
+                    if resp.status_code < 200 or resp.status_code > 299:
+                        if resp.status_code == 404:
+                            return
+                        self.logger.debug("RDAP Server '%s' responded with '%d' for domain '%s'.", service['url'], resp.status_code, url)
+                        raise ValueError(f"Unable to process server's response, the returned status-code was {resp.status_code}. Enable debug logging to see more details.")
+
                     try:
                         resp = resp.json()
                     except ValueError:


### PR DESCRIPTION
If status code not in 2xx range, then we throw an error to get administrators attention. There might be an configuration problem or smth else. Status-Code 404 is special, data will not get enriched as rdap does not have any information about that given domain.

Fixes #1887 
Fixes #1893 