### PR TITLE
FIX: RDAP checks if entity is valid entity-type

### DIFF
--- a/intelmq/bots/experts/rdap/expert.py
+++ b/intelmq/bots/experts/rdap/expert.py
@@ -112,12 +112,20 @@ class RDAPExpertBot(Bot):
                         self.logger.debug("Server response: %r", resp.text)
                         raise ValueError("Unable to parse server response as JSON. Enable debug logging to see more details.")
                     for entity in resp['entities']:
+                        if not isinstance(entity, dict):
+                            self.logger.warn("Invalid type '%s' in entities of response for domain '%s' found.", type(entity), url)
+                            continue
+
                         if 'removed' in entity['roles']:
                             continue
 
                         for entrole in entity['roles']:
                             if 'entities' in entity:
                                 for subentity in entity['entities']:
+                                    if not isinstance(subentity, dict):
+                                        self.logger.warn("Invalid type '%s' in entities of response for domain '%s' found.", type(subentity), url)
+                                        continue
+
                                     for subentrole in subentity['roles']:
                                         if 'vcardArray' in subentity:
                                             entity_data = self.parse_entities(subentity['vcardArray'])

--- a/intelmq/tests/bots/experts/rdap/test_data/example.com.json
+++ b/intelmq/tests/bots/experts/rdap/test_data/example.com.json
@@ -1,0 +1,161 @@
+{
+    "events": [{
+        "eventDate": "2014-04-29T14:08:54.068772Z",
+        "eventActor": 9999,
+        "eventAction": "registration"
+    }, {
+        "eventDate": "2017-06-07T06:39:57.707217Z",
+        "eventActor": 9999,
+        "eventAction": "last changed"
+    }, {
+        "eventDate": "2022-04-29T14:08:54.068772Z",
+        "eventAction": "expiration"
+    }, {
+        "eventDate": "2021-05-12T09:10:06.405218Z",
+        "eventAction": "last update of RDAP database"
+    }],
+    "handle": "D0000000007-VERS",
+    "status": ["auto renew period", "client delete prohibited", "client transfer prohibited", "client update prohibited", "server delete prohibited", "server transfer prohibited", "server update prohibited"],
+    "ldhName": "nic.com",
+    "notices": [{
+        "links": [{
+            "rel": "terms-of-service",
+            "href": "http://www.nic.com/rdap/tos",
+            "type": "text/html"
+        }],
+        "title": "Terms of service",
+        "description": ["Copyright (c) 2021 by example.com(2)", "Except for agreed Internet operational purposes, no part of this information may be reproduced, stored in a retrieval system, or transmitted, in any form or by any means, electronic, mechanical, recording, or otherwise, without  prior permission of example.com on behalf of itself and/or the copyright holders. Any use of this material to target advertising or similar activities is explicitly forbidden and can be prosecuted.", "Furthermore, it is strictly forbidden to use the RDAP database in such a way that jeopardizes or could jeopardize the stability of the technical systems of example.com under any circumstances. In particular, this includes any misuse of the RDAP database and any use of he RDAP database which disturbs its operation. ", "Should the user violate these points, example.com reserves the right to deactivate the RDAP database entirely or partly for the user. Moreover, the user shall be held liable for any and all damage arising from a violation of these points."]
+    }, {
+        "links": [{
+            "href": "https://icann.org/epp",
+            "type": "text/html"
+        }],
+        "title": "Status Codes",
+        "description": ["For more information on domain status codes, please visit https://icann.org/epp"]
+    }, {
+        "links": [{
+            "href": "https://icann.org/wicf",
+            "type": "text/html"
+        }],
+        "title": "RDDS Inaccuracy Complaint Form",
+        "description": ["URL of the ICANN RDDS Inaccuracy Complaint Form: https://icann.org/wicf"]
+    }],
+    "entities": [{
+        "roles": ["registrant", "administrative"],
+        "events": [{
+            "eventDate": "2017-01-24T07:28:44.320049Z",
+            "eventActor": 9999,
+            "eventAction": "registration"
+        },
+        null,
+        {
+            "eventDate": "2018-09-26T07:16:34.157134Z",
+            "eventActor": 9999,
+            "eventAction": "last changed"
+        }],
+        "handle": "C0000013489-VERS",
+        "status": ["active", "associated"],
+        "remarks": [{
+            "type": "object redacted due to authorization",
+            "title": "EMAIL REDACTED FOR PRIVACY",
+            "description": ["Please query the RDDS  service of the registrar of record identified in this output for information on how to contact the registrant of the queried domain name"]
+        }],
+        "vcardArray": ["vcard", [
+            ["version", {}, "text", "4.0"],
+            ["fn", {}, "text", "example.com"],
+            ["adr", {
+                "cc": "DE"
+            }, "text", ["", "", "Any-Address 13/37", "Berlin", "Berlin", "1337", ""]]
+        ]],
+        "objectClassName": "entity"
+    },
+    null,
+    {
+        "roles": ["technical"],
+        "events": [{
+            "eventDate": "2014-04-29T14:08:52.546880Z",
+            "eventActor": 9999,
+            "eventAction": "registration"
+        }, {
+            "eventDate": "2018-05-24T07:32:11.358333Z",
+            "eventActor": 9999,
+            "eventAction": "last changed"
+        }],
+        "handle": "C0000000002-VERS",
+        "status": ["active", "associated"],
+        "remarks": [{
+            "type": "object redacted due to authorization",
+            "title": "EMAIL REDACTED FOR PRIVACY",
+            "description": ["Please query the RDDS  service of the registrar of record identified in this output for information on how to contact the registrant of the queried domain name"]
+        }],
+        "vcardArray": ["vcard", [
+            ["version", {}, "text", "4.0"],
+            ["fn", {}, "text", "EXAMPLE"],
+            ["org", {}, "text", "example.com"],
+            ["adr", {
+                "cc": "AT"
+            }, "text", ["", "", "Any-Address 13/37", "Berlin", "Berlin", "1337", ""]],
+            ["tel", {
+                "type": "voice"
+            }, "uri", "tel:+13.371337;ext=730"],
+            ["tel", {
+                "type": "fax"
+            }, "uri", "tel:+13.371337;ext=19"]
+        ]],
+        "objectClassName": "entity"
+    }, {
+        "roles": ["registrar"],
+        "handle": 9999,
+        "entities": [{
+            "roles": ["abuse"],
+            "vcardArray": ["vcard", [
+                ["version", {}, "text", "4.0"],
+                ["fn", {}, "text", "example.com"],
+                ["role", {}, "text", "abuse"],
+                ["tel", {
+                    "type": "voice"
+                }, "uri", "tel:+13.371337"],
+                ["email", {}, "text", "service@example.com"]
+            ]],
+            "objectClassName": "entity"
+        }],
+        "publicIds": [{
+            "type": "IANA Registrar ID",
+            "identifier": 9999
+        }],
+        "objectClassName": "entity"
+    }],
+    "secureDNS": {
+        "dsData": [{
+            "digest": "ad739f5b95e0cab749fc1fb6859270de8614fe0aadd2662fe9f556324a3b8f1b",
+            "keyTag": "34525",
+            "algorithm": "8",
+            "digestType": "2"
+        }],
+        "zoneSigned": true,
+        "delegationSigned": true
+    },
+    "nameservers": [{
+        "events": [{
+            "eventDate": "2014-04-29T14:08:52.601632Z",
+            "eventActor": 9999,
+            "eventAction": "registration"
+        }],
+        "handle": "H0000000003-VERS",
+        "status": ["active", "associated"],
+        "ldhName": "sec1.example.com",
+        "objectClassName": "nameserver"
+    }, {
+        "events": [{
+            "eventDate": "2014-04-29T14:08:52.662556Z",
+            "eventActor": 9999,
+            "eventAction": "registration"
+        }],
+        "handle": "H0000000004-VERS",
+        "status": ["active", "associated"],
+        "ldhName": "sec2.rcode0.net",
+        "objectClassName": "nameserver"
+    }],
+    "objectClassName": "domain",
+    "rdapConformance": ["rdap_level_0", "icann_rdap_response_profile_0", "icann_rdap_technical_implementation_guide_0"]
+}

