### PR TITLE
DOCS: Updated docker instructions

### DIFF
--- a/docs/dev/release-procedure.rst
+++ b/docs/dev/release-procedure.rst
@@ -73,7 +73,9 @@ Releasing a new Docker image is very easy.
 * Clone `IntelMQ Docker Repository <https://github.com/certat/intelmq-docker>`_ with ``git clone https://github.com/certat/intelmq-docker.git --recursive`` as this repository contains submodules
 * Run `./build.sh`, check your console if the build was successful.
 * Run `./test.sh` - It will run nosetests3 with exotic flag. All errors/warnings will be displayed.
-* If no error/warning was shown, you can release with `./publish.sh`. Change the namespace variable in `publish.sh`.
+* Change the ``build_version`` in ``publish.sh`` to the new version you want to release.
+* Change the ``namespace`` variable in `publish.sh`.
+* If no error/warning was shown, you can release with `./publish.sh`.
 
 *************
 Announcements

--- a/docs/user/installation.rst
+++ b/docs/user/installation.rst
@@ -89,7 +89,6 @@ Optional dependencies:
 Docker (beta)
 ^^^^^^^^^^^^^
 
-**ATTENTION** Currently the version published on docker hub is not tagged with the same IntelMQ version. During beta, each version is published with tag `1.0`.
 **ATTENTION** Currently you can't manage your botnet via :doc:`intelmqctl`. You need to use `IntelMQ-Manager <https://github.com/certtools/intelmq-manager>`_ currently!
 
 Follow `Docker Install <https://docs.docker.com/engine/install/>`_ and
@@ -135,9 +134,9 @@ PyPi
 .. code-block:: bash
 
    sudo -i
-   
+
    pip3 install intelmq
-   
+
    useradd -d /opt/intelmq -U -s /bin/bash intelmq
    sudo intelmqsetup
 
@@ -178,7 +177,7 @@ In order to work with your current infrastructure, you need to specify some envi
 
    sudo docker pull redis:latest
 
-   sudo docker pull certat/intelmq-full:1.0
+   sudo docker pull certat/intelmq-full:latest
 
    sudo docker pull certat/intelmq-nginx:latest
 
@@ -189,8 +188,7 @@ In order to work with your current infrastructure, you need to specify some envi
                    --name redis \
                    redis:latest
 
-   sudo docker run -v ~/intelmq/intelmq-manager/html:/www \
-                   --network intelmq-internal \
+   sudo docker run --network intelmq-internal \
                    --name nginx \
                    certat/intelmq-nginx:latest
 

--- a/docs/user/upgrade.rst
+++ b/docs/user/upgrade.rst
@@ -40,11 +40,11 @@ Use your systems package management.
 Docker (beta)
 ^^^^^^^^^^^^^
 
-**ATTENTION** Currently the version published on docker hub is not tagged with the same IntelMQ version. During beta, each version is published with tag `1.0`.
+You can check out all current versions on our `DockerHub <https://hub.docker.com/r/certat/intelmq-full>`_.
 
 .. code-block:: bash
 
-   docker pull certat/intelmq-full:1.0
+   docker pull certat/intelmq-full:latest
 
    docker pull certat/intelmq-nginx:latest
 
@@ -60,7 +60,7 @@ The Version format for each included item is `key=value` and they are saparated 
 
 .. code-block:: bash
 
-   docker inspect --format '{{ index .Config.Labels "org.opencontainers.image.version" }}' intelmq-full:1.0
+   docker inspect --format '{{ index .Config.Labels "org.opencontainers.image.version" }}' intelmq-full:latest
 
 Now restart your container, if you're using docker-compose you simply write:
 


### PR DESCRIPTION
Adapted docker instructions as they are now a bit different than
our first release. We are publishing intelmq with its current
version on dockerhub now. Tag 1.0 will remain but is deprecated.