### PR TITLE
ENH: Sieve: Drop redundant operators, split string and numeric matches into single- and multivalued variants

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,20 @@ IntelMQ now uses YAML for the runtime configuration and therefore needs the `rua
 Both the XMPP collector bot and the XMPP output bot were removed. This [was evaluated on the mailinglist](https://lists.cert.at/pipermail/intelmq-users/2020-October/000177.html)
 and the XMPP bots were deprecated in 391d625.
 
+The Sieve expert bot has had major updates to its syntax. Breaking new changes:
+* the removal of the `:notcontains` operator, which can be replaced using the newly added
+ expression negation, e.g `! foo :contains ['.mx', '.zz']` rather than `foo :notcontains ['.mx', '.zz']`. 
+* changed operators for comparisons against lists of values, e.g `source.ip :in ['127.0.0.5', '192.168.1.2']` rather than `source.ip == ['127.0.0.5', '192.168.1.2']`
+
+New features:
+* arbitrary nesting of if clauses + mixed conditionals and actions in the same level of nesting
+* new matches on fields containing list values and booleans
+* new list-based actions
+* negation of arbitrary expressions and expression groups separated by brackets through a prepended `!`, e.g `! src.port :in [80, 443]`
+* non-string values accepted by `add`/`add!`/`update`
+
+The bot documentation at `docs/user/bots.rst` has been updated to reflect on these new changes.
+
 ### Harmonization
 The classification scheme has been updated to better match the [Reference Security Incident Taxonomy (RSIT)](https://github.com/enisaeu/Reference-Security-Incident-Taxonomy-Task-Force/). The following labels were renamed:
 

--- a/docs/user/bots.rst
+++ b/docs/user/bots.rst
@@ -2818,19 +2818,19 @@ The following operators may be used to match events:
 
    ``if source.ip << '10.0.0.0/8' { ... }``
 
- * Values to match against can also be specified as list, in which case any one of the values will result in a match:
+ * String values to match against can also be specified as lists of strings, which have separate operators. For example:
 
-   ``if source.ip == ['8.8.8.8', '8.8.4.4'] { ... }``
+   ``if source.ip :in ['8.8.8.8', '8.8.4.4'] { ... }``
 
   In this case, the event will match if it contains a key `source.ip` with
   either value `8.8.8.8` or `8.8.4.4`.
 
-  With inequality operators, the behavior is the same, so it matches if any expression does not match:
+  There are also `:containsany` to match at least one of a list of substrings, and `:regexin` to match at least one of
+  a list of regular expressions, similar to the `:contains` and `=~` operators.
 
-  ``if source.ip != ['8.8.8.8', '8.8.4.4'] { ... }``
+ * Lists of numeric values support `:in` to check for inclusion in a list of numbers:
 
-  Events with values like `8.8.8.8` or `8.8.4.4` will match, as they are always unequal to the other value.
-  **Attention:** The result is *not* that the field must be unequal to all given values.
+   ``if source.port :in [80, 443] { ... }``
 
  * `:equals` tests for equality between lists, including order. Example for checking a hostname-port pair:
    ``if extra.host_tuple :equals ['dns.google', 53] { ... }``
@@ -2855,8 +2855,12 @@ The following operators may be used to match events:
 
  * Any single expression or a parenthesised group of expressions can be negated using `!`:
 
- ``if ! source.ip :contains '127.0.0' || ! ( source.ip == '172.16.0.5' && source.port == 25 ) { ... }``
+ ``if ! source.ip :contains '127.0.0.' || ! ( source.ip == '172.16.0.5' && source.port == 25 ) { ... }``
 
+  * Note: Since 3.0.0, list-based operators are used on list values, such as `foo :in [1, 2, 3]` instead of `foo == [1, 2, 3]`
+    and `foo :regexin ['.mx', '.zz']` rather than `foo =~ ['.mx', '.zz']`, and similarly for `:containsany` vs `:contains`.
+    Besides that, ``:notcontains` has been removed, with e.g `foo :notcontains ['.mx', '.zz']` now being represented using negation
+    as `! foo :contains ['.mx', '.zz']`.
 
 *Actions*
 

