### PR TITLE
Sieve: expression negation, nested if / mixed conditionals and actions, support for non-strings in add/add!/update

### DIFF
--- a/docs/user/bots.rst
+++ b/docs/user/bots.rst
@@ -2598,8 +2598,7 @@ The sieve file contains an arbitrary number of rules of the form:
    }
 
 
-*Please note* that nesting if-statements is currently not possible. `ACTIONS`
-must contain one or more actions of the actions listed below.
+Nested if-statements and mixed if statements and rules in the same scope are possible.
 
 *Expressions*
 
@@ -2618,9 +2617,9 @@ The following operators may be used to match events:
 
     ``if :exists source.fqdn { ... }``
 
- * `==` and `!=` match for equality of strings and numbers, for example:
+ * `==` and `!=` match for equality of strings, numbers, and booleans, for example:
 
-   ``if feed.name != 'acme-security' || feed.accuracy == 100 { ... }``
+   ``if feed.name != 'acme-security' || feed.accuracy == 100 || extra.false_positive == false { ... }``
 
  * `:contains` matches on substrings.
 
@@ -2646,7 +2645,7 @@ The following operators may be used to match events:
   Events with values like `8.8.8.8` or `8.8.4.4` will match, as they are always unequal to the other value.
   **Attention:** The result is *not* that the field must be unequal to all given values.
 
- * `:equals` tests for equality between lists, including order. Its result can be inverted by using `! :equals`. Example for checking a hostname-port pair:
+ * `:equals` tests for equality between lists, including order. Example for checking a hostname-port pair:
    ``if extra.host_tuple :equals ['dns.google', 53] { ... }``
  * `:setequals` tests for set-based equality (ignoring duplicates and value order) between a list of given values. Example for checking for the first nameserver of two domains, regardless of the order they are given in the list:
    ``if extra.hostnames :setequals ['ns1.example.com', 'ns1.example.mx'] { ... }``
@@ -2660,14 +2659,16 @@ The following operators may be used to match events:
  * `:supersetof` tests if the list of values from the given key is a superset of the values specified as the argument. Example for matching hosts with at least the IoT and vulnerable tags:
    ``if extra.tags :supersetof ['iot', 'vulnerable'] { ... }``
 
- * The results of the list operators (`:equals`, `:setequals`, `:overlaps`, `:subsetof` and `:supersetof`) can be inverted with a prepended exclamation mark, such as `! :overlaps`. Note that in case there is no value with the given key or it is a non-list value, the result will always be false, regardless of negation. The existence of the key can be checked for separately.
-
  * Boolean values can be matched with `==` or `!=` followed by `true` or `false`. Example:
    ``if extra.has_known_vulns == true { ... }``
 
  * The combination of multiple expressions can be done using parenthesis and boolean operators:
 
   ``if (source.ip == '127.0.0.1') && (comment == 'add field' || classification.taxonomy == 'vulnerable') { ... }``
+
+ * Any single expression or a parenthesised group of expressions can be negated using `!`:
+
+ ``if ! source.ip :contains '127.0.0' || ! ( source.ip == '172.16.0.5' && source.port == 25 ) { ... }``
 
 
 *Actions*
@@ -2677,7 +2678,7 @@ If part of a rule matches the given conditions, the actions enclosed in `{` and
 in the sieve file will be forwarded to the next bot in the pipeline, unless the
 `drop` action is applied.
 
- * `add` adds a key value pair to the event. This action only applies if the key is not yet defined in the event. If the key is already defined, the action is ignored. Example:
+ * `add` adds a key value pair to the event. It can be a string, number, or boolean. This action only applies if the key is not yet defined in the event. If the key is already defined, the action is ignored. Example:
 
    ``add comment = 'hello, world'``
 

--- a/intelmq/bots/experts/sieve/sieve.tx
+++ b/intelmq/bots/experts/sieve/sieve.tx
@@ -3,12 +3,13 @@
  For details, see: https://github.com/igordejanovic/textX
 */
 
-SieveModel: rules*=Rule ;
+SieveModel: statements*=Statement;
 