--- a/intelmq/tests/bots/experts/rdap/test_data/nic.versicherung.json
+++ b/intelmq/tests/bots/experts/rdap/test_data/nic.versicherung.json
@@ -1,0 +1,157 @@
+{
+    "events": [{
+        "eventDate": "2014-04-29T14:08:54.068772Z",
+        "eventActor": 9999,
+        "eventAction": "registration"
+    }, {
+        "eventDate": "2017-06-07T06:39:57.707217Z",
+        "eventActor": 9999,
+        "eventAction": "last changed"
+    }, {
+        "eventDate": "2022-04-29T14:08:54.068772Z",
+        "eventAction": "expiration"
+    }, {
+        "eventDate": "2021-05-12T10:32:02.024808Z",
+        "eventAction": "last update of RDAP database"
+    }],
+    "handle": "D0000000007-VERS",
+    "status": ["auto renew period", "client delete prohibited", "client transfer prohibited", "client update prohibited", "server delete prohibited", "server transfer prohibited", "server update prohibited"],
+    "ldhName": "nic.versicherung",
+    "notices": [{
+        "links": [{
+            "rel": "terms-of-service",
+            "href": "http://www.nic.versicherung/rdap/tos",
+            "type": "text/html"
+        }],
+        "title": "Terms of service",
+        "description": ["Copyright (c) 2021 by tldbox GmbH (2)", "Except for agreed Internet operational purposes, no part of this information may be reproduced, stored in a retrieval system, or transmitted, in any form or by any means, electronic, mechanical, recording, or otherwise, without  prior permission of tldbox GmbH on behalf of itself and/or the copyright holders. Any use of this material to target advertising or similar activities is explicitly forbidden and can be prosecuted.", "Furthermore, it is strictly forbidden to use the RDAP database in such a way that jeopardizes or could jeopardize the stability of the technical systems of tldbox GmbH under any circumstances. In particular, this includes any misuse of the RDAP database and any use of he RDAP database which disturbs its operation. ", "Should the user violate these points, tldbox GmbH reserves the right to deactivate the RDAP database entirely or partly for the user. Moreover, the user shall be held liable for any and all damage arising from a violation of these points."]
+    }, {
+        "links": [{
+            "href": "https://icann.org/epp",
+            "type": "text/html"
+        }],
+        "title": "Status Codes",
+        "description": ["For more information on domain status codes, please visit https://icann.org/epp"]
+    }, {
+        "links": [{
+            "href": "https://icann.org/wicf",
+            "type": "text/html"
+        }],
+        "title": "RDDS Inaccuracy Complaint Form",
+        "description": ["URL of the ICANN RDDS Inaccuracy Complaint Form: https://icann.org/wicf"]
+    }],
+    "entities": [{
+        "roles": ["registrant", "administrative"],
+        "events": [{
+            "eventDate": "2017-01-24T07:28:44.320049Z",
+            "eventActor": 9999,
+            "eventAction": "registration"
+        }, {
+            "eventDate": "2018-09-26T07:16:34.157134Z",
+            "eventActor": 9999,
+            "eventAction": "last changed"
+        }],
+        "handle": "C0000013489-VERS",
+        "status": ["active", "associated"],
+        "remarks": [{
+            "type": "object redacted due to authorization",
+            "title": "EMAIL REDACTED FOR PRIVACY",
+            "description": ["Please query the RDDS  service of the registrar of record identified in this output for information on how to contact the registrant of the queried domain name"]
+        }],
+        "vcardArray": ["vcard", [
+            ["version", {}, "text", "4.0"],
+            ["fn", {}, "text", "tldbox GmbH"],
+            ["adr", {
+                "cc": "AT"
+            }, "text", ["", "", "Jakob-Haringer-Strasse 8/V", "Salzburg", "", "5020", ""]]
+        ]],
+        "objectClassName": "entity"
+    }, {
+        "roles": ["technical"],
+        "events": [{
+            "eventDate": "2014-04-29T14:08:52.546880Z",
+            "eventActor": 9999,
+            "eventAction": "registration"
+        }, {
+            "eventDate": "2018-05-24T07:32:11.358333Z",
+            "eventActor": 9999,
+            "eventAction": "last changed"
+        }],
+        "handle": "C0000000002-VERS",
+        "status": ["active", "associated"],
+        "remarks": [{
+            "type": "object redacted due to authorization",
+            "title": "EMAIL REDACTED FOR PRIVACY",
+            "description": ["Please query the RDDS  service of the registrar of record identified in this output for information on how to contact the registrant of the queried domain name"]
+        }],
+        "vcardArray": ["vcard", [
+            ["version", {}, "text", "4.0"],
+            ["fn", {}, "text", "TLDBOX"],
+            ["org", {}, "text", "tldbox GmbH"],
+            ["adr", {
+                "cc": "AT"
+            }, "text", ["", "", "Jakob-Haringer-Strasse 8/V", "Salzburg", "Salzburg", "5020", ""]],
+            ["tel", {
+                "type": "voice"
+            }, "uri", "tel:+13.371337;ext=730"],
+            ["tel", {
+                "type": "fax"
+            }, "uri", "tel:+13.371337;ext=19"]
+        ]],
+        "objectClassName": "entity"
+    }, {
+        "roles": ["registrar"],
+        "handle": 9999,
+        "entities": [{
+            "roles": ["abuse"],
+            "vcardArray": ["vcard", [
+                ["version", {}, "text", "4.0"],
+                ["fn", {}, "text", "tldbox GmbH"],
+                ["role", {}, "text", "abuse"],
+                ["tel", {
+                    "type": "voice"
+                }, "uri", "tel:+13.371337"],
+                ["email", {}, "text", "service@tld-box.at"]
+            ]],
+            "objectClassName": "entity"
+        }],
+        "publicIds": [{
+            "type": "IANA Registrar ID",
+            "identifier": 9999
+        }],
+        "objectClassName": "entity"
+    }],
+    "secureDNS": {
+        "dsData": [{
+            "digest": "ad739f5b95e0cab749fc1fb6859270de8614fe0aadd2662fe9f556324a3b8f1b",
+            "keyTag": "34525",
+            "algorithm": "8",
+            "digestType": "2"
+        }],
+        "zoneSigned": true,
+        "delegationSigned": true
+    },
+    "nameservers": [{
+        "events": [{
+            "eventDate": "2014-04-29T14:08:52.601632Z",
+            "eventActor": 9999,
+            "eventAction": "registration"
+        }],
+        "handle": "H0000000003-VERS",
+        "status": ["active", "associated"],
+        "ldhName": "sec1.rcode0.net",
+        "objectClassName": "nameserver"
+    }, {
+        "events": [{
+            "eventDate": "2014-04-29T14:08:52.662556Z",
+            "eventActor": 9999,
+            "eventAction": "registration"
+        }],
+        "handle": "H0000000004-VERS",
+        "status": ["active", "associated"],
+        "ldhName": "sec2.rcode0.net",
+        "objectClassName": "nameserver"
+    }],
+    "objectClassName": "domain",
+    "rdapConformance": ["rdap_level_0", "icann_rdap_response_profile_0", "icann_rdap_technical_implementation_guide_0"]
+}

