### PR TITLE
FIX: GHA docker workflow publish

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -52,6 +52,7 @@ jobs:
 
       - name: Login to DockerHub
         uses: docker/login-action@v1
+        if: github.repository == 'certtools/intelmq'
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -71,6 +72,7 @@ jobs:
           ./test.sh
 
       - name: Publish develop version to dockerhub
+        if: github.repository == 'certtools/intelmq'
         run: |
           docker tag intelmq-full:latest certat/intelmq-full:develop
           docker push certat/intelmq-full:develop


### PR DESCRIPTION
Publishing a new docker image to certat/* namespace on dockerhub
will only run if repository name is certtools/intelmq. So forks
dont fail as they dont execute the publish commands.

Fixes #1931

Signed-off-by: Sebastian Waldbauer <waldbauer@cert.at>