-Rule: (if_=IfClause (elif_=ElifClause)* (else_=ElseClause)? | actions_*=Action);
-IfClause: 'if' expr=Expression '{' actions*=Action '}';
-ElifClause: 'elif' expr=Expression '{' actions*=Action '}';
-ElseClause: 'else' '{' actions*=Action '}';
+Statement: Action | Branching;
+Branching: if_=IfClause elif_*=ElifClause (else_=ElseClause)?;
+IfClause: 'if' expr=Expression '{' statements*=Statement '}';
+ElifClause: 'elif' expr=Expression '{' statements*=Statement '}';
+ElseClause: 'else' '{' statements*=Statement '}';
 
 Expression: conj=Conjunction ('||' conj=Conjunction)*;
 Conjunction: cond=Condition ('&&' cond=Condition)*;

--- a/intelmq/bots/experts/sieve/sieve.tx
+++ b/intelmq/bots/experts/sieve/sieve.tx
@@ -105,9 +105,9 @@ Action: action=DropAction
 DropAction: 'drop';
 KeepAction: 'keep';
 PathAction: 'path' path=PathValue;
-AddAction: 'add' key=Key operator=AssignOperator value=STRING;              // add key/value without overwriting existing key
-AddForceAction: 'add!' key=Key operator=AssignOperator value=STRING;        // add key/value, overwriting existing key
-UpdateAction: 'update' key=Key operator=AssignOperator value=STRING;        // update key/value, do not create if not exists
+AddAction: 'add' key=Key operator=AssignOperator value=TypedValue;          // add key/value without overwriting existing key
+AddForceAction: 'add!' key=Key operator=AssignOperator value=TypedValue;    // add key/value, overwriting existing key
+UpdateAction: 'update' key=Key operator=AssignOperator value=TypedValue;    // update key/value, do not create if not exists
 RemoveAction: 'remove' key=Key;
 AppendAction: 'append' key=Key value=TypedValue;                            // append an element to a list if it exists
 AppendForceAction: 'append!' key=Key value=TypedValue;                      // append an element to a list; converts a single item to a list with one element

--- a/intelmq/bots/experts/sieve/sieve.tx
+++ b/intelmq/bots/experts/sieve/sieve.tx
@@ -13,13 +13,15 @@ ElseClause: 'else' '{' actions*=Action '}';
 Expression: conj=Conjunction ('||' conj=Conjunction)*;
 Conjunction: cond=Condition ('&&' cond=Condition)*;
 Condition:
-    match=StringMatch
-    | match=NumericMatch
-    | match=IpRangeMatch
-    | match=ExistMatch
-    | match=ListMatch
-    | match=BoolMatch
-    | ( '(' match=Expression ')' )
+    neg?=Negation (
+        match=StringMatch
+        | match=NumericMatch
+        | match=IpRangeMatch
+        | match=ExistMatch
+        | match=ListMatch
+        | match=BoolMatch
+        | ( '(' match=Expression ')' )
+    )
 ;
 
 
@@ -51,7 +53,7 @@ IpRangeList: '[' values+=SingleIpRange[','] ']' ;
 ExistMatch: op=ExistOperator key=Key;
 ExistOperator: ':exists' | ':notexists';
 
-ListMatch: key=Key neg=Negation? op=ListOperator value=ListValue;
+ListMatch: key=Key op=ListOperator value=ListValue;
 ListOperator:
   ':equals'           // lists are equal, including order
   | ':setequals'      // lists contain the same elements, ignoring order and repeating values

--- a/intelmq/tests/bots/experts/sieve/test_expert.py
+++ b/intelmq/tests/bots/experts/sieve/test_expert.py
@@ -17,7 +17,7 @@ EXAMPLE_MD5 = {"__type": "Event",
                }
 
 
-#@test.skip_exotic()
+@test.skip_exotic()
 class TestSieveExpertBot(test.BotTestCase, unittest.TestCase):
     """
     A TestCase for SieveExpertBot.

--- a/intelmq/tests/bots/experts/sieve/test_expert.py
+++ b/intelmq/tests/bots/experts/sieve/test_expert.py
@@ -17,7 +17,7 @@ EXAMPLE_MD5 = {"__type": "Event",
                }
 
 
-@test.skip_exotic()
+#@test.skip_exotic()
 class TestSieveExpertBot(test.BotTestCase, unittest.TestCase):
     """
     A TestCase for SieveExpertBot.
@@ -1119,25 +1119,6 @@ class TestSieveExpertBot(test.BotTestCase, unittest.TestCase):
         self.run_bot()
         self.assertMessageEqual(0, expected)
 