--- a/intelmq/bots/experts/sieve/expert.py
+++ b/intelmq/bots/experts/sieve/expert.py
@@ -49,7 +49,6 @@ class SieveExpertBot(Bot):
         '==': operator.eq,
         '!=': operator.ne,
         ':contains': lambda lhs, rhs: lhs.find(rhs) >= 0,
-        ':notcontains': lambda lhs, rhs: lhs.find(rhs) == -1,
         '=~': lambda lhs, rhs: re.search(rhs, lhs) is not None,
         '!~': lambda lhs, rhs: re.search(rhs, lhs) is None,
     }
@@ -241,7 +240,7 @@ class SieveExpertBot(Bot):
 
     def process_string_match(self, key, op, value, event) -> bool:
         if key not in event:
-            return op in {'!=', '!~', ':notcontains'}
+            return op in {'!=', '!~'}
 
         name = value.__class__.__name__
 

--- a/intelmq/bots/experts/sieve/expert.py
+++ b/intelmq/bots/experts/sieve/expert.py
@@ -266,8 +266,6 @@ class SieveExpertBot(Bot):
         raise TextXSemanticError(f'Unhandled type: {name}')
 
     def process_numeric_operator(self, lhs, op, rhs) -> bool:
-        if not self.is_numeric(lhs) or not self.is_numeric(rhs):
-            return False
         return self._numeric_op_map[op](lhs, rhs)
 
     def process_ip_range_match(self, key, ip_range, event) -> bool:
@@ -411,11 +409,6 @@ class SieveExpertBot(Bot):
         except ValueError:
             position = SieveExpertBot.get_linecol(ipaddr, as_dict=True)
             raise TextXSemanticError('Invalid ip address: %s.' % ipaddr.value, **position)
-
-    @staticmethod
-    def is_numeric(num) -> bool:
-        """ Returns True if argument is a number (integer or float). """
-        return str(num).lstrip('-').replace('.', '', 1).isnumeric()
 
     @staticmethod
     def get_linecol(model_obj, as_dict=False):

--- a/intelmq/bots/experts/sieve/sieve.tx
+++ b/intelmq/bots/experts/sieve/sieve.tx
@@ -26,8 +26,11 @@ Condition:
 ;
 
 
-StringMatch: key=Key op=StringOperator value=StringValue;
-StringOperator:
+StringMatch: SingleStringMatch | MultiStringMatch;
+SingleStringMatch: key=Key op=SingleStringOperator value=SingleStringValue;
+MultiStringMatch: key=Key op=MultiStringOperator value=StringValueList;
+
+SingleStringOperator:
   '=='             // compares two whole strings with each other
   | '!='           // test for string inequality
   | ':contains'    // sub-string match
@@ -35,8 +38,18 @@ StringOperator:
   | '!~'           // inverse match with regular expression
 ;
 
-NumericMatch: key=Key op=NumericOperator value=NumericValue;
-NumericOperator:
+MultiStringOperator:
+  ':in'            // tests if a string is in a list of strings
+  | ':containsany' // sub-string match against multiple substrings
+  | ':regexin'     // match a string against at least one of a list of regex patterns
+;
+
+
+NumericMatch: SingleNumericMatch | MultiNumericMatch;
+SingleNumericMatch: key=Key op=SingleNumericOperator value=SingleNumericValue;
+MultiNumericMatch: key=Key op=MultiNumericOperator value=NumericValueList;
+
+SingleNumericOperator:
   '=='          // equal
   | '!='        // not equal
   | '<='        // less than or equal
@@ -44,6 +57,11 @@ NumericOperator:
   | '<'         // less than
   | '>'         // greater than
 ;
+
+MultiNumericOperator:
+  ':in'         // tests if number is in a list of numbers
+;
+
 
 IpRangeMatch: key=Key '<<' range=IpRange;
 IpRange: SingleIpRange | IpRangeList;
@@ -73,11 +91,9 @@ ListValue: '[' values+=TypedValue[','] ']' ;
 
 Key: /[a-z0-9_\.]+/;
 
-StringValue: SingleStringValue | StringValueList ;
 SingleStringValue: value=STRING ;
 StringValueList: '[' values+=SingleStringValue[','] ']' ;
 
