### PR TITLE
Minor enhancements to bot debugger and SMTP output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,7 @@ Update allowed classification fields to 2020-01-28 version (#1409, #1476). Old n
 #### Outputs
 - Remove `intelmq.bots.outputs.xmpp`: one of the dependencies of the bot was deprecated and according to a short survey on the IntelMQ
   users mailinglist, the bot is not used by anyone. (https://lists.cert.at/pipermail/intelmq-users/2020-October/000177.html, PR#1761, closes #1614)
+- `intelmq.bots.outputs.smtp`: Add more debug logging (PR#1949 by Sebastian Wagner).
 
 ### Documentation
 - Updated user and developer documentation to reflect the removal of the BOTS file (PR#1780 by Birger Schacht).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ CHANGELOG
 - `intelmq.lib.bot_debugger`:
   - Set bot's `logging_level` directly in `__init__` before the bot's initialization by changing the default value (by Sebastian Wagner).
   - Rewrite `load_configuration_patch` by adapting it to the parameter and configuration rewrite (by Sebastian Wagner).
+  - Do not rely on the runtime configuration's `group` setting of bots to determine the required message type of messages given on the command line (PR#1949 by Sebastian Wagner).
 
 ### Development
 - `rewrite_config_files.py`: Removed obsolete BOTS-file-related rewriting functionality.

--- a/intelmq/bots/outputs/smtp/output.py
+++ b/intelmq/bots/outputs/smtp/output.py
@@ -54,11 +54,13 @@ class SMTPOutputBot(Bot):
 
         with self.smtp_class(self.smtp_host, self.smtp_port, **self.kwargs) as smtp:
             if self.starttls:
+                self.logger.debug("Issuing STARTTLS with{verify} certificate verification.".format(verify="" if self.http_verify_cert else "out"))
                 if self.http_verify_cert:
                     smtp.starttls(context=ssl.create_default_context())
                 else:
                     smtp.starttls()
             if self.smtp_username and self.smtp_password:
+                self.logger.debug('Authenticating against SMTP server.')
                 smtp.login(user=self.smtp_username, password=self.smtp_password)
             msg = MIMEMultipart()
             if self.text is not None:
@@ -71,6 +73,7 @@ class SMTPOutputBot(Bot):
             recipients = [recipient
                           for recipient
                           in self.mail_to.format(ev=event).split(',')]
+            self.logger.debug(f'Sending mail to {recipients!r}.')
             smtp.send_message(msg, from_addr=self.mail_from,
                               to_addrs=recipients)
 

--- a/intelmq/lib/bot_debugger.py
+++ b/intelmq/lib/bot_debugger.py
@@ -21,6 +21,7 @@ import time
 
 from intelmq import RUNTIME_CONF_FILE
 from intelmq.lib import utils
+from intelmq.lib.bot import ParserBot
 from intelmq.lib.message import MessageFactory
 from intelmq.lib.pipeline import Pipeline
 from intelmq.lib.utils import StreamHandler, error_message_from_exc
@@ -162,8 +163,8 @@ class BotDebugger:
         self.output.append(msg)
 
     def arg2msg(self, msg):
+        default_type = "Report" if (self.runtime_configuration.get("group", None) == "Parser" or isinstance(self.instance, ParserBot)) else "Event"
         try:
-            default_type = "Report" if self.runtime_configuration["group"] == "Parser" else "Event"
             msg = MessageFactory.unserialize(msg, default_type=default_type)
         except (Exception, KeyError, TypeError, ValueError) as exc:
             if exists(msg):


### PR DESCRIPTION
ENH: lib/bot_debugger: better detect bot type for message type
Do not rely on the runtime configuration's `group` setting of bots to determine the required message type of messages given on the command line

ENH: smtp output: Add more debug logging 