-        # positive test with negation (!)
-        event = base.copy()
-        event['comment'] = 'match3'
-        expected = base.copy()
-        expected['comment'] = 'changed3'
-
-        self.input_message = event
-        self.run_bot()
-        self.assertMessageEqual(0, expected)
-
-        # negative test with negation (!)
-        event = base.copy()
-        event['comment'] = 'match4'
-        expected = event.copy()
-
-        self.input_message = event
-        self.run_bot()
-        self.assertMessageEqual(0, expected)
-
     def test_list_setequals_match(self):
         """ Test list/set-based :setequals match """
         self.sysconfig['file'] = os.path.join(os.path.dirname(__file__), 'test_sieve_files/test_list_setequals_match.sieve')
@@ -1158,25 +1139,6 @@ class TestSieveExpertBot(test.BotTestCase, unittest.TestCase):
         # negative test
         event = base.copy()
         event['comment'] = 'match2'
-        expected = event.copy()
-
-        self.input_message = event
-        self.run_bot()
-        self.assertMessageEqual(0, expected)
-
-        # positive test with negation (!)
-        event = base.copy()
-        event['comment'] = 'match3'
-        expected = base.copy()
-        expected['comment'] = 'changed3'
-
-        self.input_message = event
-        self.run_bot()
-        self.assertMessageEqual(0, expected)
-
-        # negative test with negation (!)
-        event = base.copy()
-        event['comment'] = 'match4'
         expected = event.copy()
 
         self.input_message = event
@@ -1209,25 +1171,6 @@ class TestSieveExpertBot(test.BotTestCase, unittest.TestCase):
         self.run_bot()
         self.assertMessageEqual(0, expected)
 
-        # positive test with negation (!)
-        event = base.copy()
-        event['comment'] = 'match3'
-        expected = base.copy()
-        expected['comment'] = 'changed3'
-
-        self.input_message = event
-        self.run_bot()
-        self.assertMessageEqual(0, expected)
-
-        # negative test with negation (!)
-        event = base.copy()
-        event['comment'] = 'match4'
-        expected = event.copy()
-
-        self.input_message = event
-        self.run_bot()
-        self.assertMessageEqual(0, expected)
-
     def test_list_subsetof_match(self):
         """ Test list/set-based :subsetof match """
         self.sysconfig['file'] = os.path.join(os.path.dirname(__file__), 'test_sieve_files/test_list_subsetof_match.sieve')
@@ -1254,25 +1197,6 @@ class TestSieveExpertBot(test.BotTestCase, unittest.TestCase):
         self.run_bot()
         self.assertMessageEqual(0, expected)
 
-        # positive test with negation (!)
-        event = base.copy()
-        event['comment'] = 'match3'
-        expected = base.copy()
-        expected['comment'] = 'changed3'
-
-        self.input_message = event
-        self.run_bot()
-        self.assertMessageEqual(0, expected)
-
-        # negative test with negation (!)
-        event = base.copy()
-        event['comment'] = 'match4'
-        expected = event.copy()
-
-        self.input_message = event
-        self.run_bot()
-        self.assertMessageEqual(0, expected)
-
     def test_list_supersetof_match(self):
         """ Test list/set-based :supersetof match """
         self.sysconfig['file'] = os.path.join(os.path.dirname(__file__), 'test_sieve_files/test_list_supersetof_match.sieve')
@@ -1293,25 +1217,6 @@ class TestSieveExpertBot(test.BotTestCase, unittest.TestCase):
         # negative test
         event = base.copy()
         event['comment'] = 'match2'
-        expected = event.copy()
-
-        self.input_message = event
-        self.run_bot()
-        self.assertMessageEqual(0, expected)
-
-        # positive test with negation (!)
-        event = base.copy()
-        event['comment'] = 'match3'
-        expected = base.copy()
-        expected['comment'] = 'changed3'
-
-        self.input_message = event
-        self.run_bot()
-        self.assertMessageEqual(0, expected)
-
-        # negative test with negation (!)
-        event = base.copy()
-        event['comment'] = 'match4'
         expected = event.copy()
 
         self.input_message = event
@@ -1486,6 +1391,94 @@ class TestSieveExpertBot(test.BotTestCase, unittest.TestCase):
         self.input_message = event
         self.run_bot()
         self.assertMessageEqual(0, expected)