--- a/intelmq/tests/bots/experts/rdap/test_data/rdns.json
+++ b/intelmq/tests/bots/experts/rdap/test_data/rdns.json
@@ -1,0 +1,43 @@
+{
+    "description": "RDAP bootstrap file for Domain Name System registrations",
+    "publication": "2021-05-11T21:00:02Z",
+    "services": [
+      [
+        [
+          "nowruz",
+          "pars",
+          "shia",
+          "tci",
+          "xn--mgbt3dhd"
+        ],
+        [
+          "https://api.rdap.agitsys.net/"
+        ]
+      ],
+      [
+        [
+          "xn--p1acf"
+        ],
+        [
+          "https://api.rdap.nic.xn--p1acf/"
+        ]
+      ],
+      [
+        [
+          "moscow"
+        ],
+        [
+          "https://flexireg.net/moscow/rdap/"
+        ]
+      ],
+      [
+        [
+          "xn--80adxhks"
+        ],
+        [
+          "https://flexireg.net/xn--80adxhks/rdap/"
+        ]
+      ]
+    ],
+    "version": "1.0"
+  }

--- a/intelmq/tests/bots/experts/rdap/test_expert.py
+++ b/intelmq/tests/bots/experts/rdap/test_expert.py
@@ -1,9 +1,12 @@
 # -*- coding: utf-8 -*-
 """
-Testing url2fqdn.
+Testing rdap expert.
 """
 
 import unittest