-NumericValue: SingleNumericValue | NumericValueList ;
 SingleNumericValue: value=NUMBER ;
 NumericValueList: '[' values+=SingleNumericValue[','] ']' ;
 

--- a/intelmq/bots/experts/sieve/sieve.tx
+++ b/intelmq/bots/experts/sieve/sieve.tx
@@ -31,7 +31,6 @@ StringOperator:
   '=='             // compares two whole strings with each other
   | '!='           // test for string inequality
   | ':contains'    // sub-string match
-  | ':notcontains' // inverse sub-string match
   | '=~'           // match strings according to regular expression
   | '!~'           // inverse match with regular expression
 ;

--- a/intelmq/tests/bots/experts/sieve/test_expert.py
+++ b/intelmq/tests/bots/experts/sieve/test_expert.py
@@ -335,36 +335,6 @@ class TestSieveExpertBot(test.BotTestCase, unittest.TestCase):
         self.run_bot()
         self.assertMessageEqual(0, event)
 
-    def test_string_notcontains_match(self):
-        """ Test :notcontains string match."""
-        self.sysconfig['file'] = os.path.join(os.path.dirname(__file__),
-                                              'test_sieve_files/test_string_notcontains_match.sieve')
-
-        # positive test (key undefined)
-        event = EXAMPLE_INPUT.copy()
-        expected = event.copy()
-        expected['comment'] = 'match'
-        self.input_message = event
-        self.run_bot()
-        self.assertMessageEqual(0, expected)
-
-        # positive test (key mismatch)
-        event = EXAMPLE_INPUT.copy()
-        event['source.url'] = 'https://www.switch.ch/security/'
-        expected = event.copy()
-        expected['comment'] = 'match'
-        self.input_message = event
-        self.run_bot()
-        self.assertMessageEqual(0, expected)
-
-        # negative test (key match)
-        event = EXAMPLE_INPUT.copy()
-        event['source.url'] = 'https://www.google.com/'
-        self.input_message = event
-        self.run_bot()
-        self.assertMessageEqual(0, event)
-
-
     def test_string_regex_match(self):
         """ Test =~ string match """
         self.sysconfig['file'] = os.path.join(os.path.dirname(__file__),

--- a/intelmq/tests/bots/experts/sieve/test_expert.py
+++ b/intelmq/tests/bots/experts/sieve/test_expert.py
@@ -17,7 +17,7 @@ EXAMPLE_MD5 = {"__type": "Event",
                }
 
 
-#@test.skip_exotic()
+@test.skip_exotic()
 class TestSieveExpertBot(test.BotTestCase, unittest.TestCase):
     """
     A TestCase for SieveExpertBot.
@@ -401,7 +401,7 @@ class TestSieveExpertBot(test.BotTestCase, unittest.TestCase):
         with self.assertRaises(ValueError) as context:
             self.run_bot()
         exception = context.exception
-        self.assertRegex(str(exception), 'Invalid ip address:')
+        self.assertRegex(str(exception), 'Invalid IP address:')
 
     def test_numeric_equal_match(self):
         """ Test == numeric match """

--- a/intelmq/tests/bots/experts/sieve/test_expert.py
+++ b/intelmq/tests/bots/experts/sieve/test_expert.py
@@ -17,7 +17,7 @@ EXAMPLE_MD5 = {"__type": "Event",
                }
 
 
-@test.skip_exotic()
+#@test.skip_exotic()
 class TestSieveExpertBot(test.BotTestCase, unittest.TestCase):
     """
     A TestCase for SieveExpertBot.
@@ -610,6 +610,64 @@ class TestSieveExpertBot(test.BotTestCase, unittest.TestCase):
         self.input_message = string_value_list_match_3
         self.run_bot()
         self.assertMessageEqual(0, string_value_list_match_3)
+
+        # match containsany, first match
+        event = EXAMPLE_INPUT.copy()
+        event['source.fqdn'] = 'matched.mx'
+        expected = event.copy()
+        expected['comment'] = 'containsany match'
+
+        self.input_message = event
+        self.run_bot()
+        self.assertMessageEqual(0, expected)
+
+        # match containsany, first match
+        event = EXAMPLE_INPUT.copy()
+        event['source.fqdn'] = 'matched.zz'
+        expected = event.copy()
+        expected['comment'] = 'containsany match'
+
+        self.input_message = event
+        self.run_bot()
+        self.assertMessageEqual(0, expected)
+
+        # do not match containsany
+        event = EXAMPLE_INPUT.copy()
+        event['source.fqdn'] = 'matched.yy'
+        expected = event.copy()
+
+        self.input_message = event
+        self.run_bot()
+        self.assertMessageEqual(0, expected)
+
+        # match regexin, first match
+        event = EXAMPLE_INPUT.copy()
+        event['extra.tag'] = 'xxee'
+        expected = event.copy()
+        expected['comment'] = 'regexin match'
+
+        self.input_message = event
+        self.run_bot()
+        self.assertMessageEqual(0, expected)
+
+        # match regexin, second match
+        event = EXAMPLE_INPUT.copy()
+        event['extra.tag'] = 'abcd'
+        expected = event.copy()
+        expected['comment'] = 'regexin match'
+
+        self.input_message = event
+        self.run_bot()
+        self.assertMessageEqual(0, expected)
+
+        # do not match regexin
+        event = EXAMPLE_INPUT.copy()
+        event['extra.tag'] = 'eeabcc'
+        expected = event.copy()
+
+        self.input_message = event
+        self.run_bot()
+        self.assertMessageEqual(0, expected)
 
     def test_numeric_match_value_list(self):
         """ Test numeric match with NumericValueList """

--- a/intelmq/tests/bots/experts/sieve/test_sieve_files/test_keep_event.sieve
+++ b/intelmq/tests/bots/experts/sieve/test_sieve_files/test_keep_event.sieve
@@ -5,6 +5,6 @@ if comment == 'keep' {
   keep
 }
 
-if comment == ['continue', 'keep'] {
+if comment :in ['continue', 'keep'] {
   update comment = 'changed'
 }

--- a/intelmq/tests/bots/experts/sieve/test_sieve_files/test_numeric_match_value_list.sieve
+++ b/intelmq/tests/bots/experts/sieve/test_sieve_files/test_numeric_match_value_list.sieve
@@ -1,10 +1,10 @@
-if destination.asn == [20965,6939,8220] {
+if destination.asn :in [20965,6939,8220] {
 
    add comment='Belongs to peering group'
 
 }
 
-if destination.asn == [1930,199155] {
+if destination.asn :in [1930,199155] {
 
    add comment='Belongs constituency group'
 

--- a/intelmq/tests/bots/experts/sieve/test_sieve_files/test_string_match_value_list.sieve
+++ b/intelmq/tests/bots/experts/sieve/test_sieve_files/test_string_match_value_list.sieve
@@ -1,11 +1,15 @@
-if classification.type == ['infected-system'] {
-
-add comment='infected hosts'
-
+if classification.type :in ['infected-system'] {
+	add comment = 'infected hosts'
 }
 
-if classification.type == ['c2-server','malware-configuration'] {
+if classification.type :in ['c2-server','malware-configuration'] {
+	add comment = 'malicious server / service'
+}
 
-add comment='malicious server / service'
+if source.fqdn :containsany ['.mx', '.zz'] {
+	add comment = 'containsany match'
+}
 
+if extra.tag :regexin ['ee$', 'ab.d'] {
+	add comment = 'regexin match'
 }

--- a/intelmq/tests/bots/experts/sieve/test_sieve_files/test_string_notcontains_match.sieve
+++ b/intelmq/tests/bots/experts/sieve/test_sieve_files/test_string_notcontains_match.sieve
@@ -1,3 +1,0 @@
-if source.url :notcontains '.com' {
-    add comment = 'match'
-}


### PR DESCRIPTION
This commit:
* drops the `:notcontains` and `!~` from Sieve, as they are made redundant by negation (`! foo :contains 'x'` == `foo :notcontains 'x'`)
* splits string and numeric matches into single- and multivalued variants, with the relevant new operators `:in`, `:containsany` and `:regexin` for string lists, and `:in` for numeric value lists
* adds documentation and tests for the above
* adds a note to the documentation regarding breaking changes

Should the breaking changes be referenced somewhere besides the documentation as well?