+
+    def test_negation(self):
+        ''' Test expression negation '''
+        self.sysconfig['file'] = os.path.join(os.path.dirname(__file__), 'test_sieve_files/test_negation.sieve')
+
+        # positive test with single expression
+        event = EXAMPLE_INPUT.copy()
+        event['comment'] = 'match1'
+        expected = event.copy()
+        expected['comment'] = 'changed1'
+
+        self.input_message = event
+        self.run_bot()
+        self.assertMessageEqual(0, expected)
+
+        # positive test with single expression in braces
+        event = EXAMPLE_INPUT.copy()
+        event['comment'] = 'match2'
+        expected = event.copy()
+        expected['comment'] = 'changed2'
+
+        self.input_message = event
+        self.run_bot()
+        self.assertMessageEqual(0, expected)
+
+        # positive test with OR'ing of two negated expressions, first matches
+        event = EXAMPLE_INPUT.copy()
+        event['comment'] = 'match3'
+        event['extra.text'] = 'test1'
+        expected = event.copy()
+        expected['comment'] = 'changed3'
+
+        self.input_message = event
+        self.run_bot()
+        self.assertMessageEqual(0, expected)
+
+        # positive test with OR'ing of two negated expressions, second matches
+        event = EXAMPLE_INPUT.copy()
+        event['comment'] = 'match3'
+        event['extra.text'] = 'test2'
+        expected = event.copy()
+        expected['comment'] = 'changed3'
+
+        self.input_message = event
+        self.run_bot()
+        self.assertMessageEqual(0, expected)
+
+        # positive test with OR'ing of two negated expressions, neither match
+        event = EXAMPLE_INPUT.copy()
+        event['comment'] = 'match3'
+        event['extra.text'] = 'test3'
+        expected = event.copy()
+
+        self.input_message = event
+        self.run_bot()
+        self.assertMessageEqual(0, expected)
+
+        # negative test with AND'ing of two negated expressions, first does not match
+        event = EXAMPLE_INPUT.copy()
+        event['comment'] = 'match4'
+        event['extra.text'] = 'test1'
+        expected = event.copy()
+
+        self.input_message = event
+        self.run_bot()
+        self.assertMessageEqual(0, expected)
+
+        # negative test with AND'ing of two negated expressions, second does not match
+        event = EXAMPLE_INPUT.copy()
+        event['comment'] = 'match4'
+        event['extra.text'] = 'test2'
+        expected = event.copy()
+
+        self.input_message = event
+        self.run_bot()
+        self.assertMessageEqual(0, expected)
+
+        # positive test with AND'ing of two negated expressions
+        event = EXAMPLE_INPUT.copy()
+        event['comment'] = 'match4'
+        event['extra.text'] = 'test3'
+        expected = event.copy()
+        expected['comment'] = 'changed4'
+
+        self.input_message = event
+        self.run_bot()
+        self.assertMessageEqual(0, expected)
+
 
 
 if __name__ == '__main__':  # pragma: no cover

--- a/intelmq/tests/bots/experts/sieve/test_expert.py
+++ b/intelmq/tests/bots/experts/sieve/test_expert.py
@@ -1310,9 +1310,11 @@ class TestSieveExpertBot(test.BotTestCase, unittest.TestCase):
     def test_typed_values(self):
         ''' Test typed values '''
         self.sysconfig['file'] = os.path.join(os.path.dirname(__file__), 'test_sieve_files/test_typed_values.sieve')
+
+        # test with list of values of mixed types
         event = EXAMPLE_INPUT.copy()
-        event['extra.list'] = [True, 2.0, 'three', 4]
-        event['comment'] = 'match'
+        event['extra.list'] = [True, 2.1, 'three', 4]
+        event['comment'] = 'foo'
 
         expected = event.copy()
         expected['comment'] = 'changed'
@@ -1320,6 +1322,49 @@ class TestSieveExpertBot(test.BotTestCase, unittest.TestCase):
         self.input_message = event
         self.run_bot()
         self.assertMessageEqual(0, expected)
