### PR TITLE
Correct fix of Splunk expert on Python 3.5

### DIFF
--- a/intelmq/bots/experts/splunk_saved_search/expert.py
+++ b/intelmq/bots/experts/splunk_saved_search/expert.py
@@ -134,7 +134,7 @@ class SplunkSavedSearchBot(Bot):
 
         query = '|savedsearch "{saved_search}"'.format(saved_search=self.saved_search)
         for field, parameter in self.search_parameters.items():
-            query += ' "{parameter}"="{event[field]}"'.format(parameter=parameter, event=event)
+            query += ' "{parameter}"="{field}"'.format(parameter=parameter, field=event[field])
         if "limit" in self.multiple_result_handling:
             query += " | head 1"
 


### PR DESCRIPTION
Move the entire expression out of the f-string into the argument to `str.format()`, fixing the "KeyError: 'field'" that has been the only
result of running this bot since commit ddc213021775828a535b5ef88f9b4224a2161f7f (BUG/TST: fix splunk expert on python 3.5).

This bug is also present in the `develop` branch. Do you want to cherry-pick this commit to there, have me submit another pull request, revert ddc213021775828a535b5ef88f9b4224a2161f7f on that branch, or something else?