+import os
+
+import requests_mock
 
 import intelmq.lib.test as test
 from intelmq.bots.experts.rdap.expert import RDAPExpertBot
@@ -16,12 +19,26 @@ EXAMPLE_INPUT = {"__type": "Event",
 EXAMPLE_OUTPUT = {"__type": "Event",
                   "source.url": "http://nic.versicherung/something/index.php",
                   "source.fqdn": "nic.versicherung",
-                  "source.abuse_contact": 'service@tld-box.at',
+                  "source.abuse_contact": "service@tld-box.at",
                   "time.observation": "2015-01-01T00:00:00+00:00"
                   }
 
+EXAMPLE_INPUT2 = EXAMPLE_INPUT.copy()
+EXAMPLE_INPUT2['source.fqdn'] = 'example.com'
+EXAMPLE_OUTPUT2 = EXAMPLE_OUTPUT.copy()
+EXAMPLE_OUTPUT2['source.fqdn'] = 'example.com'
+EXAMPLE_OUTPUT2['source.abuse_contact'] = 'service@example.com'
+
+
+def prepare_mocker(mocker):
+    with open(os.path.join(os.path.dirname(__file__), 'test_data', 'rdns.json'), 'rb') as f:
+        mocker.get('https://data.iana.org/rdap/dns.json', content=f.read())
+    for filename in os.listdir(os.path.join(os.path.dirname(__file__), 'test_data')):
+        with open(os.path.join(os.path.dirname(__file__), 'test_data', filename), 'rb') as f:
+            mocker.get('http://localhost/rdap/v1/domain/%s' % filename.replace('.json', ''), content=f.read())
 
 @test.skip_internet()
+@requests_mock.Mocker()
 class TestRDAPExpertBot(test.BotTestCase, unittest.TestCase):
     """
     A TestCase for RDAPExpertBot.
@@ -31,10 +48,26 @@ class TestRDAPExpertBot(test.BotTestCase, unittest.TestCase):
     def set_bot(self):
         self.bot_reference = RDAPExpertBot
 
-    def test(self):
+    def test(self, mocker):
+        prepare_mocker(mocker)
         self.input_message = EXAMPLE_INPUT
-        self.run_bot()
+        self.run_bot(parameters={
+            'rdap_bootstrapped_servers': {
+                'versicherung': 'http://localhost/rdap/v1/',
+            }
+        })
         self.assertMessageEqual(0, EXAMPLE_OUTPUT)
+
+    def test_object_validation(self, mocker):
+        prepare_mocker(mocker)
+        self.input_message = EXAMPLE_INPUT2
+        self.allowed_warning_count = 1
+        self.run_bot(parameters={
+            'rdap_bootstrapped_servers': {
+                'com': 'http://localhost/rdap/v1/',
+            }
+        })
+        self.assertMessageEqual(0, EXAMPLE_OUTPUT2)
 
 
 if __name__ == '__main__':  # pragma: no cover

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ exclude =
     intelmq/tests/
 
 [codespell]
-skip = *.csv,*.data,./docs/_build,.eggs,.git,testfile.txt,dga.txt
+skip = *.csv,*.data,./docs/_build,.eggs,.git,testfile.txt,dga.txt,./intelmq/tests/bots/experts/rdap/test_data
 ignore-words-list = crypted,ba,nwe,ether
 exclude-file = .github/workflows/codespell.excludelines
 


### PR DESCRIPTION
As some RDAP implementation may vary, we check if the entity
is a valid entity-type. As of the RFC for RDAP only JSON dicts
are allowed.

Closes #1942 