+
+        # test assigning a string
+        event = EXAMPLE_INPUT.copy()
+        event['comment'] = 'match1'
+        expected = event.copy()
+        expected['extra.value'] = 'string'
+
+        self.input_message = event
+        self.run_bot()
+        self.assertMessageEqual(0, expected)
+
+        # test force-adding an int
+        event = EXAMPLE_INPUT.copy()
+        event['comment'] = 'match2'
+        expected = event.copy()
+        expected['extra.value'] = 100
+
+        self.input_message = event
+        self.run_bot()
+        self.assertMessageEqual(0, expected)
+
+        # test updating to a string
+        event = EXAMPLE_INPUT.copy()
+        event['comment'] = 'match3'
+        expected = event.copy()
+        expected['extra.value'] = 1.5
+
+        self.input_message = event
+        self.run_bot()
+        self.assertMessageEqual(0, expected)
+
+        # test assigning a bool
+        event = EXAMPLE_INPUT.copy()
+        event['comment'] = 'match4'
+        expected = event.copy()
+        expected['extra.value'] = True
+
+        self.input_message = event
+        self.run_bot()
+        self.assertMessageEqual(0, expected)
+
+
+
 
     def test_append(self):
         ''' Test append action '''

--- a/intelmq/tests/bots/experts/sieve/test_expert.py
+++ b/intelmq/tests/bots/experts/sieve/test_expert.py
@@ -1479,6 +1479,129 @@ class TestSieveExpertBot(test.BotTestCase, unittest.TestCase):
         self.run_bot()
         self.assertMessageEqual(0, expected)
 
+    def test_nested_if(self):
+        ''' Test nested if statements '''
+        self.sysconfig['file'] = os.path.join(os.path.dirname(__file__), 'test_sieve_files/test_nested_if.sieve')
+
+        # match outer if and inner if
+        event = EXAMPLE_INPUT.copy()
+        event['comment'] = 'match1'
+        event['extra.text'] = 'test1'
+        expected = event.copy()
+        expected['comment'] = 'changed1'
+
+        self.input_message = event
+        self.run_bot()
+        self.assertMessageEqual(0, expected)
+
+        # match outer if and inner elif
+        event = EXAMPLE_INPUT.copy()
+        event['comment'] = 'match1'
+        event['extra.text'] = 'test2'
+        expected = event.copy()
+        expected['comment'] = 'changed2'
+
+        self.input_message = event
+        self.run_bot()
+        self.assertMessageEqual(0, expected)
+
+        # match outer if and inner else
+        event = EXAMPLE_INPUT.copy()
+        event['comment'] = 'match1'
+        expected = event.copy()
+        expected['comment'] = 'changed3'
+
+        self.input_message = event
+        self.run_bot()
+        self.assertMessageEqual(0, expected)
+
+        # match outer elif and inner if
+        event = EXAMPLE_INPUT.copy()
+        event['comment'] = 'match2'
+        event['extra.text'] = 'test4'
+        expected = event.copy()
+        expected['comment'] = 'changed4'
+
+        self.input_message = event
+        self.run_bot()
+        self.assertMessageEqual(0, expected)
+
+        # match outer elif and inner elif
+        event = EXAMPLE_INPUT.copy()
+        event['comment'] = 'match2'
+        event['extra.text'] = 'test5'
+        expected = event.copy()
+        expected['comment'] = 'changed5'
+
+        self.input_message = event
+        self.run_bot()
+        self.assertMessageEqual(0, expected)
+
+        # match outer elif and inner else
+        event = EXAMPLE_INPUT.copy()
+        event['comment'] = 'match2'
+        expected = event.copy()
+        expected['comment'] = 'changed6'
+
+        self.input_message = event
+        self.run_bot()
+        self.assertMessageEqual(0, expected)
+
+        # match outer else and inner if
+        event = EXAMPLE_INPUT.copy()
+        event['comment'] = 'match3'
+        event['extra.text'] = 'test7'
+        expected = event.copy()
+        expected['comment'] = 'changed7'
+
+        self.input_message = event
+        self.run_bot()
+        self.assertMessageEqual(0, expected)
+
+        # match outer else and inner elif
+        event = EXAMPLE_INPUT.copy()
+        event['comment'] = 'match3'
+        event['extra.text'] = 'test8'
+        expected = event.copy()
+        expected['comment'] = 'changed8'
+
+        self.input_message = event
+        self.run_bot()
+        self.assertMessageEqual(0, expected)
+
+        # match outer else and inner else
+        event = EXAMPLE_INPUT.copy()
+        event['comment'] = 'match3'
+        expected = event.copy()
+        expected['comment'] = 'changed9'
+
+        self.input_message = event
+        self.run_bot()
+        self.assertMessageEqual(0, expected)
+
+    def test_mixed_if_and_actions(self):
+        ''' Test mixed if statements and actions '''
+        self.sysconfig['file'] = os.path.join(os.path.dirname(__file__), 'test_sieve_files/test_mixed_if.sieve')
+
+        # pass unconditional and conditional statement
+        event = EXAMPLE_INPUT.copy()
+        event['comment'] = 'match'
+        expected = event.copy()
+        expected['comment'] = 'changed'
+        expected['extra.tag'] = 'matched'
+
+        self.input_message = event
+        self.run_bot()
+        self.assertMessageEqual(0, expected)
+
+        # pass unconditional, but not conditional statement
+        event = EXAMPLE_INPUT.copy()
+        expected = event.copy()
+        expected['extra.tag'] = 'matched'
+
+        self.input_message = event
+        self.run_bot()
+        self.assertMessageEqual(0, expected)
 
 
 if __name__ == '__main__':  # pragma: no cover

--- a/intelmq/tests/bots/experts/sieve/test_sieve_files/test_list_equals_match.sieve
+++ b/intelmq/tests/bots/experts/sieve/test_sieve_files/test_list_equals_match.sieve
@@ -5,11 +5,3 @@ if comment == 'match1' && extra.list :equals ['a', 'b', 'c'] {
 if comment == 'match2' && extra.list :equals ['d', 'e', 'f'] {
 	update comment = 'unreachable'
 }
-
-if comment == 'match3' && extra.list ! :equals ['d', 'e', 'f'] {
-	update comment = 'changed3'
-}
-
-if comment == 'match4' && extra.list ! :equals ['a', 'b', 'c'] {
-	update comment = 'unreachable'
-}

--- a/intelmq/tests/bots/experts/sieve/test_sieve_files/test_list_overlaps_match.sieve
+++ b/intelmq/tests/bots/experts/sieve/test_sieve_files/test_list_overlaps_match.sieve
@@ -5,11 +5,3 @@ if comment == 'match1' && extra.list :overlaps ['a', 'b', 'd'] {
 if comment == 'match2' && extra.list :overlaps ['d', 'e', 'f'] {
 	update comment = 'unreachable'
 }
-
-if comment == 'match3' && extra.list ! :overlaps ['d', 'e', 'f'] {
-	update comment = 'changed3'
-}
-
-if comment == 'match4' && extra.list ! :overlaps ['a', 'b', 'd'] {
-	update comment = 'unreachable'
-}

--- a/intelmq/tests/bots/experts/sieve/test_sieve_files/test_list_setequals_match.sieve
+++ b/intelmq/tests/bots/experts/sieve/test_sieve_files/test_list_setequals_match.sieve
@@ -5,11 +5,3 @@ if comment == 'match1' && extra.list :setequals ['a', 'c', 'b', 'a'] {
 if comment == 'match2' && extra.list :setequals ['a', 'b', 'c', 'd'] {
 	update comment = 'unreachable'
 }
-
-if comment == 'match3' && extra.list ! :setequals ['a', 'b', 'c', 'd'] {
-	update comment = 'changed3'
-}
-
-if comment == 'match4' && extra.list ! :setequals ['c', 'b', 'a'] {
-	update comment = 'unreachable'
-}

--- a/intelmq/tests/bots/experts/sieve/test_sieve_files/test_list_subsetof_match.sieve
+++ b/intelmq/tests/bots/experts/sieve/test_sieve_files/test_list_subsetof_match.sieve
@@ -5,11 +5,3 @@ if comment == 'match1' && extra.list :subsetof ['a', 'b', 'c', 'd'] {
 if comment == 'match2' && extra.list :subsetof ['b', 'c', 'd', 'e'] {
 	update comment = 'unreachable'
 }
-
-if comment == 'match3' && extra.list ! :subsetof ['b', 'c', 'd', 'e'] {
-	update comment = 'changed3'
-}
-
-if comment == 'match4' && extra.list ! :subsetof ['a', 'b', 'c', 'd'] {
-	update comment = 'unreachable'
-}

--- a/intelmq/tests/bots/experts/sieve/test_sieve_files/test_list_supersetof_match.sieve
+++ b/intelmq/tests/bots/experts/sieve/test_sieve_files/test_list_supersetof_match.sieve
@@ -5,11 +5,3 @@ if comment == 'match1' && extra.list :supersetof ['a', 'b'] {
 if comment == 'match2' && extra.list :supersetof ['a', 'b', 'c', 'd'] {
 	update comment = 'unreachable'
 }
-
-if comment == 'match3' && extra.list ! :supersetof ['a', 'b', 'c', 'd'] {
-	update comment = 'changed3'
-}
-
-if comment == 'match4' && extra.list ! :supersetof ['a', 'b'] {
-	update comment = 'unreachable'
-}

--- a/intelmq/tests/bots/experts/sieve/test_sieve_files/test_mixed_if.sieve
+++ b/intelmq/tests/bots/experts/sieve/test_sieve_files/test_mixed_if.sieve
@@ -1,0 +1,5 @@
+add extra.tag = 'matched'
+
+if comment == 'match' {
+	update comment = 'changed'
+}

--- a/intelmq/tests/bots/experts/sieve/test_sieve_files/test_negation.sieve
+++ b/intelmq/tests/bots/experts/sieve/test_sieve_files/test_negation.sieve
@@ -1,0 +1,15 @@
+if comment == 'match1' && ! extra.text == 'test' {
+	update comment = 'changed1'
+}
+
+if comment == 'match2' && ! ( extra.text == 'test' ) {
+	update comment = 'changed2'
+}
+
+if comment == 'match3' && ( ! extra.text != 'test1' || ! extra.text != 'test2' ) {
+	update comment = 'changed3'
+}
+
+if comment == 'match4' &&  ( ! extra.text == 'test1' && ! extra.text == 'test2' ) {
+	update comment = 'changed4'
+}

--- a/intelmq/tests/bots/experts/sieve/test_sieve_files/test_nested_if.sieve
+++ b/intelmq/tests/bots/experts/sieve/test_sieve_files/test_nested_if.sieve
@@ -1,0 +1,33 @@
+if comment == 'match1' {
+	if extra.text == 'test1' {
+		update comment = 'changed1'
+	}
+	elif extra.text == 'test2' {
+		update comment = 'changed2'
+	}
+	else {
+		update comment = 'changed3'
+	}
+}
+elif comment == 'match2' {
+	if extra.text == 'test4' {
+		update comment = 'changed4'
+	}
+	elif extra.text == 'test5' {
+		update comment = 'changed5'
+	}
+	else {
+		update comment = 'changed6'
+	}
+}
+else {
+	if extra.text == 'test7' {
+		update comment = 'changed7'
+	}
+	elif extra.text == 'test8' {
+		update comment = 'changed8'
+	}
+	else {
+		update comment = 'changed9'
+	}
+}

--- a/intelmq/tests/bots/experts/sieve/test_sieve_files/test_typed_values.sieve
+++ b/intelmq/tests/bots/experts/sieve/test_sieve_files/test_typed_values.sieve
@@ -1,3 +1,18 @@
-if extra.list :equals [true, 2.0, 'three', 4] {
+if extra.list :equals [true, 2.1, 'three', 4] {
 	update comment = 'changed'
+}
+
+if comment == 'match1' {
+	add extra.value = 'string'
+}
+elif comment == 'match2' {
+	add extra.value = 'dummy value'
+	add! extra.value = 100
+}
+elif comment == 'match3' {
+	add extra.value = 'dummy value'
+	update extra.value = 1.5
+}
+elif comment == 'match4' {
+	add extra.value = true
 }


### PR DESCRIPTION
This PR has three parts:
* generic negation of arbitrary expressions, along with the removal of the list match negation
* nested if statements, plus mixed actions and actions in the same scope
* the attribute manipulation actions `add`, `add!` and `update` support non-string (bool/int/float) values

There is also an RFC-ish last commit, with some somewhat breaking changes.
* Some operators which were made redundant by negation (`!~` and `:notcontains`) are removed
* `:in` is used for list inclusion checks instead of `==`
* there's a clear split between single-value and multi-value matches, with a couple of new operators due to that: `:containsany` and `:regexin` for string matching against multiple regexes or string inclusions)

The last commit is not expected to be accepted at the moment. It'll break a bunch of stuff. Though comments on it would be appreciated.