### PR TITLE
ENH: add license header information to files

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,3 @@
-<!-- comment
-   SPDX-License-Identifier: AGPL-3.0-or-later
--->
-
 # Please read the notes below and replace them with the description of you pull request
 
 Make sure you follow the instructions in the [Developer Guide](https://intelmq.readthedocs.io/en/latest/dev/guide.html) - it describes how to run the test suite and which coding rules to follow.

--- a/.github/pull_request_template.md.license
+++ b/.github/pull_request_template.md.license
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: 2021 Birger Schacht
+#
+# SPDX-License-Identifier: CC0-1.0
+

--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -1,0 +1,27 @@
+#Github Workflow reuse licensecheck
+#
+#SPDX-FileCopyrightText: 2021 Birger Schacht
+#SPDX-License-Identifier: AGPL-3.0-or-later
+
+name: "ReUse License Check"
+
+on:
+  push:
+  pull_request:
+    branches: [ develop ]
+
+jobs:
+  license:
+    name: Check license compliance
+    runs-on: ubuntu-latest
+    # This should not fail the whole workflow run
+    continue-on-error: true
+
+    strategy:
+      fail-fast: false
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+    - name: REUSE compliance check
+      uses: fsfe/reuse-action@v1

--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -2,22 +2,30 @@ Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: intelmq
 Source: https://github.com/certtools/intelmq
 
+Files:     contrib/logcheck/*
+Copyright: 2018 Sebastian Wagner
+License:   AGPL-3.0-or-later
+
+Files:     contrib/logrotate/intelmq
+Copyright: 2016 aaronkaplan <aaron@lo-res.org>
+License:   AGPL-3.0-or-later
+
+Files:     contrib/tmpfiles.d/intelmq.conf
+Copyright: 2016 Sebastian Wagner <sebix@sebix.at>
+License:   AGPL-3.0-or-later
+
 Files:     debian/*
-Copyright: 
+Copyright: 2016 Intevation GmbH
 License:   AGPL-3.0-or-later
 
-Files:     intelmq/*
-Copyright: 
+Files:     debian/cron.d/intelmq-update-database
+Copyright: 2020 gethvi <gethvi@tuta.io>
 License:   AGPL-3.0-or-later
 
-Files:     contrib/*
-Copyright: 
+Files:     debian/intelmq.maintscript, debian/intelmq.tmpfile, debian/patches/fix-intelmq-paths.patch, debian/sedfile
+Copyright: 2020 Sebastian Wagner <wagner@cert.at>
 License:   AGPL-3.0-or-later
 
-Files:     docs/dev/*
-Copyright: 
-License:   AGPL-3.0-or-later
-
-Files:     docs/user/*
-Copyright: 
+Files:     debian/debian/py3dist-overrides
+Copyright: 2021 Birger Schacht
 License:   AGPL-3.0-or-later

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: CC0-1.0
+# SPDX-FileCopyrightText: L. Aaron Kaplan <kaplanlo-res.org>
 
 Tomás Lima <synchroack@protonmail.ch>
 Mauro Silva <mauro.a.silva@gmail.com>

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2016 aaronkaplan
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+-->
 
 # Contrib
 

--- a/contrib/bash-completion/README.md
+++ b/contrib/bash-completion/README.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2017 Sebastian Wagner
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
 # Bash Completion for intelmq
 
 It completes (sub-)commands and parameters (bots and pipeline names, log levels).

--- a/contrib/bash-completion/intelmqctl
+++ b/contrib/bash-completion/intelmqctl
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2018 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
 # bash completion for intelmqctl                            -*- shell-script -*-
 
 _intelmqctl ()

--- a/contrib/bash-completion/intelmqdump
+++ b/contrib/bash-completion/intelmqdump
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2018 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
 # bash completion for intelmqdump                           -*- shell-script -*-
 
 _intelmqdump ()

--- a/contrib/check_mk/README.md
+++ b/contrib/check_mk/README.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2019 Sebastian Wagner
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
 # Monitoring scripts for check_mk
 
 Some scripts to integrate IntelMQ into a [Check_MK](https://mathias-kettner.com/) instance:

--- a/contrib/check_mk/cronjob_intelmq_queues.py
+++ b/contrib/check_mk/cronjob_intelmq_queues.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
 
+# SPDX-FileCopyrightText: 2019 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 import intelmq.bin.intelmqctl as ctl
 import intelmq.lib.utils as utils
 import sys

--- a/contrib/check_mk/cronjob_intelmq_statistics.py
+++ b/contrib/check_mk/cronjob_intelmq_statistics.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2019 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """
 Created on Thu Mar 28 09:52:19 2019

--- a/contrib/config-backups/Makefile
+++ b/contrib/config-backups/Makefile
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2016 aaronkaplan
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 DATE:=$(shell date +"%Y%m%d-%H%M%S")
 
 backup:

--- a/contrib/cron-jobs/README.md
+++ b/contrib/cron-jobs/README.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2017 Sebastian Wagner
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
 # Common cron jobs for IntelMQ
 
 Downloads the latest database files for commonly used bots.

--- a/contrib/development-tools/bots-feeds.sh
+++ b/contrib/development-tools/bots-feeds.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# SPDX-FileCopyrightText: 2019 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 echo "Bots:"
 bots=$(intelmqctl --type json list bots)
 echo $bots | jq '.Collector | keys | length'

--- a/contrib/elasticsearch/README.md
+++ b/contrib/elasticsearch/README.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2018 SYNchroACK
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
 # ElasticMapper Tool
 
 ## Description

--- a/contrib/elasticsearch/elasticmapper
+++ b/contrib/elasticsearch/elasticmapper
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2018 SYNchroACK <synchroack@protonmail.ch>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """
 Author: SYNchroACK <synchroack@protonmail.ch>
 """

--- a/contrib/eventdb/README.md
+++ b/contrib/eventdb/README.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2019 Sebastian Wagner
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
 EventDB Utilities
 =================
 

--- a/contrib/eventdb/apply_domain_suffix.py
+++ b/contrib/eventdb/apply_domain_suffix.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2019 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """
 Created on Thu Mar 29 17:23:52 2018

--- a/contrib/eventdb/apply_mapping_eventdb.py
+++ b/contrib/eventdb/apply_mapping_eventdb.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2019 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """
 Created on Wed Jul 11 15:47:07 2018

--- a/contrib/eventdb/common.py
+++ b/contrib/eventdb/common.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2019 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """
 Created on Mon Aug 26 10:09:56 2019

--- a/contrib/eventdb/trigger_oldest_time.source.sql
+++ b/contrib/eventdb/trigger_oldest_time.source.sql
@@ -1,3 +1,7 @@
+-- SPDX-FileCopyrightText: 2020 Sebastian Wagner
+--
+-- SPDX-License-Identifier: AGPL-3.0-or-later
+
 -- create a table to save the information
 CREATE TABLE meta (
     "oldest_time.source" TIMESTAMP WITH TIME ZONE NULL

--- a/contrib/feeds-config-generator/README.md
+++ b/contrib/feeds-config-generator/README.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2018 SYNchroACK
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
 # Feeds Configuration Generator
 
 Quickly generate feeds configurations (runtime and pipeline configs).

--- a/contrib/feeds-config-generator/intelmq_gen_feeds_conf
+++ b/contrib/feeds-config-generator/intelmq_gen_feeds_conf
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2018 SYNchroACK <synchroack@protonmail.ch>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
 
 import argparse
 import json

--- a/contrib/logcheck/README.md
+++ b/contrib/logcheck/README.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2016 Sebastian Wagner
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
 # logcheck ruleset
 
 logcheck is a simple and effective log monitoring tool checking for known and

--- a/contrib/malware_name_mapping/README.md
+++ b/contrib/malware_name_mapping/README.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2018 Sebastian Wagner
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
 Malware Name Mapping
 ====================
 

--- a/contrib/malware_name_mapping/download_mapping.py
+++ b/contrib/malware_name_mapping/download_mapping.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2018 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """
 TODO: Fix ordering of dicts

--- a/contrib/malware_name_mapping/test_download_mapping.py
+++ b/contrib/malware_name_mapping/test_download_mapping.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2019 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 import unittest
 import json

--- a/contrib/prettyprint/prettyprint.sh
+++ b/contrib/prettyprint/prettyprint.sh
@@ -1,5 +1,9 @@
 #!/bin/sh
 
+# SPDX-FileCopyrightText: 2016 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 while read -r i;
 do
   echo "$i" | python -m json.tool ;

--- a/contrib/prettyprint/prettyprint.txt
+++ b/contrib/prettyprint/prettyprint.txt
@@ -1,1 +1,7 @@
+#!/bin/sh
+
+# SPDX-FileCopyrightText: 2016 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 sh scrips/prettyprint.txt /opt/intelmq/var/lib/bots/file-output/events.txt

--- a/contrib/systemd/conf.py
+++ b/contrib/systemd/conf.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2017 navtej
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 import os.path
 import shutil

--- a/contrib/systemd/ignored_ids.txt
+++ b/contrib/systemd/ignored_ids.txt
@@ -1,2 +1,6 @@
+# SPDX-FileCopyrightText: 2017 navtej <nsbuttar@hotmail.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
 # all the bot ids existing in this file will be ignored by systemd script
 # one bot id on one line

--- a/contrib/systemd/systemd.py
+++ b/contrib/systemd/systemd.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2017 navtej
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 # flake8: noqa
 import collections

--- a/contrib/systemd/templates.py
+++ b/contrib/systemd/templates.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2017 navtej
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 from string import Template
 

--- a/docs/_static/Logo_Intel_MQ.svg.license
+++ b/docs/_static/Logo_Intel_MQ.svg.license
@@ -1,1 +1,2 @@
+SPDX-FileCopyrightText: 2017 Dustin Demuth <dustin@intevation.de>
 SPDX-License-Identifier: CC0-1.0

--- a/docs/_static/intelmq-arch-schema.png.license
+++ b/docs/_static/intelmq-arch-schema.png.license
@@ -1,1 +1,2 @@
+SPDX-FileCopyrightText: 2014 synchroack <synchroack@gmail.com>
 SPDX-License-Identifier: CC0-1.0

--- a/docs/_static/intelmq-arch-schema.vsd.license
+++ b/docs/_static/intelmq-arch-schema.vsd.license
@@ -1,1 +1,2 @@
+SPDX-FileCopyrightText: 2014 synchroack <synchroack@gmail.com>
 SPDX-License-Identifier: CC0-1.0

--- a/docs/_static/intelmq_logo.jpg.license
+++ b/docs/_static/intelmq_logo.jpg.license
@@ -1,1 +1,2 @@
+SPDX-FileCopyrightText: 2014 synchroack <synchroack@gmail.com>
 SPDX-License-Identifier: CC0-1.0

--- a/docs/_static/rabbitmq-user-monitoring.png.license
+++ b/docs/_static/rabbitmq-user-monitoring.png.license
@@ -1,1 +1,2 @@
+SPDX-FileCopyrightText: 2019 Sebastian Wagner
 SPDX-License-Identifier: CC0-1.0

--- a/docs/dev/IntelMQ-3.0-Architecture.md
+++ b/docs/dev/IntelMQ-3.0-Architecture.md
@@ -1,3 +1,8 @@
+<!-- comment
+   SPDX-FileCopyrightText: 2019 aaronkaplan <aaron@lo-res.org>
+   SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
 # Idea list and architecture of IntelMQ 3.0
 
 Authors: Aaron Kaplan <kaplan@cert.at>, Sebastian Wagner <wagner@cert.at>

--- a/docs/dev/data-format.rst
+++ b/docs/dev/data-format.rst
@@ -1,3 +1,7 @@
+..
+   SPDX-FileCopyrightText: 2015 Aaron Kaplan <aaron@lo-res.org>
+   SPDX-License-Identifier: AGPL-3.0-or-later
+
 ##################
 Data Format
 ##################

--- a/docs/dev/feeds-wishlist.rst
+++ b/docs/dev/feeds-wishlist.rst
@@ -1,3 +1,7 @@
+..
+   SPDX-FileCopyrightText: 2020 Sebastian Wagner <wagner@cert.at>
+   SPDX-License-Identifier: AGPL-3.0-or-later
+
 ###############
 Feeds wishlist
 ###############

--- a/docs/dev/guide.rst
+++ b/docs/dev/guide.rst
@@ -1,3 +1,7 @@
+..
+   SPDX-FileCopyrightText: 2015 Aaron Kaplan <aaron@lo-res.org>
+   SPDX-License-Identifier: AGPL-3.0-or-later
+
 ################
 Developers Guide
 ################

--- a/docs/dev/release-procedure.rst
+++ b/docs/dev/release-procedure.rst
@@ -1,3 +1,7 @@
+..
+   SPDX-FileCopyrightText: 2017 Sebastian Wagner
+   SPDX-License-Identifier: AGPL-3.0-or-later
+
 #################
 Release procedure
 #################

--- a/docs/user/ELK-Stack.rst
+++ b/docs/user/ELK-Stack.rst
@@ -1,3 +1,7 @@
+..
+   SPDX-FileCopyrightText: 2020 gethvi <gethvi@tuta.io>
+   SPDX-License-Identifier: AGPL-3.0-or-later
+
 ELK Stack
 =========
 

--- a/docs/user/FAQ.rst
+++ b/docs/user/FAQ.rst
@@ -1,3 +1,7 @@
+..
+   SPDX-FileCopyrightText: 2014 Tomás Lima <synchroack@gmail.com>
+   SPDX-License-Identifier: AGPL-3.0-or-later
+
 Frequently asked questions
 ==========================
 

--- a/docs/user/MISP-Integrations.rst
+++ b/docs/user/MISP-Integrations.rst
@@ -1,3 +1,7 @@
+..
+   SPDX-FileCopyrightText: 2019 Sebastian Wagner
+   SPDX-License-Identifier: AGPL-3.0-or-later
+
 MISP integrations in IntelMQ
 ============================
 

--- a/docs/user/bots.rst
+++ b/docs/user/bots.rst
@@ -1,3 +1,7 @@
+..
+   SPDX-FileCopyrightText: 2015 Sebastian Wagner
+   SPDX-License-Identifier: AGPL-3.0-or-later
+
 ####
 Bots
 ####

--- a/docs/user/configuration-management.rst
+++ b/docs/user/configuration-management.rst
@@ -1,3 +1,7 @@
+..
+   SPDX-FileCopyrightText: 2015 Aaron Kaplan <aaron@lo-res.org>
+   SPDX-License-Identifier: AGPL-3.0-or-later
+
 ############################
 Configuration and Management
 ############################

--- a/docs/user/ecosystem.rst
+++ b/docs/user/ecosystem.rst
@@ -1,3 +1,7 @@
+..
+   SPDX-FileCopyrightText: 2019 Sebastian Wagner
+   SPDX-License-Identifier: AGPL-3.0-or-later
+
 IntelMQ Ecosystem
 =================
 

--- a/docs/user/eventdb.rst
+++ b/docs/user/eventdb.rst
@@ -1,3 +1,7 @@
+..
+   SPDX-FileCopyrightText: 2021 Birger Schacht
+   SPDX-License-Identifier: AGPL-3.0-or-later
+
 =======
 EventDB
 =======

--- a/docs/user/hardware-requirements.rst
+++ b/docs/user/hardware-requirements.rst
@@ -1,3 +1,7 @@
+..
+   SPDX-FileCopyrightText: 2021 Sebastian Wagner
+   SPDX-License-Identifier: AGPL-3.0-or-later
+
 #####################
 Hardware Requirements
 #####################

--- a/docs/user/installation.rst
+++ b/docs/user/installation.rst
@@ -1,3 +1,7 @@
+..
+   SPDX-FileCopyrightText: 2017 Sebastian Wagner
+   SPDX-License-Identifier: AGPL-3.0-or-later
+
 Installation
 ============
 

--- a/docs/user/intelmq-manager.rst
+++ b/docs/user/intelmq-manager.rst
@@ -1,3 +1,7 @@
+..
+   SPDX-FileCopyrightText: 2020-2021 Birger Schacht
+   SPDX-License-Identifier: AGPL-3.0-or-later
+
 ###############
 IntelMQ Manager
 ###############

--- a/docs/user/intelmqctl.rst
+++ b/docs/user/intelmqctl.rst
@@ -1,3 +1,7 @@
+..
+   SPDX-FileCopyrightText: 2017 Sebastian Wagner
+   SPDX-License-Identifier: AGPL-3.0-or-later
+
 ========================
 intelmqctl documentation
 ========================

--- a/docs/user/introduction.rst
+++ b/docs/user/introduction.rst
@@ -1,3 +1,7 @@
+..
+   SPDX-FileCopyrightText: 2020-2021 Birger Schacht
+   SPDX-License-Identifier: AGPL-3.0-or-later
+
 ############
 Introduction
 ############

--- a/docs/user/n6-integrations.rst
+++ b/docs/user/n6-integrations.rst
@@ -1,3 +1,7 @@
+..
+   SPDX-FileCopyrightText: 2020 Sebastian Wagner
+   SPDX-License-Identifier: AGPL-3.0-or-later
+
 IntelMQ - n6 Integration
 ========================
 

--- a/docs/user/upgrade.rst
+++ b/docs/user/upgrade.rst
@@ -1,3 +1,7 @@
+..
+   SPDX-FileCopyrightText: 2017 Sebastian Wagner <wagner@cert.at>
+   SPDX-License-Identifier: AGPL-3.0-or-later
+
 Upgrade instructions
 ====================
 

--- a/intelmq/__init__.py
+++ b/intelmq/__init__.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2014 Tomás Lima
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 from .version import __version__, __version_info__  # noqa: F401
 import os
 import pathlib

--- a/intelmq/bin/intelmq_generate_misp_objects_templates.py
+++ b/intelmq/bin/intelmq_generate_misp_objects_templates.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2019 Raphaël Vinot
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """
 Generates a MISP object template

--- a/intelmq/bin/intelmq_psql_initdb.py
+++ b/intelmq/bin/intelmq_psql_initdb.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2015 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """
 Generates a SQL command file with commands to create the events table.

--- a/intelmq/bin/intelmqctl.py
+++ b/intelmq/bin/intelmqctl.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2016 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 import argparse
 import datetime

--- a/intelmq/bin/intelmqdump.py
+++ b/intelmq/bin/intelmqdump.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2016 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """
 """

--- a/intelmq/bin/rewrite_config_files.py
+++ b/intelmq/bin/rewrite_config_files.py
@@ -1,4 +1,9 @@
 #!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2016 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import argparse

--- a/intelmq/bots/collectors/alienvault_otx/REQUIREMENTS.txt
+++ b/intelmq/bots/collectors/alienvault_otx/REQUIREMENTS.txt
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: 2017 Sebastian Wagner
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 OTXv2>=1.2.0

--- a/intelmq/bots/collectors/alienvault_otx/collector.py
+++ b/intelmq/bots/collectors/alienvault_otx/collector.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2015 robcza
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 import datetime
 import json

--- a/intelmq/bots/collectors/amqp/REQUIREMENTS.txt
+++ b/intelmq/bots/collectors/amqp/REQUIREMENTS.txt
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: 2020 Sebastian Wagner
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 pika

--- a/intelmq/bots/collectors/amqp/collector_amqp.py
+++ b/intelmq/bots/collectors/amqp/collector_amqp.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2019 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """
 Collecting from a (remote) AMQP Server and fetching either intelmq or any other messages.

--- a/intelmq/bots/collectors/api/REQUIREMENTS.txt
+++ b/intelmq/bots/collectors/api/REQUIREMENTS.txt
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: 2018 tavi.poldma
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 tornado>=4.5.3

--- a/intelmq/bots/collectors/api/collector_api.py
+++ b/intelmq/bots/collectors/api/collector_api.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2018 tavi.poldma
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """
 API Collector bot

--- a/intelmq/bots/collectors/blueliv/REQUIREMENTS.txt
+++ b/intelmq/bots/collectors/blueliv/REQUIREMENTS.txt
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: 2016 Sebastian Wagner
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 git+git://github.com/Blueliv/api-python-sdk

--- a/intelmq/bots/collectors/blueliv/collector_crimeserver.py
+++ b/intelmq/bots/collectors/blueliv/collector_crimeserver.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2015 robcza
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 import json
 import logging

--- a/intelmq/bots/collectors/calidog/REQUIREMENTS.txt
+++ b/intelmq/bots/collectors/calidog/REQUIREMENTS.txt
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: 2018 Sebastian Wagner
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 certstream

--- a/intelmq/bots/collectors/calidog/collector_certstream.py
+++ b/intelmq/bots/collectors/calidog/collector_certstream.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2018 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 """

--- a/intelmq/bots/collectors/eset/REQUIREMENTS.txt
+++ b/intelmq/bots/collectors/eset/REQUIREMENTS.txt
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: 2020 Sebastian Wagner
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 cabby

--- a/intelmq/bots/collectors/eset/collector.py
+++ b/intelmq/bots/collectors/eset/collector.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 Mikk Margus Möll
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 import datetime
 
 from intelmq.lib.bot import CollectorBot

--- a/intelmq/bots/collectors/file/collector_file.py
+++ b/intelmq/bots/collectors/file/collector_file.py
@@ -1,4 +1,8 @@
 # -*- coding: utf-8 -*-
+# SPDX-FileCopyrightText: 2016 by Bundesamt für Sicherheit in der Informationstechnik
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 """
 File Collector Bot
 

--- a/intelmq/bots/collectors/fireeye/REQUIREMENTS.txt
+++ b/intelmq/bots/collectors/fireeye/REQUIREMENTS.txt
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: 2021 CysihZ
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 xmltodict>=0.12.0

--- a/intelmq/bots/collectors/fireeye/collector_mas.py
+++ b/intelmq/bots/collectors/fireeye/collector_mas.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2021 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """
 Fireeye collector bot

--- a/intelmq/bots/collectors/github_api/REQUIREMENTS.txt
+++ b/intelmq/bots/collectors/github_api/REQUIREMENTS.txt
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: 2019 Tomas Bellus
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 requests

--- a/intelmq/bots/collectors/github_api/_collector_github_api.py
+++ b/intelmq/bots/collectors/github_api/_collector_github_api.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2021 Sebastian Waldbauer
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """
 GITHUB API Collector bot

--- a/intelmq/bots/collectors/github_api/collector_github_contents_api.py
+++ b/intelmq/bots/collectors/github_api/collector_github_contents_api.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2019 Tomas Bellus
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """
 GITHUB contents API Collector bot

--- a/intelmq/bots/collectors/http/REQUIREMENTS.txt
+++ b/intelmq/bots/collectors/http/REQUIREMENTS.txt
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: 2017 Sebastian Wagner
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 python-gnupg

--- a/intelmq/bots/collectors/http/collector_http.py
+++ b/intelmq/bots/collectors/http/collector_http.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2015 National CyberSecurity Center
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """
 HTTP collector bot

--- a/intelmq/bots/collectors/http/collector_http_stream.py
+++ b/intelmq/bots/collectors/http/collector_http_stream.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2015 National CyberSecurity Center
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """
 HTTP collector bot

--- a/intelmq/bots/collectors/kafka/REQUIREMENTS.txt
+++ b/intelmq/bots/collectors/kafka/REQUIREMENTS.txt
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: 2020 Birger Schacht
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 kafka-python

--- a/intelmq/bots/collectors/kafka/collector.py
+++ b/intelmq/bots/collectors/kafka/collector.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 Birger Schacht
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 """
 Kafka Collector Bot
 

--- a/intelmq/bots/collectors/mail/REQUIREMENTS.txt
+++ b/intelmq/bots/collectors/mail/REQUIREMENTS.txt
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: 2016 Sebastian Wagner
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 imbox>=0.8.5

--- a/intelmq/bots/collectors/mail/_lib.py
+++ b/intelmq/bots/collectors/mail/_lib.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2021 Sebastian Waldbauer
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 import imaplib
 import re

--- a/intelmq/bots/collectors/mail/collector_mail_attach.py
+++ b/intelmq/bots/collectors/mail/collector_mail_attach.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2015 National CyberSecurity Center
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """
 In Version 0.9.5 the attachment filename is no longer surrounded by double quotes, see for the discussion:

--- a/intelmq/bots/collectors/mail/collector_mail_body.py
+++ b/intelmq/bots/collectors/mail/collector_mail_body.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2018 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """
 Uses the common mail iteration method from the lib file.

--- a/intelmq/bots/collectors/mail/collector_mail_url.py
+++ b/intelmq/bots/collectors/mail/collector_mail_url.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2015 National CyberSecurity Center
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """
 Uses the common mail iteration method from the lib file.

--- a/intelmq/bots/collectors/microsoft/REQUIREMENTS.txt
+++ b/intelmq/bots/collectors/microsoft/REQUIREMENTS.txt
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: 2017 Sebastian Wagner
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 azure-storage-blob>=12.0.0

--- a/intelmq/bots/collectors/microsoft/collector_azure.py
+++ b/intelmq/bots/collectors/microsoft/collector_azure.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2017 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """
 Uses the azure.storage.blob module. Tested with version 12.13.1

--- a/intelmq/bots/collectors/microsoft/collector_interflow.py
+++ b/intelmq/bots/collectors/microsoft/collector_interflow.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2018 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """
 https://interflow.portal.azure-api.net/

--- a/intelmq/bots/collectors/misp/REQUIREMENTS.txt
+++ b/intelmq/bots/collectors/misp/REQUIREMENTS.txt
@@ -1,2 +1,5 @@
+# SPDX-FileCopyrightText: 2016 kralca
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 pymisp>=2.4.36,<=2.4.119.1; python_version < '3.6'
 pymisp>=2.4.36; python_version >= '3.6'

--- a/intelmq/bots/collectors/misp/collector.py
+++ b/intelmq/bots/collectors/misp/collector.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2016 kralca
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """A collector for grabbing appropriately tagged events from MISP.
 

--- a/intelmq/bots/collectors/opendxl/REQUIREMENTS.txt
+++ b/intelmq/bots/collectors/opendxl/REQUIREMENTS.txt
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: 2018 root
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 dxlclient>=4.1.0.185

--- a/intelmq/bots/collectors/opendxl/collector.py
+++ b/intelmq/bots/collectors/opendxl/collector.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2018 root
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 """
 openDXL Collector Bot
 Connects to a openDXL fabric and subscribes to ATD topic

--- a/intelmq/bots/collectors/rsync/collector_rsync.py
+++ b/intelmq/bots/collectors/rsync/collector_rsync.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2018 dargen3
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 from os import mkdir, path
 from subprocess import run, PIPE

--- a/intelmq/bots/collectors/rt/REQUIREMENTS.txt
+++ b/intelmq/bots/collectors/rt/REQUIREMENTS.txt
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: 2016 Sebastian Wagner
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 rt>=1.0.9

--- a/intelmq/bots/collectors/rt/collector_rt.py
+++ b/intelmq/bots/collectors/rt/collector_rt.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2015 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 import re
 from datetime import datetime, timedelta

--- a/intelmq/bots/collectors/shodan/REQUIREMENTS.txt
+++ b/intelmq/bots/collectors/shodan/REQUIREMENTS.txt
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: 2018 Sebastian Wagner
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 shodan>=1.7.2

--- a/intelmq/bots/collectors/shodan/collector_stream.py
+++ b/intelmq/bots/collectors/shodan/collector_stream.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2018 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """
 Parameters:

--- a/intelmq/bots/collectors/stomp/REQUIREMENTS.txt
+++ b/intelmq/bots/collectors/stomp/REQUIREMENTS.txt
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: 2017 Sebastian Wagner
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 stomp.py>=4.1.8

--- a/intelmq/bots/collectors/stomp/ca.pem.license
+++ b/intelmq/bots/collectors/stomp/ca.pem.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2017 Sebastian Wagner
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/bots/collectors/stomp/collector.py
+++ b/intelmq/bots/collectors/stomp/collector.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2017 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 import os.path
 

--- a/intelmq/bots/collectors/tcp/collector.py
+++ b/intelmq/bots/collectors/tcp/collector.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2018 Edvard Rejthar
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import socket

--- a/intelmq/bots/collectors/twitter/REQUIREMENTS.txt
+++ b/intelmq/bots/collectors/twitter/REQUIREMENTS.txt
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: 2018 Karel
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 python-twitter

--- a/intelmq/bots/collectors/twitter/collector_twitter.py
+++ b/intelmq/bots/collectors/twitter/collector_twitter.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2018 Karel
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 """
 Twitter Collector Bot
 

--- a/intelmq/bots/experts/abusix/REQUIREMENTS.txt
+++ b/intelmq/bots/experts/abusix/REQUIREMENTS.txt
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: 2017 Sebastian Wagner
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 querycontacts

--- a/intelmq/bots/experts/abusix/_lib.py
+++ b/intelmq/bots/experts/abusix/_lib.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2021 Sebastian Waldbauer
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 import ipaddress
 import re

--- a/intelmq/bots/experts/abusix/expert.py
+++ b/intelmq/bots/experts/abusix/expert.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2015 National CyberSecurity Center
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 '''
 Reference: https://abusix.com/contactdb.html

--- a/intelmq/bots/experts/asn_lookup/REQUIREMENTS.txt
+++ b/intelmq/bots/experts/asn_lookup/REQUIREMENTS.txt
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: 2016 Sebastian Wagner
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 pyasn==1.6.0b1

--- a/intelmq/bots/experts/asn_lookup/expert.py
+++ b/intelmq/bots/experts/asn_lookup/expert.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2015 National CyberSecurity Center
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 import os
 import io

--- a/intelmq/bots/experts/asn_lookup/update-asn-data.license
+++ b/intelmq/bots/experts/asn_lookup/update-asn-data.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2016 Sascha Wilde
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/bots/experts/csv_converter/expert.py
+++ b/intelmq/bots/experts/csv_converter/expert.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2019 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 import csv
 import io

--- a/intelmq/bots/experts/cymru_whois/_lib.py
+++ b/intelmq/bots/experts/cymru_whois/_lib.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2021 Sebastian Waldbauer
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """
 Reference: https://team-cymru.com/community-services/ip-asn-mapping/#dns

--- a/intelmq/bots/experts/cymru_whois/expert.py
+++ b/intelmq/bots/experts/cymru_whois/expert.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2015 National CyberSecurity Center
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 import json
 

--- a/intelmq/bots/experts/deduplicator/expert.py
+++ b/intelmq/bots/experts/deduplicator/expert.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2015 National CyberSecurity Center
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """Deduplicator expert bot
 

--- a/intelmq/bots/experts/do_portal/expert.py
+++ b/intelmq/bots/experts/do_portal/expert.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2019 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """
 As the frontend reverse-proxies the (backend) API

--- a/intelmq/bots/experts/domain_suffix/REQUIREMENTS.txt
+++ b/intelmq/bots/experts/domain_suffix/REQUIREMENTS.txt
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: 2018 Sebastian Wagner
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 publicsuffixlist>=0.6.0

--- a/intelmq/bots/experts/domain_suffix/_lib.py
+++ b/intelmq/bots/experts/domain_suffix/_lib.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2021 Sebastian Waldbauer
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """
 A custom public suffix implementation

--- a/intelmq/bots/experts/domain_suffix/expert.py
+++ b/intelmq/bots/experts/domain_suffix/expert.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2018 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """
 The library publicsuffixlist will be used if installed,

--- a/intelmq/bots/experts/field_reducer/expert.py
+++ b/intelmq/bots/experts/field_reducer/expert.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2017 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """
 Reducer bot

--- a/intelmq/bots/experts/filter/expert.py
+++ b/intelmq/bots/experts/filter/expert.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2015 National CyberSecurity Center
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import re

--- a/intelmq/bots/experts/format_field/expert.py
+++ b/intelmq/bots/experts/format_field/expert.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2019 Brajneesh kumar
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 from intelmq.lib.bot import Bot
 

--- a/intelmq/bots/experts/generic_db_lookup/REQUIREMENTS.txt
+++ b/intelmq/bots/experts/generic_db_lookup/REQUIREMENTS.txt
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: 2017 Sebastian Wagner
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 psycopg2-binary>=2.5.5

--- a/intelmq/bots/experts/generic_db_lookup/expert.py
+++ b/intelmq/bots/experts/generic_db_lookup/expert.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2016 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """
 Generic DB Lookup

--- a/intelmq/bots/experts/geohash/REQUIREMENTS.txt
+++ b/intelmq/bots/experts/geohash/REQUIREMENTS.txt
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: 2019 Sebastian Wagner
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 geolib

--- a/intelmq/bots/experts/geohash/expert.py
+++ b/intelmq/bots/experts/geohash/expert.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2019 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 '''
 Uses

--- a/intelmq/bots/experts/gethostbyname/expert.py
+++ b/intelmq/bots/experts/gethostbyname/expert.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2016 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """
 These are all possible gaierrors according to the source:

--- a/intelmq/bots/experts/idea/expert.py
+++ b/intelmq/bots/experts/idea/expert.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2017 Pavel Kácha
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """
 IDEA classification: https://idea.cesnet.cz/en/classifications

--- a/intelmq/bots/experts/lookyloo/REQUIREMENTS.txt
+++ b/intelmq/bots/experts/lookyloo/REQUIREMENTS.txt
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: 2021 Sebastian Waldbauer
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 pylookyloo>=0.6

--- a/intelmq/bots/experts/lookyloo/expert.py
+++ b/intelmq/bots/experts/lookyloo/expert.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2021 Sebastian Waldbauer
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 from intelmq.lib.bot import Bot

--- a/intelmq/bots/experts/maxmind_geoip/README.md
+++ b/intelmq/bots/experts/maxmind_geoip/README.md
@@ -1,2 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2015 National CyberSecurity Center
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
 This product includes GeoLite2 data created by MaxMind, available from
 <a href="http://www.maxmind.com">http://www.maxmind.com</a>.

--- a/intelmq/bots/experts/maxmind_geoip/REQUIREMENTS.txt
+++ b/intelmq/bots/experts/maxmind_geoip/REQUIREMENTS.txt
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2016 Sebastian Wagner
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 geoip2>=2.2.0; python_version >= '3.6'
 geoip2>=2.2.0,<4.0.0; python_version < '3.6'
 maxminddb<2; python_version < '3.6'

--- a/intelmq/bots/experts/maxmind_geoip/expert.py
+++ b/intelmq/bots/experts/maxmind_geoip/expert.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2015 National CyberSecurity Center
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """
 This product includes GeoLite2 data created by MaxMind, available from

--- a/intelmq/bots/experts/maxmind_geoip/update-geoip-data.license
+++ b/intelmq/bots/experts/maxmind_geoip/update-geoip-data.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2016 Sascha Wilde
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/bots/experts/mcafee/REQUIREMENTS.txt
+++ b/intelmq/bots/experts/mcafee/REQUIREMENTS.txt
@@ -1,2 +1,5 @@
+# SPDX-FileCopyrightText: 2018 tux78
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 dxlclient>=4.1.0.185
 dxlmarclient>=0.2.0

--- a/intelmq/bots/experts/mcafee/expert_mar.py
+++ b/intelmq/bots/experts/mcafee/expert_mar.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2018 tux78
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """
 

--- a/intelmq/bots/experts/misp/REQUIREMENTS.txt
+++ b/intelmq/bots/experts/misp/REQUIREMENTS.txt
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: 2019 Raphaël Vinot
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 pymisp>=2.4.117.3

--- a/intelmq/bots/experts/misp/expert.py
+++ b/intelmq/bots/experts/misp/expert.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2019 Raphaël Vinot
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """
 An expert to for looking up values in MISP.

--- a/intelmq/bots/experts/modify/examples/default.conf.license
+++ b/intelmq/bots/experts/modify/examples/default.conf.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2016 Gernot Schulz
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/bots/experts/modify/expert.py
+++ b/intelmq/bots/experts/modify/expert.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2015 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """
 Modify Expert bot let's you manipulate all fields with a config file.

--- a/intelmq/bots/experts/national_cert_contact_certat/expert.py
+++ b/intelmq/bots/experts/national_cert_contact_certat/expert.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2017 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """
 CERT.at geolocate the national CERT abuse service

--- a/intelmq/bots/experts/rdap/expert.py
+++ b/intelmq/bots/experts/rdap/expert.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2021 Sebastian Waldbauer
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 from intelmq.lib.bot import Bot
 from intelmq.lib.utils import create_request_session

--- a/intelmq/bots/experts/recordedfuture_iprisk/expert.py
+++ b/intelmq/bots/experts/recordedfuture_iprisk/expert.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2018 olekristoffer
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """
 See README for database download.

--- a/intelmq/bots/experts/recordedfuture_iprisk/update-rfiprisk-data.license
+++ b/intelmq/bots/experts/recordedfuture_iprisk/update-rfiprisk-data.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2018 olekristoffer
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/bots/experts/reverse_dns/expert.py
+++ b/intelmq/bots/experts/reverse_dns/expert.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2015 robcza
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 from datetime import datetime

--- a/intelmq/bots/experts/rfc1918/expert.py
+++ b/intelmq/bots/experts/rfc1918/expert.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2015 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # *- coding: utf-8 -*-
 """
 RFC 1918 Will Drop Local IP from a given record and a bit more.

--- a/intelmq/bots/experts/ripe/expert.py
+++ b/intelmq/bots/experts/ripe/expert.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2018 Brajneesh Kumar
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 '''
 Reference:

--- a/intelmq/bots/experts/ripencc_abuse_contact/expert.py
+++ b/intelmq/bots/experts/ripencc_abuse_contact/expert.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2015 National CyberSecurity Center
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 from ..ripe.expert import RIPEExpertBot
 

--- a/intelmq/bots/experts/sieve/REQUIREMENTS.txt
+++ b/intelmq/bots/experts/sieve/REQUIREMENTS.txt
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: 2017 Antoine Neuenschwander
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 textX>=1.5.1

--- a/intelmq/bots/experts/sieve/expert.py
+++ b/intelmq/bots/experts/sieve/expert.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2017 Antoine Neuenschwander
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """
 SieveExpertBot filters and modifies events based on a specification language similar to mail sieve.

--- a/intelmq/bots/experts/sieve/sieve.tx.license
+++ b/intelmq/bots/experts/sieve/sieve.tx.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2017 Antoine Neuenschwander
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/bots/experts/taxonomy/expert.py
+++ b/intelmq/bots/experts/taxonomy/expert.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2015 National CyberSecurity Center
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """
 The mapping follows

--- a/intelmq/bots/experts/tor_nodes/expert.py
+++ b/intelmq/bots/experts/tor_nodes/expert.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2015 National CyberSecurity Center
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """
 See README for database download.

--- a/intelmq/bots/experts/tor_nodes/update-tor-nodes.license
+++ b/intelmq/bots/experts/tor_nodes/update-tor-nodes.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2016 Sascha Wilde
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/bots/experts/url2fqdn/expert.py
+++ b/intelmq/bots/experts/url2fqdn/expert.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2015 robcza
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 from urllib.parse import urlparse
 

--- a/intelmq/bots/experts/uwhoisd/expert.py
+++ b/intelmq/bots/experts/uwhoisd/expert.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2021 Raphaël Vinot
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import socket

--- a/intelmq/bots/experts/wait/expert.py
+++ b/intelmq/bots/experts/wait/expert.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2018 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """
 Created on Tue Jan 23 15:25:58 2018

--- a/intelmq/bots/outputs/amqptopic/REQUIREMENTS.txt
+++ b/intelmq/bots/outputs/amqptopic/REQUIREMENTS.txt
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: 2016 pedromreis
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 pika>=0.10.0

--- a/intelmq/bots/outputs/amqptopic/output.py
+++ b/intelmq/bots/outputs/amqptopic/output.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2016 Pedro Reis
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 import ssl
 

--- a/intelmq/bots/outputs/blackhole/output.py
+++ b/intelmq/bots/outputs/blackhole/output.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2018 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 from intelmq.lib.bot import Bot
 

--- a/intelmq/bots/outputs/elasticsearch/REQUIREMENTS.txt
+++ b/intelmq/bots/outputs/elasticsearch/REQUIREMENTS.txt
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: 2017 Sebastian Wagner
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 elasticsearch>=7.0.0,<8.0.0

--- a/intelmq/bots/outputs/elasticsearch/output.py
+++ b/intelmq/bots/outputs/elasticsearch/output.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2017 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """
 The ES-connection can't be closed explicitly.

--- a/intelmq/bots/outputs/file/output.py
+++ b/intelmq/bots/outputs/file/output.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2015 National CyberSecurity Center
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 import datetime
 import os

--- a/intelmq/bots/outputs/files/output.py
+++ b/intelmq/bots/outputs/files/output.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2017 Pavel Kácha
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 import errno
 import io

--- a/intelmq/bots/outputs/mcafee/REQUIREMENTS.txt
+++ b/intelmq/bots/outputs/mcafee/REQUIREMENTS.txt
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: 2018 Sebastian Wagner
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 mfe_saw

--- a/intelmq/bots/outputs/mcafee/output_esm_ip.py
+++ b/intelmq/bots/outputs/mcafee/output_esm_ip.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2018 tux78
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """
 ESMOutputBot connects to McAfee Enterprise Security Manager, and updates IP based watchlists

--- a/intelmq/bots/outputs/misp/REQUIREMENTS.txt
+++ b/intelmq/bots/outputs/misp/REQUIREMENTS.txt
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: 2019 Sebastian Wagner
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 pymisp>=2.4.120; python_version >= '3.6'

--- a/intelmq/bots/outputs/misp/output_feed.py
+++ b/intelmq/bots/outputs/misp/output_feed.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2019 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 import datetime
 import json

--- a/intelmq/bots/outputs/mongodb/REQUIREMENTS.txt
+++ b/intelmq/bots/outputs/mongodb/REQUIREMENTS.txt
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: 2016 Sebastian Wagner
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 pymongo>=2.7.1

--- a/intelmq/bots/outputs/mongodb/output.py
+++ b/intelmq/bots/outputs/mongodb/output.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2015 National CyberSecurity Center
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """
 pymongo library automatically tries to reconnect if connection has been lost.

--- a/intelmq/bots/outputs/postgresql/output.py
+++ b/intelmq/bots/outputs/postgresql/output.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2015 National CyberSecurity Center
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """
 Compatibility shim

--- a/intelmq/bots/outputs/redis/output.py
+++ b/intelmq/bots/outputs/redis/output.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2016 pedromreis
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import redis

--- a/intelmq/bots/outputs/restapi/output.py
+++ b/intelmq/bots/outputs/restapi/output.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2015 robcza
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 from typing import Iterable
 

--- a/intelmq/bots/outputs/rt/REQUIREMENTS.txt
+++ b/intelmq/bots/outputs/rt/REQUIREMENTS.txt
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: 2020 Marius Urkis
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 rt>=1.0.9

--- a/intelmq/bots/outputs/rt/output.py
+++ b/intelmq/bots/outputs/rt/output.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 Marius Urkis
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """
 Request Tracker output bot

--- a/intelmq/bots/outputs/smtp/output.py
+++ b/intelmq/bots/outputs/smtp/output.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2017 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 import csv
 import io

--- a/intelmq/bots/outputs/sql/REQUIREMENTS.txt
+++ b/intelmq/bots/outputs/sql/REQUIREMENTS.txt
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: 2019 Edvard Rejthar
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 psycopg2-binary>=2.5.5

--- a/intelmq/bots/outputs/sql/output.py
+++ b/intelmq/bots/outputs/sql/output.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2019 Edvard Rejthar
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """
 SQL output bot.

--- a/intelmq/bots/outputs/stomp/REQUIREMENTS.txt
+++ b/intelmq/bots/outputs/stomp/REQUIREMENTS.txt
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: 2016 aaronkaplan
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 stomp.py>=4.1.8

--- a/intelmq/bots/outputs/stomp/output.py
+++ b/intelmq/bots/outputs/stomp/output.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2016 Mauro Silva
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 import os.path
 

--- a/intelmq/bots/outputs/tcp/output.py
+++ b/intelmq/bots/outputs/tcp/output.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2015 National CyberSecurity Center
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """
 For intelmq collectors on the other side we can expect the "ok" sent back.

--- a/intelmq/bots/outputs/touch/output.py
+++ b/intelmq/bots/outputs/touch/output.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2019 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """
 Using pathlib.Path.touch(path) and os.utime(path) did not work -

--- a/intelmq/bots/outputs/udp/output.py
+++ b/intelmq/bots/outputs/udp/output.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2016 pedromreis
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 import socket
 import unicodedata

--- a/intelmq/bots/parsers/abusech/parser_domain.py
+++ b/intelmq/bots/parsers/abusech/parser_domain.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2015 robcza
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """
 Parses simple newline separated list of domains.

--- a/intelmq/bots/parsers/abusech/parser_ip.py
+++ b/intelmq/bots/parsers/abusech/parser_ip.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2015 robcza
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """
 Parses simple newline separated list of IPs.

--- a/intelmq/bots/parsers/alienvault/parser.py
+++ b/intelmq/bots/parsers/alienvault/parser.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2015 National CyberSecurity Center
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 from intelmq.lib.bot import ParserBot

--- a/intelmq/bots/parsers/alienvault/parser_otx.py
+++ b/intelmq/bots/parsers/alienvault/parser_otx.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2015 robcza
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """
 Events are gathered based on user subscriptions in AlienVault OTX

--- a/intelmq/bots/parsers/anubisnetworks/parser.py
+++ b/intelmq/bots/parsers/anubisnetworks/parser.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2017 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """
 AnubisNetworks Cyberfeed Stream parser

--- a/intelmq/bots/parsers/autoshun/parser.py
+++ b/intelmq/bots/parsers/autoshun/parser.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2015 National CyberSecurity Center
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 import html
 

--- a/intelmq/bots/parsers/bambenek/parser.py
+++ b/intelmq/bots/parsers/bambenek/parser.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2016 jgedeon120
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """ IntelMQ parser for Bambenek DGA, Domain, and IP feeds """
 

--- a/intelmq/bots/parsers/blocklistde/parser.py
+++ b/intelmq/bots/parsers/blocklistde/parser.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2015 National CyberSecurity Center
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 import posixpath
 from urllib.parse import urlparse

--- a/intelmq/bots/parsers/blueliv/parser_crimeserver.py
+++ b/intelmq/bots/parsers/blueliv/parser_crimeserver.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2015 robcza
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """
 """

--- a/intelmq/bots/parsers/calidog/parser_certstream.py
+++ b/intelmq/bots/parsers/calidog/parser_certstream.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2018 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 """
 A bot to parse certstream data.
 @author: Christoph Giese (Telekom Security, CDR)

--- a/intelmq/bots/parsers/cert_eu/parser_csv.py
+++ b/intelmq/bots/parsers/cert_eu/parser_csv.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2018 Pierre Dumont
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 """
 CERT-EU parser
 

--- a/intelmq/bots/parsers/ci_army/parser.py
+++ b/intelmq/bots/parsers/ci_army/parser.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2015 National CyberSecurity Center
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 from intelmq.lib import utils

--- a/intelmq/bots/parsers/cleanmx/parser.py
+++ b/intelmq/bots/parsers/cleanmx/parser.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2016 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 from collections import OrderedDict
 from datetime import datetime
 from xml.etree import ElementTree

--- a/intelmq/bots/parsers/cymru/parser_cap_program.py
+++ b/intelmq/bots/parsers/cymru/parser_cap_program.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2018 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 import re
 

--- a/intelmq/bots/parsers/cymru/parser_full_bogons.py
+++ b/intelmq/bots/parsers/cymru/parser_full_bogons.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2018 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 import dateutil
 

--- a/intelmq/bots/parsers/cznic/parser_haas.py
+++ b/intelmq/bots/parsers/cznic/parser_haas.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 gethvi
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 import dateutil.parser
 

--- a/intelmq/bots/parsers/cznic/parser_proki.py
+++ b/intelmq/bots/parsers/cznic/parser_proki.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 sinus-x
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 import json
 

--- a/intelmq/bots/parsers/danger_rulez/parser.py
+++ b/intelmq/bots/parsers/danger_rulez/parser.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2015 National CyberSecurity Center
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 import re
 

--- a/intelmq/bots/parsers/dataplane/parser.py
+++ b/intelmq/bots/parsers/dataplane/parser.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2016 jgedeon120
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """ IntelMQ Dataplane Parser """
 

--- a/intelmq/bots/parsers/dshield/parser_asn.py
+++ b/intelmq/bots/parsers/dshield/parser_asn.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2015 National CyberSecurity Center
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """
 # created: Tue, 22 Dec 2015 12:19:03 +0000#

--- a/intelmq/bots/parsers/dshield/parser_block.py
+++ b/intelmq/bots/parsers/dshield/parser_block.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2015 National CyberSecurity Center
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """
 #   primary URL: https://feeds.dshield.org/block.txt

--- a/intelmq/bots/parsers/dshield/parser_domain.py
+++ b/intelmq/bots/parsers/dshield/parser_domain.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2015 National CyberSecurity Center
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """
 #   DShield.org Suspicious Domain List

--- a/intelmq/bots/parsers/dyn/parser.py
+++ b/intelmq/bots/parsers/dyn/parser.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2015 National CyberSecurity Center
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """
 format:

--- a/intelmq/bots/parsers/eset/parser.py
+++ b/intelmq/bots/parsers/eset/parser.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 Mikk Margus Möll
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 import json
 
 from intelmq.lib.bot import ParserBot

--- a/intelmq/bots/parsers/fireeye/REQUIREMENTS.txt
+++ b/intelmq/bots/parsers/fireeye/REQUIREMENTS.txt
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: 2021 Sebastian Wagner
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 xmltodict>=0.12.0

--- a/intelmq/bots/parsers/fireeye/parser.py
+++ b/intelmq/bots/parsers/fireeye/parser.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2021 CysihZ
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 """
 Fireeye Parser Bot
 Retrieves a base64 encoded JSON-String from raw and converts it into an

--- a/intelmq/bots/parsers/fraunhofer/parser_dga.py
+++ b/intelmq/bots/parsers/fraunhofer/parser_dga.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2015 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """
 The source provides a JSON file with a dictionary. The keys of this dict are

--- a/intelmq/bots/parsers/generic/parser_csv.py
+++ b/intelmq/bots/parsers/generic/parser_csv.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2016 robcza
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """
 Generic CSV parser

--- a/intelmq/bots/parsers/github_feed/REQUIREMENTS.txt
+++ b/intelmq/bots/parsers/github_feed/REQUIREMENTS.txt
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: 2019 Tomas Bellus
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 validators

--- a/intelmq/bots/parsers/github_feed/parser.py
+++ b/intelmq/bots/parsers/github_feed/parser.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2019 Tomas Bellus
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 """
 Github IOC feeds' parser
 """

--- a/intelmq/bots/parsers/hibp/parser_callback.py
+++ b/intelmq/bots/parsers/hibp/parser_callback.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2019 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """
 There are two different Formats: Breaches and Pastes

--- a/intelmq/bots/parsers/html_table/REQUIREMENTS.txt
+++ b/intelmq/bots/parsers/html_table/REQUIREMENTS.txt
@@ -1,2 +1,5 @@
+# SPDX-FileCopyrightText: 2019 Brajneesh Kumar
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 beautifulsoup4
 lxml

--- a/intelmq/bots/parsers/html_table/parser.py
+++ b/intelmq/bots/parsers/html_table/parser.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2019 Brajneesh Kumar
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """
 HTML Table parser

--- a/intelmq/bots/parsers/json/parser.py
+++ b/intelmq/bots/parsers/json/parser.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2016 by Bundesamt für Sicherheit in der Informationstechnik
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """
 JSON Parser Bot
 Retrieves a base64 encoded JSON-String from raw and converts it into an

--- a/intelmq/bots/parsers/malc0de/parser.py
+++ b/intelmq/bots/parsers/malc0de/parser.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2016 jgedeon120
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """ IntelMQ parser for Malc0de feeds """
 

--- a/intelmq/bots/parsers/malwaredomains/parser.py
+++ b/intelmq/bots/parsers/malwaredomains/parser.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2015 National CyberSecurity Center
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """
 The descriptions give a hint about what the entry is about and is very mixed.

--- a/intelmq/bots/parsers/malwarepatrol/parser_dansguardian.py
+++ b/intelmq/bots/parsers/malwarepatrol/parser_dansguardian.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2015 National CyberSecurity Center
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 import re
 import time

--- a/intelmq/bots/parsers/malwareurl/parser.py
+++ b/intelmq/bots/parsers/malwareurl/parser.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2018 dargen3
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 from html.parser import HTMLParser
 

--- a/intelmq/bots/parsers/mcafee/parser_atd.py
+++ b/intelmq/bots/parsers/mcafee/parser_atd.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2018 tux78
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """
 ATDParserBot parses McAfee Advanced Threat Defense reports.

--- a/intelmq/bots/parsers/microsoft/parser_bingmurls.py
+++ b/intelmq/bots/parsers/microsoft/parser_bingmurls.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2018 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """
 Parses BingMURLs data in JSON format.

--- a/intelmq/bots/parsers/microsoft/parser_ctip.py
+++ b/intelmq/bots/parsers/microsoft/parser_ctip.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2018 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """
 Parses CTIP data in JSON format.

--- a/intelmq/bots/parsers/misp/parser.py
+++ b/intelmq/bots/parsers/misp/parser.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2016 kralca
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 import json
 from datetime import datetime

--- a/intelmq/bots/parsers/n6/parser_n6stomp.py
+++ b/intelmq/bots/parsers/n6/parser_n6stomp.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2015 aaronkaplan
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """
 The source provides a JSON file with a dictionary. The keys of this dict are

--- a/intelmq/bots/parsers/netlab_360/parser.py
+++ b/intelmq/bots/parsers/netlab_360/parser.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2016 jgedeon120
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """ IntelMQ parser for Netlab 360 data feeds. """
 

--- a/intelmq/bots/parsers/openphish/parser.py
+++ b/intelmq/bots/parsers/openphish/parser.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2015 National CyberSecurity Center
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 from intelmq.lib import utils

--- a/intelmq/bots/parsers/openphish/parser_commercial.py
+++ b/intelmq/bots/parsers/openphish/parser_commercial.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2018 Filip Pokorný
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import json

--- a/intelmq/bots/parsers/phishtank/parser.py
+++ b/intelmq/bots/parsers/phishtank/parser.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2014 Tomás Lima
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 import csv
 import io

--- a/intelmq/bots/parsers/shadowserver/_config.py
+++ b/intelmq/bots/parsers/shadowserver/_config.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2016-2018 by Bundesamt für Sicherheit in der Informationstechnik (BSI)
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
 # -*- coding: utf-8 -*-
 """
 Copyright (c)2016-2018 by Bundesamt für Sicherheit in der Informationstechnik (BSI)

--- a/intelmq/bots/parsers/shadowserver/parser.py
+++ b/intelmq/bots/parsers/shadowserver/parser.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2016 by Bundesamt für Sicherheit in der Informationstechnik
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
 # -*- coding: utf-8 -*-
 """
 Copyright (C) 2016 by Bundesamt für Sicherheit in der Informationstechnik

--- a/intelmq/bots/parsers/shodan/parser.py
+++ b/intelmq/bots/parsers/shodan/parser.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2018 by nic.at GmbH
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """
 Shodan Stream Parser
 

--- a/intelmq/bots/parsers/spamhaus/parser_cert.py
+++ b/intelmq/bots/parsers/spamhaus/parser_cert.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2015 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
 # -*- coding: utf-8 -*-
 """
 Header of the File:

--- a/intelmq/bots/parsers/spamhaus/parser_drop.py
+++ b/intelmq/bots/parsers/spamhaus/parser_drop.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2015 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """ Single IntelMQ parser for Spamhaus drop feeds """
 

--- a/intelmq/bots/parsers/sucuri/parser.py
+++ b/intelmq/bots/parsers/sucuri/parser.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2018 dargen3
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """
 Only parses hidden iframes and conditional redirections, not Encoded javascript.

--- a/intelmq/bots/parsers/surbl/parser.py
+++ b/intelmq/bots/parsers/surbl/parser.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2018 dargen3
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 from intelmq.lib import utils
 from intelmq.lib.bot import Bot

--- a/intelmq/bots/parsers/taichung/parser.py
+++ b/intelmq/bots/parsers/taichung/parser.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2015 National CyberSecurity Center
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """
 unmapped:

--- a/intelmq/bots/parsers/threatminer/parser.py
+++ b/intelmq/bots/parsers/threatminer/parser.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2018 dargen3
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 from html.parser import HTMLParser
 

--- a/intelmq/bots/parsers/turris/parser.py
+++ b/intelmq/bots/parsers/turris/parser.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2015 robcza
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 import csv
 import io

--- a/intelmq/bots/parsers/twitter/REQUIREMENTS.txt
+++ b/intelmq/bots/parsers/twitter/REQUIREMENTS.txt
@@ -1,2 +1,5 @@
+# SPDX-FileCopyrightText: 2018 Karel
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 tld
 url-normalize

--- a/intelmq/bots/parsers/twitter/parser.py
+++ b/intelmq/bots/parsers/twitter/parser.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2018 Karel
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 r"""
 
 Parser of text intended to obtain IOCs from tweets.

--- a/intelmq/bots/parsers/vxvault/parser.py
+++ b/intelmq/bots/parsers/vxvault/parser.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2014 Tomás Lima
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 from urllib.parse import urlparse
 

--- a/intelmq/bots/parsers/webinspektor/parser.py
+++ b/intelmq/bots/parsers/webinspektor/parser.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2018 dargen3
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 from html.parser import HTMLParser
 

--- a/intelmq/bots/parsers/zoneh/parser.py
+++ b/intelmq/bots/parsers/zoneh/parser.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2017 Chris Horsley
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """
 ZoneH CSV defacement report parser

--- a/intelmq/etc/feeds.yaml
+++ b/intelmq/etc/feeds.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2018 SYNchroACK
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 providers:
   ViriBack:

--- a/intelmq/etc/harmonization.conf.license
+++ b/intelmq/etc/harmonization.conf.license
@@ -1,2 +1,3 @@
 SPDX-FileCopyrightText: 2016 Sebastian Wagner
-SPDX-License-Identifier: CC0-1.0
+SPDX-License-Identifier: AGPL-3.0-or-later
+

--- a/intelmq/etc/runtime.yaml
+++ b/intelmq/etc/runtime.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2021 Birger Schacht <schacht@cert.at>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
 cymru-whois-expert:
   bot_id: cymru-whois-expert
   description: Cymru Whois (IP to ASN) is the bot responsible to add network information

--- a/intelmq/lib/bot.py
+++ b/intelmq/lib/bot.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2014 Tomás Lima
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """
 The bot library has the base classes for all bots.

--- a/intelmq/lib/bot_debugger.py
+++ b/intelmq/lib/bot_debugger.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2017 Edvard Rejthar
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """
 Utilities for debugging intelmq bots.

--- a/intelmq/lib/cache.py
+++ b/intelmq/lib/cache.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2014 Tomás Lima
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """
 Cache is a set with information already seen by the system.

--- a/intelmq/lib/exceptions.py
+++ b/intelmq/lib/exceptions.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2015 Dognaedis
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 '''
     IntelMQ Exception Class

--- a/intelmq/lib/harmonization.py
+++ b/intelmq/lib/harmonization.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2015 Dognaedis
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """
 The following types are implemented with sanitize() and is_valid() functions:

--- a/intelmq/lib/message.py
+++ b/intelmq/lib/message.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2014 Mauro Silva
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """
 Messages are the information packages in pipelines.

--- a/intelmq/lib/mixins/__init__.py
+++ b/intelmq/lib/mixins/__init__.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2021 Birger Schacht
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 from intelmq.lib.mixins.http import HttpMixin
 from intelmq.lib.mixins.cache import CacheMixin
 

--- a/intelmq/lib/pipeline.py
+++ b/intelmq/lib/pipeline.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2014 Tomás Lima
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 import time
 import inspect

--- a/intelmq/lib/splitreports.py
+++ b/intelmq/lib/splitreports.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2016 Bernhard Herzog
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """
 Support for splitting large raw reports into smaller ones.

--- a/intelmq/lib/test.py
+++ b/intelmq/lib/test.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2015 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """
 Utilities for testing intelmq bots.

--- a/intelmq/lib/utils.py
+++ b/intelmq/lib/utils.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2014 Tomás Lima
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """
 Common utility functions for intelmq.

--- a/intelmq/tests/assets/bots.schema.json.license
+++ b/intelmq/tests/assets/bots.schema.json.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2018 Sebastian Wagner
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/assets/feeds.schema.json.license
+++ b/intelmq/tests/assets/feeds.schema.json.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2018 Sebastian Wagner
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/assets/foobar.gz.license
+++ b/intelmq/tests/assets/foobar.gz.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2018 Sebastian Wagner
+
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/assets/foobar.txt.asc.license
+++ b/intelmq/tests/assets/foobar.txt.asc.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2020 sinus-x
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/assets/foobar.txt.license
+++ b/intelmq/tests/assets/foobar.txt.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2019 Sebastian Wagner
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/assets/key-private.pgp.license
+++ b/intelmq/tests/assets/key-private.pgp.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2020 sinus-x
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/assets/key-public.pgp.license
+++ b/intelmq/tests/assets/key-public.pgp.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2020 sinus-x
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/assets/two_files.tar.gz.license
+++ b/intelmq/tests/assets/two_files.tar.gz.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2017 Sebastian Wagner
+
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/assets/two_files.zip.license
+++ b/intelmq/tests/assets/two_files.zip.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2019 Sebastian Wagner
+
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bin/initdb.sql.license
+++ b/intelmq/tests/bin/initdb.sql.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2016 Sebastian Wagner
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bin/test_intelmqctl.py
+++ b/intelmq/tests/bin/test_intelmqctl.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2016 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 import unittest
 

--- a/intelmq/tests/bin/test_intelmqdump.py
+++ b/intelmq/tests/bin/test_intelmqdump.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2016 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 import unittest
 

--- a/intelmq/tests/bin/test_psql_initdb.py
+++ b/intelmq/tests/bin/test_psql_initdb.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2016 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """
 Created on Tue Aug  9 14:04:13 2016

--- a/intelmq/tests/bots/collectors/alienvault_otx/test_collector.py
+++ b/intelmq/tests/bots/collectors/alienvault_otx/test_collector.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2016 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """
 Testing Alienvault OTX collector

--- a/intelmq/tests/bots/collectors/amqp/test_collector_amqp.py
+++ b/intelmq/tests/bots/collectors/amqp/test_collector_amqp.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2019 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 import json
 import unittest

--- a/intelmq/tests/bots/collectors/api/test_collector.py
+++ b/intelmq/tests/bots/collectors/api/test_collector.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2018 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """
 Testing API collector

--- a/intelmq/tests/bots/collectors/blueliv/test_collector.py
+++ b/intelmq/tests/bots/collectors/blueliv/test_collector.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2016 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """
 Testing Blueliv crimeserver collector

--- a/intelmq/tests/bots/collectors/calidog/test_collector.py
+++ b/intelmq/tests/bots/collectors/calidog/test_collector.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2018 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 """
 Test for the certstream Collector Bot
 """

--- a/intelmq/tests/bots/collectors/eset/test_collector.py
+++ b/intelmq/tests/bots/collectors/eset/test_collector.py
@@ -1,1 +1,5 @@
+# SPDX-FileCopyrightText: 2020 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 import intelmq.bots.collectors.eset.collector

--- a/intelmq/tests/bots/collectors/file/test_collector.py
+++ b/intelmq/tests/bots/collectors/file/test_collector.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2016 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """
 Testing File Collector

--- a/intelmq/tests/bots/collectors/file/testfile.txt.license
+++ b/intelmq/tests/bots/collectors/file/testfile.txt.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2016 Sebastian Wagner
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/collectors/fireeye/first_request.json.license
+++ b/intelmq/tests/bots/collectors/fireeye/first_request.json.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2021 Sebastian Wagner
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/collectors/fireeye/second_request.xml.license
+++ b/intelmq/tests/bots/collectors/fireeye/second_request.xml.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2021 Sebastian Wagner
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/collectors/fireeye/test_collector_mas.py
+++ b/intelmq/tests/bots/collectors/fireeye/test_collector_mas.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2021 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 import unittest
 import pathlib
 import secrets

--- a/intelmq/tests/bots/collectors/github_api/example_github_repo_contents_response.json.license
+++ b/intelmq/tests/bots/collectors/github_api/example_github_repo_contents_response.json.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2019 Tomas Bellus
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/collectors/github_api/test_collector.py
+++ b/intelmq/tests/bots/collectors/github_api/test_collector.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2019 Tomas Bellus
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """
 Testing Github API Collectors

--- a/intelmq/tests/bots/collectors/http/test_collector.py
+++ b/intelmq/tests/bots/collectors/http/test_collector.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2016 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """
 Testing HTTP collector

--- a/intelmq/tests/bots/collectors/http/test_collector_stream.py
+++ b/intelmq/tests/bots/collectors/http/test_collector_stream.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2016 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """
 Testing HTTP Stream collector

--- a/intelmq/tests/bots/collectors/mail/fake_attachment.eml.license
+++ b/intelmq/tests/bots/collectors/mail/fake_attachment.eml.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2020 Sebastian Wagner
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/collectors/mail/foobartxt.eml.license
+++ b/intelmq/tests/bots/collectors/mail/foobartxt.eml.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2019 Sebastian Wagner
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/collectors/mail/foobarzip.eml.license
+++ b/intelmq/tests/bots/collectors/mail/foobarzip.eml.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2019 Sebastian Wagner
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/collectors/mail/lib.py
+++ b/intelmq/tests/bots/collectors/mail/lib.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2019 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """
 Created on Tue Sep 10 17:10:54 2019

--- a/intelmq/tests/bots/collectors/mail/test_collector_attach.py
+++ b/intelmq/tests/bots/collectors/mail/test_collector_attach.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2016 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """
 Testing Mail Attach collector

--- a/intelmq/tests/bots/collectors/mail/test_collector_body.py
+++ b/intelmq/tests/bots/collectors/mail/test_collector_body.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2019 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """
 Testing Mail Attachment collector

--- a/intelmq/tests/bots/collectors/mail/test_collector_url.py
+++ b/intelmq/tests/bots/collectors/mail/test_collector_url.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2016 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """
 Testing Mail URL collector

--- a/intelmq/tests/bots/collectors/microsoft/test_collector_azure.py
+++ b/intelmq/tests/bots/collectors/microsoft/test_collector_azure.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2017 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 """
 Test for the Microsoft Azure Collector Bot
 """

--- a/intelmq/tests/bots/collectors/microsoft/test_collector_interflow.py
+++ b/intelmq/tests/bots/collectors/microsoft/test_collector_interflow.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2019 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 """
 Test for the Microsoft Azure Collector Bot
 """

--- a/intelmq/tests/bots/collectors/misp/test_collector.py
+++ b/intelmq/tests/bots/collectors/misp/test_collector.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """
 Testing MISP collector

--- a/intelmq/tests/bots/collectors/opendxl/test_collector.py
+++ b/intelmq/tests/bots/collectors/opendxl/test_collector.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2018 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 import os
 
 if os.environ.get('INTELMQ_TEST_EXOTIC'):

--- a/intelmq/tests/bots/collectors/rsync/test_collector.py
+++ b/intelmq/tests/bots/collectors/rsync/test_collector.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2018 dargen3
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 import tempfile
 import os

--- a/intelmq/tests/bots/collectors/rsync/testfile.txt.license
+++ b/intelmq/tests/bots/collectors/rsync/testfile.txt.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2018 dargen3
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/collectors/rt/test_collector.py
+++ b/intelmq/tests/bots/collectors/rt/test_collector.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2016 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """
 """

--- a/intelmq/tests/bots/collectors/shadowserver/reports-list.json.license
+++ b/intelmq/tests/bots/collectors/shadowserver/reports-list.json.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2021 Sebastian Wagner
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/collectors/shadowserver/test_collector_reports_api.py
+++ b/intelmq/tests/bots/collectors/shadowserver/test_collector_reports_api.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2021 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 import unittest
 import pathlib
 import secrets

--- a/intelmq/tests/bots/collectors/shodan/test_collector_stream.py
+++ b/intelmq/tests/bots/collectors/shodan/test_collector_stream.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2018 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """
 """

--- a/intelmq/tests/bots/collectors/stomp/test_collector.py
+++ b/intelmq/tests/bots/collectors/stomp/test_collector.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2017 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """
 Testing stomp collector

--- a/intelmq/tests/bots/collectors/tcp/test_collector.py
+++ b/intelmq/tests/bots/collectors/tcp/test_collector.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2018 Edvard Rejthar
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 """
 Testing TCP collector
 """

--- a/intelmq/tests/bots/collectors/twitter/test_collector_twitter.py
+++ b/intelmq/tests/bots/collectors/twitter/test_collector_twitter.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2018 Karel
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 """
 Test for the Twitter Collector Bot
 """

--- a/intelmq/tests/bots/experts/abusix/test_expert.py
+++ b/intelmq/tests/bots/experts/abusix/test_expert.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2015 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 import unittest
 

--- a/intelmq/tests/bots/experts/asn_lookup/ipasn.dat.license
+++ b/intelmq/tests/bots/experts/asn_lookup/ipasn.dat.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2016 Sebastian Wagner
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/experts/asn_lookup/test_expert.py
+++ b/intelmq/tests/bots/experts/asn_lookup/test_expert.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2015 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """
 Testing asn_lookup with a faked local database

--- a/intelmq/tests/bots/experts/csv_converter/test_expert.py
+++ b/intelmq/tests/bots/experts/csv_converter/test_expert.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2019 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 import unittest
 

--- a/intelmq/tests/bots/experts/cymru_whois/test_expert.py
+++ b/intelmq/tests/bots/experts/cymru_whois/test_expert.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2015 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 import json
 import unittest

--- a/intelmq/tests/bots/experts/deduplicator/test_expert.py
+++ b/intelmq/tests/bots/experts/deduplicator/test_expert.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2015 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import unittest

--- a/intelmq/tests/bots/experts/do_portal/test_expert.py
+++ b/intelmq/tests/bots/experts/do_portal/test_expert.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2019 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """
 TODO: Test on wrong credentials

--- a/intelmq/tests/bots/experts/domain_suffix/public_suffix_list.dat.license
+++ b/intelmq/tests/bots/experts/domain_suffix/public_suffix_list.dat.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2018 Sebastian Wagner
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/experts/domain_suffix/test_expert.py
+++ b/intelmq/tests/bots/experts/domain_suffix/test_expert.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2018 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 import os.path
 import unittest

--- a/intelmq/tests/bots/experts/field_reducer/test_expert.py
+++ b/intelmq/tests/bots/experts/field_reducer/test_expert.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2017 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import unittest

--- a/intelmq/tests/bots/experts/filter/test_expert_absolute_after.py
+++ b/intelmq/tests/bots/experts/filter/test_expert_absolute_after.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2015 robcza
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import unittest

--- a/intelmq/tests/bots/experts/filter/test_expert_absolute_before.py
+++ b/intelmq/tests/bots/experts/filter/test_expert_absolute_before.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2015 robcza
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import unittest

--- a/intelmq/tests/bots/experts/filter/test_expert_regex_search.py
+++ b/intelmq/tests/bots/experts/filter/test_expert_regex_search.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2016 Dustin Demuth
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import unittest

--- a/intelmq/tests/bots/experts/filter/test_expert_relative_after.py
+++ b/intelmq/tests/bots/experts/filter/test_expert_relative_after.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2015 robcza
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import unittest

--- a/intelmq/tests/bots/experts/filter/test_expert_relative_before.py
+++ b/intelmq/tests/bots/experts/filter/test_expert_relative_before.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2015 robcza
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import unittest

--- a/intelmq/tests/bots/experts/filter/test_extra.py
+++ b/intelmq/tests/bots/experts/filter/test_extra.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2017 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import unittest

--- a/intelmq/tests/bots/experts/filter/test_paths.py
+++ b/intelmq/tests/bots/experts/filter/test_paths.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2019 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import unittest

--- a/intelmq/tests/bots/experts/filter/test_report.py
+++ b/intelmq/tests/bots/experts/filter/test_report.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2019 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import unittest

--- a/intelmq/tests/bots/experts/format_field/test_expert.py
+++ b/intelmq/tests/bots/experts/format_field/test_expert.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2019 Brajneesh kumar
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import unittest

--- a/intelmq/tests/bots/experts/generic_db_lookup/test_expert.py
+++ b/intelmq/tests/bots/experts/generic_db_lookup/test_expert.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2016 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 import os
 import unittest

--- a/intelmq/tests/bots/experts/geohash/test_expert.py
+++ b/intelmq/tests/bots/experts/geohash/test_expert.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2019 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 import unittest
 

--- a/intelmq/tests/bots/experts/gethostbyname/test_expert.py
+++ b/intelmq/tests/bots/experts/gethostbyname/test_expert.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2016 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """
 Testing GethostbynameExpertBot.

--- a/intelmq/tests/bots/experts/http/test_expert_content.py
+++ b/intelmq/tests/bots/experts/http/test_expert_content.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2021 Birger Schacht
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """
 Testing HTTP Status expert

--- a/intelmq/tests/bots/experts/http/test_expert_status.py
+++ b/intelmq/tests/bots/experts/http/test_expert_status.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2021 Birger Schacht
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """
 Testing HTTP Status expert

--- a/intelmq/tests/bots/experts/idea/test_expert.py
+++ b/intelmq/tests/bots/experts/idea/test_expert.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2017 Pavel Kácha
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 import unittest
 import json

--- a/intelmq/tests/bots/experts/lookyloo/test_expert.py
+++ b/intelmq/tests/bots/experts/lookyloo/test_expert.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2021 Sebastian Waldbauer
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 import os
 import unittest

--- a/intelmq/tests/bots/experts/maxmind_geoip/test_expert.py
+++ b/intelmq/tests/bots/experts/maxmind_geoip/test_expert.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2016 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 import os
 

--- a/intelmq/tests/bots/experts/mcafee/test_expert_mar.py
+++ b/intelmq/tests/bots/experts/mcafee/test_expert_mar.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2018 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 import os
 
 if os.environ.get('INTELMQ_TEST_EXOTIC'):

--- a/intelmq/tests/bots/experts/misp/test_expert.py
+++ b/intelmq/tests/bots/experts/misp/test_expert.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2019 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 from intelmq.bots.experts.misp.expert import MISPExpertBot
 from intelmq.lib.test import BotTestCase

--- a/intelmq/tests/bots/experts/modify/new_format.conf.license
+++ b/intelmq/tests/bots/experts/modify/new_format.conf.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2016 Sebastian Wagner
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/experts/modify/old_format.conf.license
+++ b/intelmq/tests/bots/experts/modify/old_format.conf.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2016 Sebastian Wagner
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/experts/modify/overwrite.conf.license
+++ b/intelmq/tests/bots/experts/modify/overwrite.conf.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2019 Sebastian Wagner
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/experts/modify/test_expert.py
+++ b/intelmq/tests/bots/experts/modify/test_expert.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2015 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """
 Testing modify expert bot.

--- a/intelmq/tests/bots/experts/modify/types.conf.license
+++ b/intelmq/tests/bots/experts/modify/types.conf.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2019 Sebastian Wagner
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/experts/national_cert_contact_certat/test_expert.py
+++ b/intelmq/tests/bots/experts/national_cert_contact_certat/test_expert.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2017 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """
 Testing certat_contact

--- a/intelmq/tests/bots/experts/rdap/test_data/example.com.json.license
+++ b/intelmq/tests/bots/experts/rdap/test_data/example.com.json.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2021 Sebastian Waldbauer <waldbauer@cert.at>
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/experts/rdap/test_data/nic.versicherung.json.license
+++ b/intelmq/tests/bots/experts/rdap/test_data/nic.versicherung.json.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2021 Sebastian Waldbauer <waldbauer@cert.at>
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/experts/rdap/test_data/rdns.json.license
+++ b/intelmq/tests/bots/experts/rdap/test_data/rdns.json.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2021 Sebastian Waldbauer
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/experts/rdap/test_expert.py
+++ b/intelmq/tests/bots/experts/rdap/test_expert.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2021 Sebastian Waldbauer
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """
 Testing rdap expert.

--- a/intelmq/tests/bots/experts/recordedfuture_iprisk/iprisk.dat.license
+++ b/intelmq/tests/bots/experts/recordedfuture_iprisk/iprisk.dat.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2018 olekristoffer
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/experts/recordedfuture_iprisk/test_expert.py
+++ b/intelmq/tests/bots/experts/recordedfuture_iprisk/test_expert.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2018 olekristoffer
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """
 Testing RF Risk node lookup

--- a/intelmq/tests/bots/experts/reverse_dns/test_expert.py
+++ b/intelmq/tests/bots/experts/reverse_dns/test_expert.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2015 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import unittest

--- a/intelmq/tests/bots/experts/rfc1918/test_expert.py
+++ b/intelmq/tests/bots/experts/rfc1918/test_expert.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2015 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """
 Testing rfc 1918 expert bot.

--- a/intelmq/tests/bots/experts/ripe/test_expert.py
+++ b/intelmq/tests/bots/experts/ripe/test_expert.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2018 Brajneesh Kumar
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """
 Testing RIPE Expert

--- a/intelmq/tests/bots/experts/sieve/test_expert.py
+++ b/intelmq/tests/bots/experts/sieve/test_expert.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2017 Antoine Neuenschwander
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 

--- a/intelmq/tests/bots/experts/sieve/test_sieve_files/test_add.sieve.license
+++ b/intelmq/tests/bots/experts/sieve/test_sieve_files/test_add.sieve.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2017 Kevin Holvoet
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/experts/sieve/test_sieve_files/test_add_force.sieve.license
+++ b/intelmq/tests/bots/experts/sieve/test_sieve_files/test_add_force.sieve.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2017 Kevin Holvoet
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/experts/sieve/test_sieve_files/test_and_match.sieve.license
+++ b/intelmq/tests/bots/experts/sieve/test_sieve_files/test_and_match.sieve.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2017 Kevin Holvoet
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/experts/sieve/test_sieve_files/test_append.sieve.license
+++ b/intelmq/tests/bots/experts/sieve/test_sieve_files/test_append.sieve.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2021 Mikk Margus Möll
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/experts/sieve/test_sieve_files/test_basic_math.sieve.license
+++ b/intelmq/tests/bots/experts/sieve/test_sieve_files/test_basic_math.sieve.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2020 Sebastian Waldbauer
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/experts/sieve/test_sieve_files/test_bool_match.sieve.license
+++ b/intelmq/tests/bots/experts/sieve/test_sieve_files/test_bool_match.sieve.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2021 Mikk Margus Möll
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/experts/sieve/test_sieve_files/test_comments.sieve.license
+++ b/intelmq/tests/bots/experts/sieve/test_sieve_files/test_comments.sieve.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2017 Antoine Neuenschwander
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/experts/sieve/test_sieve_files/test_drop_event.sieve.license
+++ b/intelmq/tests/bots/experts/sieve/test_sieve_files/test_drop_event.sieve.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2017 Kevin Holvoet
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/experts/sieve/test_sieve_files/test_exists_match.sieve.license
+++ b/intelmq/tests/bots/experts/sieve/test_sieve_files/test_exists_match.sieve.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2017 Kevin Holvoet
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/experts/sieve/test_sieve_files/test_force_append.sieve.license
+++ b/intelmq/tests/bots/experts/sieve/test_sieve_files/test_force_append.sieve.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2021 Mikk Margus Möll
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/experts/sieve/test_sieve_files/test_if_clause.sieve.license
+++ b/intelmq/tests/bots/experts/sieve/test_sieve_files/test_if_clause.sieve.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2017 Antoine Neuenschwander
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/experts/sieve/test_sieve_files/test_if_elif_clause.sieve.license
+++ b/intelmq/tests/bots/experts/sieve/test_sieve_files/test_if_elif_clause.sieve.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2017 Antoine Neuenschwander
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/experts/sieve/test_sieve_files/test_if_elif_else_clause.sieve.license
+++ b/intelmq/tests/bots/experts/sieve/test_sieve_files/test_if_elif_else_clause.sieve.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2017 Antoine Neuenschwander
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/experts/sieve/test_sieve_files/test_if_else_clause.sieve.license
+++ b/intelmq/tests/bots/experts/sieve/test_sieve_files/test_if_else_clause.sieve.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2017 Antoine Neuenschwander
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/experts/sieve/test_sieve_files/test_ip_range_list_match.sieve.license
+++ b/intelmq/tests/bots/experts/sieve/test_sieve_files/test_ip_range_list_match.sieve.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2017 Antoine Neuenschwander
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/experts/sieve/test_sieve_files/test_ip_range_match.sieve.license
+++ b/intelmq/tests/bots/experts/sieve/test_sieve_files/test_ip_range_match.sieve.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2017 Antoine Neuenschwander
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/experts/sieve/test_sieve_files/test_keep_event.sieve.license
+++ b/intelmq/tests/bots/experts/sieve/test_sieve_files/test_keep_event.sieve.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2017 Kevin Holvoet
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/experts/sieve/test_sieve_files/test_list_equals_match.sieve.license
+++ b/intelmq/tests/bots/experts/sieve/test_sieve_files/test_list_equals_match.sieve.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2021 Mikk Margus Möll
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/experts/sieve/test_sieve_files/test_list_overlaps_match.sieve.license
+++ b/intelmq/tests/bots/experts/sieve/test_sieve_files/test_list_overlaps_match.sieve.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2021 Mikk Margus Möll
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/experts/sieve/test_sieve_files/test_list_setequals_match.sieve.license
+++ b/intelmq/tests/bots/experts/sieve/test_sieve_files/test_list_setequals_match.sieve.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2021 Mikk Margus Möll
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/experts/sieve/test_sieve_files/test_list_subsetof_match.sieve.license
+++ b/intelmq/tests/bots/experts/sieve/test_sieve_files/test_list_subsetof_match.sieve.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2021 Mikk Margus Möll
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/experts/sieve/test_sieve_files/test_list_supersetof_match.sieve.license
+++ b/intelmq/tests/bots/experts/sieve/test_sieve_files/test_list_supersetof_match.sieve.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2021 Mikk Margus Möll
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/experts/sieve/test_sieve_files/test_mixed_if.sieve.license
+++ b/intelmq/tests/bots/experts/sieve/test_sieve_files/test_mixed_if.sieve.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2017 Chris Horsley
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/experts/sieve/test_sieve_files/test_multiple_actions.sieve.license
+++ b/intelmq/tests/bots/experts/sieve/test_sieve_files/test_multiple_actions.sieve.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2017 Kevin Holvoet
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/experts/sieve/test_sieve_files/test_named_queues.sieve.license
+++ b/intelmq/tests/bots/experts/sieve/test_sieve_files/test_named_queues.sieve.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2018 Edvard Rejthar
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/experts/sieve/test_sieve_files/test_named_queues_multi.sieve.license
+++ b/intelmq/tests/bots/experts/sieve/test_sieve_files/test_named_queues_multi.sieve.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2019 Sebastian Wagner
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/experts/sieve/test_sieve_files/test_negation.sieve.license
+++ b/intelmq/tests/bots/experts/sieve/test_sieve_files/test_negation.sieve.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2021 Mikk Margus Möll
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/experts/sieve/test_sieve_files/test_nested_if.sieve.license
+++ b/intelmq/tests/bots/experts/sieve/test_sieve_files/test_nested_if.sieve.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2021 Mikk Margus Möll
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/experts/sieve/test_sieve_files/test_network_host_bits_list_match.sieve.license
+++ b/intelmq/tests/bots/experts/sieve/test_sieve_files/test_network_host_bits_list_match.sieve.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2018 Edvard Rejthar
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/experts/sieve/test_sieve_files/test_notexists_match.sieve.license
+++ b/intelmq/tests/bots/experts/sieve/test_sieve_files/test_notexists_match.sieve.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2017 Kevin Holvoet
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/experts/sieve/test_sieve_files/test_numeric_equal_match.sieve.license
+++ b/intelmq/tests/bots/experts/sieve/test_sieve_files/test_numeric_equal_match.sieve.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2017 Kevin Holvoet
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/experts/sieve/test_sieve_files/test_numeric_greater_than_match.sieve.license
+++ b/intelmq/tests/bots/experts/sieve/test_sieve_files/test_numeric_greater_than_match.sieve.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2017 Kevin Holvoet
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/experts/sieve/test_sieve_files/test_numeric_greater_than_or_equal_match.sieve.license
+++ b/intelmq/tests/bots/experts/sieve/test_sieve_files/test_numeric_greater_than_or_equal_match.sieve.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2017 Kevin Holvoet
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/experts/sieve/test_sieve_files/test_numeric_invalid_key.sieve.license
+++ b/intelmq/tests/bots/experts/sieve/test_sieve_files/test_numeric_invalid_key.sieve.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2017 Antoine Neuenschwander
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/experts/sieve/test_sieve_files/test_numeric_key.sieve.license
+++ b/intelmq/tests/bots/experts/sieve/test_sieve_files/test_numeric_key.sieve.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2019 Sebastian Wagner
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/experts/sieve/test_sieve_files/test_numeric_less_than_match.sieve.license
+++ b/intelmq/tests/bots/experts/sieve/test_sieve_files/test_numeric_less_than_match.sieve.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2017 Kevin Holvoet
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/experts/sieve/test_sieve_files/test_numeric_less_than_or_equal_match.sieve.license
+++ b/intelmq/tests/bots/experts/sieve/test_sieve_files/test_numeric_less_than_or_equal_match.sieve.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2017 Kevin Holvoet
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/experts/sieve/test_sieve_files/test_numeric_match_value_list.sieve.license
+++ b/intelmq/tests/bots/experts/sieve/test_sieve_files/test_numeric_match_value_list.sieve.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2017 Helder
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/experts/sieve/test_sieve_files/test_numeric_not_equal_match.sieve.license
+++ b/intelmq/tests/bots/experts/sieve/test_sieve_files/test_numeric_not_equal_match.sieve.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2017 Kevin Holvoet
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/experts/sieve/test_sieve_files/test_only_multiple_actions.sieve.license
+++ b/intelmq/tests/bots/experts/sieve/test_sieve_files/test_only_multiple_actions.sieve.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2021 Sebastian Waldbauer
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/experts/sieve/test_sieve_files/test_only_one_action.sieve.license
+++ b/intelmq/tests/bots/experts/sieve/test_sieve_files/test_only_one_action.sieve.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2021 Sebastian Waldbauer
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/experts/sieve/test_sieve_files/test_or_match.sieve.license
+++ b/intelmq/tests/bots/experts/sieve/test_sieve_files/test_or_match.sieve.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2017 Kevin Holvoet
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/experts/sieve/test_sieve_files/test_parentheses.sieve.license
+++ b/intelmq/tests/bots/experts/sieve/test_sieve_files/test_parentheses.sieve.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2020 Birger Schacht
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/experts/sieve/test_sieve_files/test_precedence.sieve.license
+++ b/intelmq/tests/bots/experts/sieve/test_sieve_files/test_precedence.sieve.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2017 Antoine Neuenschwander
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/experts/sieve/test_sieve_files/test_remove.sieve.license
+++ b/intelmq/tests/bots/experts/sieve/test_sieve_files/test_remove.sieve.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2017 Kevin Holvoet
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/experts/sieve/test_sieve_files/test_string_contains_match.sieve.license
+++ b/intelmq/tests/bots/experts/sieve/test_sieve_files/test_string_contains_match.sieve.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2017 Antoine Neuenschwander
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/experts/sieve/test_sieve_files/test_string_equal_match.sieve.license
+++ b/intelmq/tests/bots/experts/sieve/test_sieve_files/test_string_equal_match.sieve.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2017 Antoine Neuenschwander
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/experts/sieve/test_sieve_files/test_string_invalid_ipaddr.sieve.license
+++ b/intelmq/tests/bots/experts/sieve/test_sieve_files/test_string_invalid_ipaddr.sieve.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2017 Antoine Neuenschwander
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/experts/sieve/test_sieve_files/test_string_inverse_regex_match.sieve.license
+++ b/intelmq/tests/bots/experts/sieve/test_sieve_files/test_string_inverse_regex_match.sieve.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2017 Antoine Neuenschwander
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/experts/sieve/test_sieve_files/test_string_match_value_list.sieve.license
+++ b/intelmq/tests/bots/experts/sieve/test_sieve_files/test_string_match_value_list.sieve.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2017 Helder
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/experts/sieve/test_sieve_files/test_string_not_equal_match.sieve.license
+++ b/intelmq/tests/bots/experts/sieve/test_sieve_files/test_string_not_equal_match.sieve.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2017 Antoine Neuenschwander
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/experts/sieve/test_sieve_files/test_string_regex_match.sieve.license
+++ b/intelmq/tests/bots/experts/sieve/test_sieve_files/test_string_regex_match.sieve.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2017 Antoine Neuenschwander
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/experts/sieve/test_sieve_files/test_typed_values.sieve.license
+++ b/intelmq/tests/bots/experts/sieve/test_sieve_files/test_typed_values.sieve.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2021 Mikk Margus Möll
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/experts/sieve/test_sieve_files/test_update.sieve.license
+++ b/intelmq/tests/bots/experts/sieve/test_sieve_files/test_update.sieve.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2017 Antoine Neuenschwander
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/experts/taxonomy/test_expert.py
+++ b/intelmq/tests/bots/experts/taxonomy/test_expert.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2015 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import unittest

--- a/intelmq/tests/bots/experts/threshold/test_expert.py
+++ b/intelmq/tests/bots/experts/threshold/test_expert.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 Karl-Johan Karlsson
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import unittest

--- a/intelmq/tests/bots/experts/tor_nodes/test_expert.py
+++ b/intelmq/tests/bots/experts/tor_nodes/test_expert.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2015 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """
 Testing tor node lookup

--- a/intelmq/tests/bots/experts/tor_nodes/tor_nodes.dat.license
+++ b/intelmq/tests/bots/experts/tor_nodes/tor_nodes.dat.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2016 Sebastian Wagner
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/experts/url2fqdn/test_expert.py
+++ b/intelmq/tests/bots/experts/url2fqdn/test_expert.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2015 robcza
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """
 Testing url2fqdn.

--- a/intelmq/tests/bots/experts/uwhoisd/test_expert.py
+++ b/intelmq/tests/bots/experts/uwhoisd/test_expert.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2021 Raphaël Vinot
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 import os
 import unittest

--- a/intelmq/tests/bots/experts/wait/test_expert.py
+++ b/intelmq/tests/bots/experts/wait/test_expert.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2018 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import unittest

--- a/intelmq/tests/bots/outputs/amqptopic/test_output.py
+++ b/intelmq/tests/bots/outputs/amqptopic/test_output.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2016 pedromreis
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 import json
 import os

--- a/intelmq/tests/bots/outputs/blackhole/test_output.py
+++ b/intelmq/tests/bots/outputs/blackhole/test_output.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2018 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 import unittest
 

--- a/intelmq/tests/bots/outputs/elasticsearch/test_output.py
+++ b/intelmq/tests/bots/outputs/elasticsearch/test_output.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2017 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 import os
 import unittest

--- a/intelmq/tests/bots/outputs/file/test_output.py
+++ b/intelmq/tests/bots/outputs/file/test_output.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2016 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 import os
 import tempfile

--- a/intelmq/tests/bots/outputs/files/test_output.py
+++ b/intelmq/tests/bots/outputs/files/test_output.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2017 Pavel Kácha
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 import os
 import tempfile

--- a/intelmq/tests/bots/outputs/mcafee/test_output.py
+++ b/intelmq/tests/bots/outputs/mcafee/test_output.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2018 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 import os
 
 if os.environ.get('INTELMQ_TEST_EXOTIC'):

--- a/intelmq/tests/bots/outputs/misp/test_output_api.py
+++ b/intelmq/tests/bots/outputs/misp/test_output_api.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 Bernhard Reiter
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 import os
 #  import unittest
 

--- a/intelmq/tests/bots/outputs/misp/test_output_feed.py
+++ b/intelmq/tests/bots/outputs/misp/test_output_feed.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2019 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 import unittest
 import sys

--- a/intelmq/tests/bots/outputs/mongodb/test_output.py
+++ b/intelmq/tests/bots/outputs/mongodb/test_output.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2016 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 import os
 import unittest

--- a/intelmq/tests/bots/outputs/redis/test_output.py
+++ b/intelmq/tests/bots/outputs/redis/test_output.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2016 pedromreis
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import json

--- a/intelmq/tests/bots/outputs/redis/test_output_as_hierarchical_json.py
+++ b/intelmq/tests/bots/outputs/redis/test_output_as_hierarchical_json.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2019 KRYSTOF
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import json

--- a/intelmq/tests/bots/outputs/restapi/test_output.py
+++ b/intelmq/tests/bots/outputs/restapi/test_output.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2016 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 import json
 import unittest

--- a/intelmq/tests/bots/outputs/rt/test_output.py
+++ b/intelmq/tests/bots/outputs/rt/test_output.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 """
 Test for the RT Output Bot
 """

--- a/intelmq/tests/bots/outputs/smtp/test_output.py
+++ b/intelmq/tests/bots/outputs/smtp/test_output.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2017 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 import unittest
 

--- a/intelmq/tests/bots/outputs/sql/test_output_postgresql.py
+++ b/intelmq/tests/bots/outputs/sql/test_output_postgresql.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2019 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 import os
 import unittest

--- a/intelmq/tests/bots/outputs/stomp/test_output.py
+++ b/intelmq/tests/bots/outputs/stomp/test_output.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2016 aaronkaplan
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 import os
 

--- a/intelmq/tests/bots/outputs/tcp/test_output.py
+++ b/intelmq/tests/bots/outputs/tcp/test_output.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2016 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 """

--- a/intelmq/tests/bots/outputs/touch/test_output.py
+++ b/intelmq/tests/bots/outputs/touch/test_output.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2019 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 import os
 import unittest

--- a/intelmq/tests/bots/outputs/udp/test_output.py
+++ b/intelmq/tests/bots/outputs/udp/test_output.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2016 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import intelmq.bots.outputs.udp.output

--- a/intelmq/tests/bots/parsers/abusech/feodoips.txt.license
+++ b/intelmq/tests/bots/parsers/abusech/feodoips.txt.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2016 Sebastian Wagner
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/abusech/test_parser_ip.py
+++ b/intelmq/tests/bots/parsers/abusech/test_parser_ip.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2015 robcza
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import os

--- a/intelmq/tests/bots/parsers/alienvault/test_parser.py
+++ b/intelmq/tests/bots/parsers/alienvault/test_parser.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2015 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import unittest

--- a/intelmq/tests/bots/parsers/alienvault/test_parser_otx.data.license
+++ b/intelmq/tests/bots/parsers/alienvault/test_parser_otx.data.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2015 robcza
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/alienvault/test_parser_otx.py
+++ b/intelmq/tests/bots/parsers/alienvault/test_parser_otx.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2015 robcza
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import os

--- a/intelmq/tests/bots/parsers/anubisnetworks/example_comm_http_host_not_dst_ip.json.license
+++ b/intelmq/tests/bots/parsers/anubisnetworks/example_comm_http_host_not_dst_ip.json.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2020 Sebastian Wagner
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/anubisnetworks/example_report.json.license
+++ b/intelmq/tests/bots/parsers/anubisnetworks/example_report.json.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2020 Sebastian Wagner
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/anubisnetworks/example_report2.json.license
+++ b/intelmq/tests/bots/parsers/anubisnetworks/example_report2.json.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2020 Sebastian Wagner
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/anubisnetworks/example_report3.json.license
+++ b/intelmq/tests/bots/parsers/anubisnetworks/example_report3.json.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2020 Sebastian Wagner
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/anubisnetworks/example_report_dns.json.license
+++ b/intelmq/tests/bots/parsers/anubisnetworks/example_report_dns.json.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2020 Sebastian Wagner
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/anubisnetworks/example_report_ignore.json.license
+++ b/intelmq/tests/bots/parsers/anubisnetworks/example_report_ignore.json.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2020 Sebastian Wagner
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/anubisnetworks/test_parser.py
+++ b/intelmq/tests/bots/parsers/anubisnetworks/test_parser.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2017 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 import os.path
 import unittest

--- a/intelmq/tests/bots/parsers/autoshun/shunlist.html
+++ b/intelmq/tests/bots/parsers/autoshun/shunlist.html
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2016 Sebastian Wagner
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
 <html><head>
 <meta http-equiv="content-type" content="text/html; charset=windows-1252"></head><body><table border="1">
 <tbody><tr>

--- a/intelmq/tests/bots/parsers/autoshun/test_parser.py
+++ b/intelmq/tests/bots/parsers/autoshun/test_parser.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2015 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 import os
 import unittest

--- a/intelmq/tests/bots/parsers/bambenek/c2-dommasterlist.txt.license
+++ b/intelmq/tests/bots/parsers/bambenek/c2-dommasterlist.txt.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2016 jgedeon120
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/bambenek/c2-ipmasterlist.txt.license
+++ b/intelmq/tests/bots/parsers/bambenek/c2-ipmasterlist.txt.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2016 jgedeon120
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/bambenek/dga-feed.txt.license
+++ b/intelmq/tests/bots/parsers/bambenek/dga-feed.txt.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2016 jgedeon120
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/bambenek/test_parser.py
+++ b/intelmq/tests/bots/parsers/bambenek/test_parser.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2016 jgedeon120
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import os

--- a/intelmq/tests/bots/parsers/blocklistde/imap.txt.license
+++ b/intelmq/tests/bots/parsers/blocklistde/imap.txt.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2015 Sebastian Wagner
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/blocklistde/test_parser.py
+++ b/intelmq/tests/bots/parsers/blocklistde/test_parser.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2015 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import os

--- a/intelmq/tests/bots/parsers/blueliv/test_parser_crimeserver.data.license
+++ b/intelmq/tests/bots/parsers/blueliv/test_parser_crimeserver.data.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2015 robcza
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/blueliv/test_parser_crimeserver.py
+++ b/intelmq/tests/bots/parsers/blueliv/test_parser_crimeserver.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2015 robcza
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import os

--- a/intelmq/tests/bots/parsers/calidog/data.json.license
+++ b/intelmq/tests/bots/parsers/calidog/data.json.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2018 Sebastian Wagner
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/calidog/test_parser.py
+++ b/intelmq/tests/bots/parsers/calidog/test_parser.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2018 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 import os.path
 import unittest

--- a/intelmq/tests/bots/parsers/cert_eu/example.csv.license
+++ b/intelmq/tests/bots/parsers/cert_eu/example.csv.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2018 Pierre Dumont
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/cert_eu/test_parser_csv.py
+++ b/intelmq/tests/bots/parsers/cert_eu/test_parser_csv.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2018 Pierre Dumont
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import os

--- a/intelmq/tests/bots/parsers/ci_army/test_parser.py
+++ b/intelmq/tests/bots/parsers/ci_army/test_parser.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2015 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import unittest

--- a/intelmq/tests/bots/parsers/cleanmx/test_parser.py
+++ b/intelmq/tests/bots/parsers/cleanmx/test_parser.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2016 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 import os
 import unittest

--- a/intelmq/tests/bots/parsers/cleanmx/xmlphishing.license
+++ b/intelmq/tests/bots/parsers/cleanmx/xmlphishing.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2016 Sebastian Wagner
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/cleanmx/xmlviruses.license
+++ b/intelmq/tests/bots/parsers/cleanmx/xmlviruses.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2016 Sebastian Wagner
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/cymru/certname_20190327.txt.license
+++ b/intelmq/tests/bots/parsers/cymru/certname_20190327.txt.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2019 Sebastian Wagner
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/cymru/infected_20171031.txt.license
+++ b/intelmq/tests/bots/parsers/cymru/infected_20171031.txt.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2017 Sebastian Wagner
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/cymru/test_cap_program.py
+++ b/intelmq/tests/bots/parsers/cymru/test_cap_program.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2017 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 import os.path
 import unittest

--- a/intelmq/tests/bots/parsers/cymru/test_cap_program_new.py
+++ b/intelmq/tests/bots/parsers/cymru/test_cap_program_new.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2019 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 import os.path
 import unittest

--- a/intelmq/tests/bots/parsers/cymru/test_full_bogons.py
+++ b/intelmq/tests/bots/parsers/cymru/test_full_bogons.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2017 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import unittest

--- a/intelmq/tests/bots/parsers/cznic/example_proki.json.license
+++ b/intelmq/tests/bots/parsers/cznic/example_proki.json.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2020 sinus-x
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/cznic/test_parser_haas.py
+++ b/intelmq/tests/bots/parsers/cznic/test_parser_haas.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 gethvi
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 import unittest
 import sys
 

--- a/intelmq/tests/bots/parsers/cznic/test_parser_proki.py
+++ b/intelmq/tests/bots/parsers/cznic/test_parser_proki.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 sinus-x
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 import os
 import json
 

--- a/intelmq/tests/bots/parsers/danger_rulez/test_parser.py
+++ b/intelmq/tests/bots/parsers/danger_rulez/test_parser.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2015 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import unittest

--- a/intelmq/tests/bots/parsers/dataplane/sipinvitation.txt.license
+++ b/intelmq/tests/bots/parsers/dataplane/sipinvitation.txt.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2016 jgedeon120
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/dataplane/sipquery.txt.license
+++ b/intelmq/tests/bots/parsers/dataplane/sipquery.txt.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2016 jgedeon120
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/dataplane/sipregistration.txt.license
+++ b/intelmq/tests/bots/parsers/dataplane/sipregistration.txt.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2016 jgedeon120
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/dataplane/sshclient.txt.license
+++ b/intelmq/tests/bots/parsers/dataplane/sshclient.txt.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2016 jgedeon120
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/dataplane/sshpwauth.txt.license
+++ b/intelmq/tests/bots/parsers/dataplane/sshpwauth.txt.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2016 jgedeon120
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/dataplane/test_parser.py
+++ b/intelmq/tests/bots/parsers/dataplane/test_parser.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2016 jgedeon120
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import os

--- a/intelmq/tests/bots/parsers/dshield/asdetailsascii.html
+++ b/intelmq/tests/bots/parsers/dshield/asdetailsascii.html
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2015 Sebastian Wagner
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
 # asdetailsascii.html
 # created: Tue, 22 Dec 2015 12:19:03 +0000#
 # Source IP is 0 padded so each byte is three digits long

--- a/intelmq/tests/bots/parsers/dshield/block.txt.license
+++ b/intelmq/tests/bots/parsers/dshield/block.txt.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2015 Sebastian Wagner
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/dshield/suspiciousdomains_High.txt.license
+++ b/intelmq/tests/bots/parsers/dshield/suspiciousdomains_High.txt.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2015 Sebastian Wagner
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/dshield/test_parser_asn.py
+++ b/intelmq/tests/bots/parsers/dshield/test_parser_asn.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2015 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import os

--- a/intelmq/tests/bots/parsers/dshield/test_parser_block.py
+++ b/intelmq/tests/bots/parsers/dshield/test_parser_block.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2015 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import os

--- a/intelmq/tests/bots/parsers/dshield/test_parser_domain.py
+++ b/intelmq/tests/bots/parsers/dshield/test_parser_domain.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2015 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import os

--- a/intelmq/tests/bots/parsers/dyn/ponmocup-infected-domains-CIF-latest.txt.license
+++ b/intelmq/tests/bots/parsers/dyn/ponmocup-infected-domains-CIF-latest.txt.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2016 Sebastian Wagner
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/dyn/test_parser.py
+++ b/intelmq/tests/bots/parsers/dyn/test_parser.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2015 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import os

--- a/intelmq/tests/bots/parsers/eset/test_parser.py
+++ b/intelmq/tests/bots/parsers/eset/test_parser.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import json

--- a/intelmq/tests/bots/parsers/fireeye/event.txt.license
+++ b/intelmq/tests/bots/parsers/fireeye/event.txt.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2021 CysihZ
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/fireeye/test_parser_fireeye.py
+++ b/intelmq/tests/bots/parsers/fireeye/test_parser_fireeye.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2021 CysihZ
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 import os
 import unittest

--- a/intelmq/tests/bots/parsers/fraunhofer/ddosattack_tests_common.py
+++ b/intelmq/tests/bots/parsers/fraunhofer/ddosattack_tests_common.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2019 Sascha Alexander Jopen
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 import json
 

--- a/intelmq/tests/bots/parsers/fraunhofer/test_parser_dga.py
+++ b/intelmq/tests/bots/parsers/fraunhofer/test_parser_dga.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2015 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import unittest

--- a/intelmq/tests/bots/parsers/generic/compose_fields.csv.license
+++ b/intelmq/tests/bots/parsers/generic/compose_fields.csv.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2020 Sebastian Wagner
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/generic/data_type.csv.license
+++ b/intelmq/tests/bots/parsers/generic/data_type.csv.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2017 navtej
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/generic/empty_src_url.csv.license
+++ b/intelmq/tests/bots/parsers/generic/empty_src_url.csv.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2017 navtej
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/generic/extra_regex.csv.license
+++ b/intelmq/tests/bots/parsers/generic/extra_regex.csv.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2017 Sebastian Wagner
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/generic/invalid_sample_report.csv.license
+++ b/intelmq/tests/bots/parsers/generic/invalid_sample_report.csv.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2018 Sebastian Wagner
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/generic/multivalue_columns.csv.license
+++ b/intelmq/tests/bots/parsers/generic/multivalue_columns.csv.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2017 navtej
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/generic/sample_report.csv.license
+++ b/intelmq/tests/bots/parsers/generic/sample_report.csv.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2016 Sebastian Wagner
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/generic/test_filter_blacklist.csv.license
+++ b/intelmq/tests/bots/parsers/generic/test_filter_blacklist.csv.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2017 Sebastian Wagner
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/generic/test_filter_blacklist.py
+++ b/intelmq/tests/bots/parsers/generic/test_filter_blacklist.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2017 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import unittest

--- a/intelmq/tests/bots/parsers/generic/test_filter_whitelist.py
+++ b/intelmq/tests/bots/parsers/generic/test_filter_whitelist.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2017 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import unittest

--- a/intelmq/tests/bots/parsers/generic/test_filter_whitelist_ipset.csv.license
+++ b/intelmq/tests/bots/parsers/generic/test_filter_whitelist_ipset.csv.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2017 Sebastian Wagner
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/generic/test_parser_csv.py
+++ b/intelmq/tests/bots/parsers/generic/test_parser_csv.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2016 robcza
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 import os
 import unittest

--- a/intelmq/tests/bots/parsers/generic/test_parser_csv2.py
+++ b/intelmq/tests/bots/parsers/generic/test_parser_csv2.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2016 robcza
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import unittest

--- a/intelmq/tests/bots/parsers/generic/test_parser_csv4.py
+++ b/intelmq/tests/bots/parsers/generic/test_parser_csv4.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2017 navtej
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import unittest

--- a/intelmq/tests/bots/parsers/generic/test_parser_csv_data_type.py
+++ b/intelmq/tests/bots/parsers/generic/test_parser_csv_data_type.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2017 navtej
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import unittest

--- a/intelmq/tests/bots/parsers/generic/test_parser_csv_extra_regex.py
+++ b/intelmq/tests/bots/parsers/generic/test_parser_csv_extra_regex.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2017 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import unittest

--- a/intelmq/tests/bots/parsers/generic/test_parser_csv_invalid_values.py
+++ b/intelmq/tests/bots/parsers/generic/test_parser_csv_invalid_values.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2018 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 import os
 import unittest

--- a/intelmq/tests/bots/parsers/generic/test_parser_multivalue_cols.py
+++ b/intelmq/tests/bots/parsers/generic/test_parser_multivalue_cols.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2017 navtej
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import unittest

--- a/intelmq/tests/bots/parsers/github_feed/example_ioc_strangereal_intel.json.license
+++ b/intelmq/tests/bots/parsers/github_feed/example_ioc_strangereal_intel.json.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2020 Sebastian Wagner
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/github_feed/test_parser.py
+++ b/intelmq/tests/bots/parsers/github_feed/test_parser.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2019 Tomas Bellus
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 import json
 import os
 import unittest

--- a/intelmq/tests/bots/parsers/hibp/breach_callbacktest.json.license
+++ b/intelmq/tests/bots/parsers/hibp/breach_callbacktest.json.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2019 Sebastian Wagner
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/hibp/breach_real.json.license
+++ b/intelmq/tests/bots/parsers/hibp/breach_real.json.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2019 Sebastian Wagner
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/hibp/paste_callbacktest.json.license
+++ b/intelmq/tests/bots/parsers/hibp/paste_callbacktest.json.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2019 Sebastian Wagner
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/hibp/test_parser_callback.py
+++ b/intelmq/tests/bots/parsers/hibp/test_parser_callback.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2019 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """
 Data is from the HIBP Documentation

--- a/intelmq/tests/bots/parsers/html_table/feodotracker.html.license
+++ b/intelmq/tests/bots/parsers/html_table/feodotracker.html.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2021 Sebastian Wagner
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/html_table/html_table.data.license
+++ b/intelmq/tests/bots/parsers/html_table/html_table.data.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2019 Brajneesh Kumar
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/html_table/html_table_column_split.data.license
+++ b/intelmq/tests/bots/parsers/html_table/html_table_column_split.data.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2019 Brajneesh Kumar
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/html_table/html_table_ignore_values.data.license
+++ b/intelmq/tests/bots/parsers/html_table/html_table_ignore_values.data.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2019 Brajneesh Kumar
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/html_table/html_table_multivalue_cols.data.license
+++ b/intelmq/tests/bots/parsers/html_table/html_table_multivalue_cols.data.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2019 Brajneesh Kumar
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/html_table/html_table_with_attribute.data.license
+++ b/intelmq/tests/bots/parsers/html_table/html_table_with_attribute.data.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2019 Brajneesh Kumar
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/html_table/test_feodotracker.py
+++ b/intelmq/tests/bots/parsers/html_table/test_feodotracker.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2021 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 import os
 import unittest
 

--- a/intelmq/tests/bots/parsers/html_table/test_parser.py
+++ b/intelmq/tests/bots/parsers/html_table/test_parser.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2019 Brajneesh Kumar
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 import os
 import unittest

--- a/intelmq/tests/bots/parsers/html_table/test_parser_column_split.py
+++ b/intelmq/tests/bots/parsers/html_table/test_parser_column_split.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2019 Brajneesh Kumar
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 import datetime
 import os

--- a/intelmq/tests/bots/parsers/html_table/test_parser_ignore_values.py
+++ b/intelmq/tests/bots/parsers/html_table/test_parser_ignore_values.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2019 Brajneesh Kumar
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 import os
 import unittest

--- a/intelmq/tests/bots/parsers/html_table/test_parser_multivalue_cols.py
+++ b/intelmq/tests/bots/parsers/html_table/test_parser_multivalue_cols.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2019 Brajneesh Kumar
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 import os
 import unittest

--- a/intelmq/tests/bots/parsers/html_table/test_parser_with_attribute.py
+++ b/intelmq/tests/bots/parsers/html_table/test_parser_with_attribute.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2019 Brajneesh Kumar
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 import datetime
 import os

--- a/intelmq/tests/bots/parsers/html_table/test_viriback.data.license
+++ b/intelmq/tests/bots/parsers/html_table/test_viriback.data.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2019 Sebastian Wagner
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/html_table/test_viriback.py
+++ b/intelmq/tests/bots/parsers/html_table/test_viriback.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2019 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 import os
 import unittest

--- a/intelmq/tests/bots/parsers/json/data.json.license
+++ b/intelmq/tests/bots/parsers/json/data.json.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2016 Sebastian Wagner
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/json/data2.json.license
+++ b/intelmq/tests/bots/parsers/json/data2.json.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2017 Sebastian Wagner
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/json/test_parser.py
+++ b/intelmq/tests/bots/parsers/json/test_parser.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2016 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 import base64
 import os

--- a/intelmq/tests/bots/parsers/key_value/test_parser.py
+++ b/intelmq/tests/bots/parsers/key_value/test_parser.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 Karl-Johan Karlsson
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import json

--- a/intelmq/tests/bots/parsers/malc0de/BOOT.license
+++ b/intelmq/tests/bots/parsers/malc0de/BOOT.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2016 Sebastian Wagner
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/malc0de/IP_Blacklist.txt.license
+++ b/intelmq/tests/bots/parsers/malc0de/IP_Blacklist.txt.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2016 Sebastian Wagner
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/malc0de/ZONE.license
+++ b/intelmq/tests/bots/parsers/malc0de/ZONE.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2016 jgedeon120
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/malc0de/test_parser.py
+++ b/intelmq/tests/bots/parsers/malc0de/test_parser.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2016 jgedeon120
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import os

--- a/intelmq/tests/bots/parsers/malwaredomains/domains.txt.license
+++ b/intelmq/tests/bots/parsers/malwaredomains/domains.txt.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2016 Sebastian Wagner
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/malwaredomains/test_parser.py
+++ b/intelmq/tests/bots/parsers/malwaredomains/test_parser.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2015 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 import base64
 import os

--- a/intelmq/tests/bots/parsers/malwarepatrol/getfile.license
+++ b/intelmq/tests/bots/parsers/malwarepatrol/getfile.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2017 Sebastian Wagner <wagner@cert.at>
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/malwarepatrol/test_parser_dansguardian.py
+++ b/intelmq/tests/bots/parsers/malwarepatrol/test_parser_dansguardian.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2015 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 import os
 import unittest

--- a/intelmq/tests/bots/parsers/malwareurl/test_malwareurl.data.license
+++ b/intelmq/tests/bots/parsers/malwareurl/test_malwareurl.data.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2018 dargen3
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/malwareurl/test_malwareurl.py
+++ b/intelmq/tests/bots/parsers/malwareurl/test_malwareurl.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2018 dargen3
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 import os
 import unittest

--- a/intelmq/tests/bots/parsers/mcafee/atdreport.txt.license
+++ b/intelmq/tests/bots/parsers/mcafee/atdreport.txt.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2018 tux78
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/mcafee/test_parser_atd.py
+++ b/intelmq/tests/bots/parsers/mcafee/test_parser_atd.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2018 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import os

--- a/intelmq/tests/bots/parsers/microsoft/bingmurls.json.license
+++ b/intelmq/tests/bots/parsers/microsoft/bingmurls.json.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2018 Sebastian Wagner
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/microsoft/ctip.txt.license
+++ b/intelmq/tests/bots/parsers/microsoft/ctip.txt.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2018 Sebastian Wagner
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/microsoft/ctip_azure.txt.license
+++ b/intelmq/tests/bots/parsers/microsoft/ctip_azure.txt.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2020 Sebastian Wagner
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/microsoft/test_parser_bingmurls.py
+++ b/intelmq/tests/bots/parsers/microsoft/test_parser_bingmurls.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2018 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 import json
 import os

--- a/intelmq/tests/bots/parsers/microsoft/test_parser_ctip.py
+++ b/intelmq/tests/bots/parsers/microsoft/test_parser_ctip.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2018 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 import json
 import os

--- a/intelmq/tests/bots/parsers/microsoft/test_parser_ctip_azure.py
+++ b/intelmq/tests/bots/parsers/microsoft/test_parser_ctip_azure.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 import json
 import os

--- a/intelmq/tests/bots/parsers/misp/misp_attribute.json.license
+++ b/intelmq/tests/bots/parsers/misp/misp_attribute.json.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2016 Sebastian Wagner
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/misp/misp_event.json.license
+++ b/intelmq/tests/bots/parsers/misp/misp_event.json.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2016 Raphaël Vinot
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/misp/test_parser.py
+++ b/intelmq/tests/bots/parsers/misp/test_parser.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2016 kralca
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import os

--- a/intelmq/tests/bots/parsers/n6/test_parser.py
+++ b/intelmq/tests/bots/parsers/n6/test_parser.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2015 aaronkaplan
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import unittest

--- a/intelmq/tests/bots/parsers/netlab_360/dga.txt.license
+++ b/intelmq/tests/bots/parsers/netlab_360/dga.txt.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2016 jgedeon120
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/netlab_360/hajime.txt.license
+++ b/intelmq/tests/bots/parsers/netlab_360/hajime.txt.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2019 Sebastian Wagner
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/netlab_360/magnitude.txt.license
+++ b/intelmq/tests/bots/parsers/netlab_360/magnitude.txt.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2016 jgedeon120
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/netlab_360/mirai.txt.license
+++ b/intelmq/tests/bots/parsers/netlab_360/mirai.txt.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2017 navtej
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/netlab_360/test_parser.py
+++ b/intelmq/tests/bots/parsers/netlab_360/test_parser.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2016 jgedeon120
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import os

--- a/intelmq/tests/bots/parsers/openphish/feed.txt.license
+++ b/intelmq/tests/bots/parsers/openphish/feed.txt.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2016 Sebastian Wagner
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/openphish/feed_commercial.txt.license
+++ b/intelmq/tests/bots/parsers/openphish/feed_commercial.txt.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2018 Filip Pokorný
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/openphish/test_parser.py
+++ b/intelmq/tests/bots/parsers/openphish/test_parser.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2015 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 import base64
 import os

--- a/intelmq/tests/bots/parsers/openphish/test_parser_commercial.py
+++ b/intelmq/tests/bots/parsers/openphish/test_parser_commercial.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2018 Filip Pokorný
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 import os
 import unittest

--- a/intelmq/tests/bots/parsers/phishtank/test_parser.py
+++ b/intelmq/tests/bots/parsers/phishtank/test_parser.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2015 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import unittest

--- a/intelmq/tests/bots/parsers/shadowserver/README.md
+++ b/intelmq/tests/bots/parsers/shadowserver/README.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2019 Guillermo Rodriguez
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
 Shadowserver test
 ==================
 

--- a/intelmq/tests/bots/parsers/shadowserver/test_blocklist.py
+++ b/intelmq/tests/bots/parsers/shadowserver/test_blocklist.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 Thomas Hungenberg
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import os

--- a/intelmq/tests/bots/parsers/shadowserver/test_botnet_drone.py
+++ b/intelmq/tests/bots/parsers/shadowserver/test_botnet_drone.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2019 Guillermo Rodriguez
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import os

--- a/intelmq/tests/bots/parsers/shadowserver/test_broken.py
+++ b/intelmq/tests/bots/parsers/shadowserver/test_broken.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2018 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import unittest

--- a/intelmq/tests/bots/parsers/shadowserver/test_caida_ip_spoofer.py
+++ b/intelmq/tests/bots/parsers/shadowserver/test_caida_ip_spoofer.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 import os
 import unittest
 

--- a/intelmq/tests/bots/parsers/shadowserver/test_cisco_smart_install.py
+++ b/intelmq/tests/bots/parsers/shadowserver/test_cisco_smart_install.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2019 Guillermo Rodriguez
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import os

--- a/intelmq/tests/bots/parsers/shadowserver/test_compromised_website.py
+++ b/intelmq/tests/bots/parsers/shadowserver/test_compromised_website.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2017 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import os

--- a/intelmq/tests/bots/parsers/shadowserver/test_darknet.py
+++ b/intelmq/tests/bots/parsers/shadowserver/test_darknet.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2018 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import os

--- a/intelmq/tests/bots/parsers/shadowserver/test_ddos_amplification.py
+++ b/intelmq/tests/bots/parsers/shadowserver/test_ddos_amplification.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2019 Guillermo Rodriguez
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import os

--- a/intelmq/tests/bots/parsers/shadowserver/test_drone_brute_force.py
+++ b/intelmq/tests/bots/parsers/shadowserver/test_drone_brute_force.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2018 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import os

--- a/intelmq/tests/bots/parsers/shadowserver/test_event4_honeypot_darknet.py
+++ b/intelmq/tests/bots/parsers/shadowserver/test_event4_honeypot_darknet.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2021 Birger Schacht
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import os

--- a/intelmq/tests/bots/parsers/shadowserver/test_event4_ip_spoofer.py
+++ b/intelmq/tests/bots/parsers/shadowserver/test_event4_ip_spoofer.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2021 Birger Schacht
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 import os
 import unittest
 

--- a/intelmq/tests/bots/parsers/shadowserver/test_event4_sinkhole.py
+++ b/intelmq/tests/bots/parsers/shadowserver/test_event4_sinkhole.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2021 Birger Schacht
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import os

--- a/intelmq/tests/bots/parsers/shadowserver/test_event4_sinkhole_http.py
+++ b/intelmq/tests/bots/parsers/shadowserver/test_event4_sinkhole_http.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2021 Birger Schacht
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import os

--- a/intelmq/tests/bots/parsers/shadowserver/test_event4_sinkhole_http_referer.py
+++ b/intelmq/tests/bots/parsers/shadowserver/test_event4_sinkhole_http_referer.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2021 Mikk Margus Möll <mikk@cert.ee>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
 # -*- coding: utf-8 -*-
 
 import os

--- a/intelmq/tests/bots/parsers/shadowserver/test_helpers.py
+++ b/intelmq/tests/bots/parsers/shadowserver/test_helpers.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2018 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """
 Created on Thu Aug  9 15:18:24 2018

--- a/intelmq/tests/bots/parsers/shadowserver/test_honeypot_brute_force.py
+++ b/intelmq/tests/bots/parsers/shadowserver/test_honeypot_brute_force.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2021 Birger Schacht
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import os

--- a/intelmq/tests/bots/parsers/shadowserver/test_honeypot_ddos_amp.py
+++ b/intelmq/tests/bots/parsers/shadowserver/test_honeypot_ddos_amp.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2021 Birger Schacht
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import os

--- a/intelmq/tests/bots/parsers/shadowserver/test_hp_http_scan.py
+++ b/intelmq/tests/bots/parsers/shadowserver/test_hp_http_scan.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2019 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import os

--- a/intelmq/tests/bots/parsers/shadowserver/test_hp_ics_scan.py
+++ b/intelmq/tests/bots/parsers/shadowserver/test_hp_ics_scan.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2019 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import os

--- a/intelmq/tests/bots/parsers/shadowserver/test_mapping.py
+++ b/intelmq/tests/bots/parsers/shadowserver/test_mapping.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 import unittest
 import os
 

--- a/intelmq/tests/bots/parsers/shadowserver/test_microsoft_sinkhole.py
+++ b/intelmq/tests/bots/parsers/shadowserver/test_microsoft_sinkhole.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2015 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import os

--- a/intelmq/tests/bots/parsers/shadowserver/test_netis_router.py
+++ b/intelmq/tests/bots/parsers/shadowserver/test_netis_router.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2019 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 import os
 import unittest

--- a/intelmq/tests/bots/parsers/shadowserver/test_outdated_dnssec_key.py
+++ b/intelmq/tests/bots/parsers/shadowserver/test_outdated_dnssec_key.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2018 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import os

--- a/intelmq/tests/bots/parsers/shadowserver/test_parameters.py
+++ b/intelmq/tests/bots/parsers/shadowserver/test_parameters.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2019 Guillermo Rodriguez
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import os

--- a/intelmq/tests/bots/parsers/shadowserver/test_report_switch.py
+++ b/intelmq/tests/bots/parsers/shadowserver/test_report_switch.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2019 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import os

--- a/intelmq/tests/bots/parsers/shadowserver/test_scan_adb.py
+++ b/intelmq/tests/bots/parsers/shadowserver/test_scan_adb.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2019 Guillermo Rodriguez
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import os

--- a/intelmq/tests/bots/parsers/shadowserver/test_scan_afp.py
+++ b/intelmq/tests/bots/parsers/shadowserver/test_scan_afp.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2019 Guillermo Rodriguez
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import os

--- a/intelmq/tests/bots/parsers/shadowserver/test_scan_ard.py
+++ b/intelmq/tests/bots/parsers/shadowserver/test_scan_ard.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 Tomas Bellus
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import os

--- a/intelmq/tests/bots/parsers/shadowserver/test_scan_chargen.py
+++ b/intelmq/tests/bots/parsers/shadowserver/test_scan_chargen.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2019 Guillermo Rodriguez
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import os

--- a/intelmq/tests/bots/parsers/shadowserver/test_scan_coap.py
+++ b/intelmq/tests/bots/parsers/shadowserver/test_scan_coap.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 Thomas Hungenberg
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import os

--- a/intelmq/tests/bots/parsers/shadowserver/test_scan_cwmp.py
+++ b/intelmq/tests/bots/parsers/shadowserver/test_scan_cwmp.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2019 Guillermo Rodriguez
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import os

--- a/intelmq/tests/bots/parsers/shadowserver/test_scan_db2.py
+++ b/intelmq/tests/bots/parsers/shadowserver/test_scan_db2.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2019 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import os

--- a/intelmq/tests/bots/parsers/shadowserver/test_scan_dns.py
+++ b/intelmq/tests/bots/parsers/shadowserver/test_scan_dns.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2019 Guillermo Rodriguez
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import os

--- a/intelmq/tests/bots/parsers/shadowserver/test_scan_elasticsearch.py
+++ b/intelmq/tests/bots/parsers/shadowserver/test_scan_elasticsearch.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2019 Guillermo Rodriguez
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import os

--- a/intelmq/tests/bots/parsers/shadowserver/test_scan_exchange.py
+++ b/intelmq/tests/bots/parsers/shadowserver/test_scan_exchange.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2021 Birger Schacht
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
 import os
 import unittest
 

--- a/intelmq/tests/bots/parsers/shadowserver/test_scan_ftp.py
+++ b/intelmq/tests/bots/parsers/shadowserver/test_scan_ftp.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2019 Guillermo Rodriguez
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import os

--- a/intelmq/tests/bots/parsers/shadowserver/test_scan_hadoop.py
+++ b/intelmq/tests/bots/parsers/shadowserver/test_scan_hadoop.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2019 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import os

--- a/intelmq/tests/bots/parsers/shadowserver/test_scan_http.py
+++ b/intelmq/tests/bots/parsers/shadowserver/test_scan_http.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2019 Guillermo Rodriguez
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import os

--- a/intelmq/tests/bots/parsers/shadowserver/test_scan_ipmi.py
+++ b/intelmq/tests/bots/parsers/shadowserver/test_scan_ipmi.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2019 Guillermo Rodriguez
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import os

--- a/intelmq/tests/bots/parsers/shadowserver/test_scan_ipp.py
+++ b/intelmq/tests/bots/parsers/shadowserver/test_scan_ipp.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 Thomas Hungenberg
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import os

--- a/intelmq/tests/bots/parsers/shadowserver/test_scan_isakmp.py
+++ b/intelmq/tests/bots/parsers/shadowserver/test_scan_isakmp.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2019 Guillermo Rodriguez
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import os

--- a/intelmq/tests/bots/parsers/shadowserver/test_scan_ldap.py
+++ b/intelmq/tests/bots/parsers/shadowserver/test_scan_ldap.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2019 Guillermo Rodriguez
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import os

--- a/intelmq/tests/bots/parsers/shadowserver/test_scan_ldap_tcp.py
+++ b/intelmq/tests/bots/parsers/shadowserver/test_scan_ldap_tcp.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2019 Guillermo Rodriguez
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import os

--- a/intelmq/tests/bots/parsers/shadowserver/test_scan_mdns.py
+++ b/intelmq/tests/bots/parsers/shadowserver/test_scan_mdns.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2019 Guillermo Rodriguez
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import os

--- a/intelmq/tests/bots/parsers/shadowserver/test_scan_memcached.py
+++ b/intelmq/tests/bots/parsers/shadowserver/test_scan_memcached.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2019 Guillermo Rodriguez
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import os

--- a/intelmq/tests/bots/parsers/shadowserver/test_scan_mongodb.py
+++ b/intelmq/tests/bots/parsers/shadowserver/test_scan_mongodb.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2019 Guillermo Rodriguez
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import os

--- a/intelmq/tests/bots/parsers/shadowserver/test_scan_mqtt.py
+++ b/intelmq/tests/bots/parsers/shadowserver/test_scan_mqtt.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 Thomas Hungenberg
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import os

--- a/intelmq/tests/bots/parsers/shadowserver/test_scan_msrdpeudp.py
+++ b/intelmq/tests/bots/parsers/shadowserver/test_scan_msrdpeudp.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2021 Sebastian Waldbauer
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import os

--- a/intelmq/tests/bots/parsers/shadowserver/test_scan_mssql.py
+++ b/intelmq/tests/bots/parsers/shadowserver/test_scan_mssql.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2019 Guillermo Rodriguez
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import os

--- a/intelmq/tests/bots/parsers/shadowserver/test_scan_nat_pmp.py
+++ b/intelmq/tests/bots/parsers/shadowserver/test_scan_nat_pmp.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2019 Guillermo Rodriguez
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import os

--- a/intelmq/tests/bots/parsers/shadowserver/test_scan_ntp.py
+++ b/intelmq/tests/bots/parsers/shadowserver/test_scan_ntp.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2019 Guillermo Rodriguez
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import os

--- a/intelmq/tests/bots/parsers/shadowserver/test_scan_ntpmonitor.py
+++ b/intelmq/tests/bots/parsers/shadowserver/test_scan_ntpmonitor.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2019 Guillermo Rodriguez
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import os

--- a/intelmq/tests/bots/parsers/shadowserver/test_scan_portmapper.py
+++ b/intelmq/tests/bots/parsers/shadowserver/test_scan_portmapper.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2019 Guillermo Rodriguez
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import os

--- a/intelmq/tests/bots/parsers/shadowserver/test_scan_qotd.py
+++ b/intelmq/tests/bots/parsers/shadowserver/test_scan_qotd.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2019 Guillermo Rodriguez
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import os

--- a/intelmq/tests/bots/parsers/shadowserver/test_scan_radmin.py
+++ b/intelmq/tests/bots/parsers/shadowserver/test_scan_radmin.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 sinus-x
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 import os
 import unittest
 

--- a/intelmq/tests/bots/parsers/shadowserver/test_scan_rdp.py
+++ b/intelmq/tests/bots/parsers/shadowserver/test_scan_rdp.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2019 Guillermo Rodriguez
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import os

--- a/intelmq/tests/bots/parsers/shadowserver/test_scan_redis.py
+++ b/intelmq/tests/bots/parsers/shadowserver/test_scan_redis.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2019 Guillermo Rodriguez
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import os

--- a/intelmq/tests/bots/parsers/shadowserver/test_scan_rsync.py
+++ b/intelmq/tests/bots/parsers/shadowserver/test_scan_rsync.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2019 Guillermo Rodriguez
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import os

--- a/intelmq/tests/bots/parsers/shadowserver/test_scan_smb.py
+++ b/intelmq/tests/bots/parsers/shadowserver/test_scan_smb.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2019 Guillermo Rodriguez
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import os

--- a/intelmq/tests/bots/parsers/shadowserver/test_scan_smb_json.py
+++ b/intelmq/tests/bots/parsers/shadowserver/test_scan_smb_json.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2021 Sebastian Waldbauer
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import os

--- a/intelmq/tests/bots/parsers/shadowserver/test_scan_snmp.py
+++ b/intelmq/tests/bots/parsers/shadowserver/test_scan_snmp.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2019 Guillermo Rodriguez
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import os

--- a/intelmq/tests/bots/parsers/shadowserver/test_scan_ssdp.py
+++ b/intelmq/tests/bots/parsers/shadowserver/test_scan_ssdp.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2019 Guillermo Rodriguez
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import os

--- a/intelmq/tests/bots/parsers/shadowserver/test_scan_ssl_freak.py
+++ b/intelmq/tests/bots/parsers/shadowserver/test_scan_ssl_freak.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2019 Guillermo Rodriguez
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import os

--- a/intelmq/tests/bots/parsers/shadowserver/test_scan_ssl_poodle.py
+++ b/intelmq/tests/bots/parsers/shadowserver/test_scan_ssl_poodle.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2019 Guillermo Rodriguez
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import os

--- a/intelmq/tests/bots/parsers/shadowserver/test_scan_telnet.py
+++ b/intelmq/tests/bots/parsers/shadowserver/test_scan_telnet.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2019 Guillermo Rodriguez
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import os

--- a/intelmq/tests/bots/parsers/shadowserver/test_scan_tftp.py
+++ b/intelmq/tests/bots/parsers/shadowserver/test_scan_tftp.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2019 Guillermo Rodriguez
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import os

--- a/intelmq/tests/bots/parsers/shadowserver/test_scan_ubiquiti.py
+++ b/intelmq/tests/bots/parsers/shadowserver/test_scan_ubiquiti.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2019 Guillermo Rodriguez
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import os

--- a/intelmq/tests/bots/parsers/shadowserver/test_scan_vnc.py
+++ b/intelmq/tests/bots/parsers/shadowserver/test_scan_vnc.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2019 Guillermo Rodriguez
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import os

--- a/intelmq/tests/bots/parsers/shadowserver/test_scan_xdmcp.py
+++ b/intelmq/tests/bots/parsers/shadowserver/test_scan_xdmcp.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2019 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import os

--- a/intelmq/tests/bots/parsers/shadowserver/test_sinkhole6_http.py
+++ b/intelmq/tests/bots/parsers/shadowserver/test_sinkhole6_http.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2018 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import os

--- a/intelmq/tests/bots/parsers/shadowserver/test_sinkhole_dns.py
+++ b/intelmq/tests/bots/parsers/shadowserver/test_sinkhole_dns.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2021 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import os

--- a/intelmq/tests/bots/parsers/shadowserver/test_sinkhole_http_drone.py
+++ b/intelmq/tests/bots/parsers/shadowserver/test_sinkhole_http_drone.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2018 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import os

--- a/intelmq/tests/bots/parsers/shadowserver/test_testdata.py
+++ b/intelmq/tests/bots/parsers/shadowserver/test_testdata.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2017 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import csv

--- a/intelmq/tests/bots/parsers/shadowserver/testdata/README.md
+++ b/intelmq/tests/bots/parsers/shadowserver/testdata/README.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2017 Gernot Schulz
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
 Shadowserver test feeds
 =======================
 

--- a/intelmq/tests/bots/parsers/shadowserver/testdata/blocklist.csv.license
+++ b/intelmq/tests/bots/parsers/shadowserver/testdata/blocklist.csv.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2020 Thomas Hungenberg
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/shadowserver/testdata/botnet_drone.csv.license
+++ b/intelmq/tests/bots/parsers/shadowserver/testdata/botnet_drone.csv.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2019 Guillermo Rodriguez
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/shadowserver/testdata/caida_ip_spoofer.csv.license
+++ b/intelmq/tests/bots/parsers/shadowserver/testdata/caida_ip_spoofer.csv.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2020 Sebastian Wagner
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/shadowserver/testdata/cisco_smart_install.csv.license
+++ b/intelmq/tests/bots/parsers/shadowserver/testdata/cisco_smart_install.csv.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2019 Guillermo Rodriguez
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/shadowserver/testdata/clean-shadowserver.awk
+++ b/intelmq/tests/bots/parsers/shadowserver/testdata/clean-shadowserver.awk
@@ -1,5 +1,9 @@
 #!/usr/bin/awk -f
 
+# SPDX-FileCopyrightText: 2017 Gernot Schulz
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 function rand_ip(n) {
     # Return IP from TEST-NET-2 (RFC 5737) address block
     rand_int = int(n * rand())

--- a/intelmq/tests/bots/parsers/shadowserver/testdata/compromised_website.csv.license
+++ b/intelmq/tests/bots/parsers/shadowserver/testdata/compromised_website.csv.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2019 Sebastian Wagner
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/shadowserver/testdata/darknet.csv.license
+++ b/intelmq/tests/bots/parsers/shadowserver/testdata/darknet.csv.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2019 Sebastian Wagner
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/shadowserver/testdata/ddos_amplification.csv.license
+++ b/intelmq/tests/bots/parsers/shadowserver/testdata/ddos_amplification.csv.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2019 Guillermo Rodriguez
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/shadowserver/testdata/drone_brute_force.csv.license
+++ b/intelmq/tests/bots/parsers/shadowserver/testdata/drone_brute_force.csv.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2019 Guillermo Rodriguez
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/shadowserver/testdata/event4_honeypot_brute_force.csv.license
+++ b/intelmq/tests/bots/parsers/shadowserver/testdata/event4_honeypot_brute_force.csv.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2021 Sebastian Wagner
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/shadowserver/testdata/event4_honeypot_darknet.csv.license
+++ b/intelmq/tests/bots/parsers/shadowserver/testdata/event4_honeypot_darknet.csv.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2021 Birger Schacht
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/shadowserver/testdata/event4_honeypot_ddos_amp.csv.license
+++ b/intelmq/tests/bots/parsers/shadowserver/testdata/event4_honeypot_ddos_amp.csv.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2021 Sebastian Wagner
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/shadowserver/testdata/event4_ip_spoofer.csv.license
+++ b/intelmq/tests/bots/parsers/shadowserver/testdata/event4_ip_spoofer.csv.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2021 Birger Schacht
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/shadowserver/testdata/event4_sinkhole.csv.license
+++ b/intelmq/tests/bots/parsers/shadowserver/testdata/event4_sinkhole.csv.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2021 Birger Schacht
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/shadowserver/testdata/event4_sinkhole_http.csv.license
+++ b/intelmq/tests/bots/parsers/shadowserver/testdata/event4_sinkhole_http.csv.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2021 Birger Schacht
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/shadowserver/testdata/event4_sinkhole_http_referer.csv.license
+++ b/intelmq/tests/bots/parsers/shadowserver/testdata/event4_sinkhole_http_referer.csv.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2021 Mikk Margus Möll <mikk@cert.ee>
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/shadowserver/testdata/hp_http_scan.csv.license
+++ b/intelmq/tests/bots/parsers/shadowserver/testdata/hp_http_scan.csv.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2019 Sebastian Wagner
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/shadowserver/testdata/hp_ics_scan.csv.license
+++ b/intelmq/tests/bots/parsers/shadowserver/testdata/hp_ics_scan.csv.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2019 Sebastian Wagner
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/shadowserver/testdata/microsoft_sinkhole.csv.license
+++ b/intelmq/tests/bots/parsers/shadowserver/testdata/microsoft_sinkhole.csv.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2019 Guillermo Rodriguez
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/shadowserver/testdata/netis_router.csv.license
+++ b/intelmq/tests/bots/parsers/shadowserver/testdata/netis_router.csv.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2019 Sebastian Wagner
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/shadowserver/testdata/outdated_dnssec_key.csv.license
+++ b/intelmq/tests/bots/parsers/shadowserver/testdata/outdated_dnssec_key.csv.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2019 Sebastian Wagner
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/shadowserver/testdata/scan_adb.csv.license
+++ b/intelmq/tests/bots/parsers/shadowserver/testdata/scan_adb.csv.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2019 Guillermo Rodriguez
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/shadowserver/testdata/scan_afp.csv.license
+++ b/intelmq/tests/bots/parsers/shadowserver/testdata/scan_afp.csv.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2019 Guillermo Rodriguez
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/shadowserver/testdata/scan_ard.csv.license
+++ b/intelmq/tests/bots/parsers/shadowserver/testdata/scan_ard.csv.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2020 Tomas Bellus
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/shadowserver/testdata/scan_chargen.csv.license
+++ b/intelmq/tests/bots/parsers/shadowserver/testdata/scan_chargen.csv.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2019 Guillermo Rodriguez
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/shadowserver/testdata/scan_chargen.short.license
+++ b/intelmq/tests/bots/parsers/shadowserver/testdata/scan_chargen.short.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2019 Guillermo Rodriguez
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/shadowserver/testdata/scan_coap.csv.license
+++ b/intelmq/tests/bots/parsers/shadowserver/testdata/scan_coap.csv.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2020 Thomas Hungenberg
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/shadowserver/testdata/scan_cwmp.csv.license
+++ b/intelmq/tests/bots/parsers/shadowserver/testdata/scan_cwmp.csv.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2019 Guillermo Rodriguez
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/shadowserver/testdata/scan_db2.csv.license
+++ b/intelmq/tests/bots/parsers/shadowserver/testdata/scan_db2.csv.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2019 Sebastian Wagner
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/shadowserver/testdata/scan_dns.csv.license
+++ b/intelmq/tests/bots/parsers/shadowserver/testdata/scan_dns.csv.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2019 Guillermo Rodriguez
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/shadowserver/testdata/scan_elasticsearch.csv.license
+++ b/intelmq/tests/bots/parsers/shadowserver/testdata/scan_elasticsearch.csv.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2019 Guillermo Rodriguez
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/shadowserver/testdata/scan_exchange.csv.license
+++ b/intelmq/tests/bots/parsers/shadowserver/testdata/scan_exchange.csv.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2021 Birger Schacht
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/shadowserver/testdata/scan_ftp.csv.license
+++ b/intelmq/tests/bots/parsers/shadowserver/testdata/scan_ftp.csv.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2019 Guillermo Rodriguez
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/shadowserver/testdata/scan_hadoop.csv.license
+++ b/intelmq/tests/bots/parsers/shadowserver/testdata/scan_hadoop.csv.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2019 Sebastian Wagner
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/shadowserver/testdata/scan_http.csv.license
+++ b/intelmq/tests/bots/parsers/shadowserver/testdata/scan_http.csv.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2019 Guillermo Rodriguez
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/shadowserver/testdata/scan_ipmi.csv.license
+++ b/intelmq/tests/bots/parsers/shadowserver/testdata/scan_ipmi.csv.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2019 Guillermo Rodriguez
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/shadowserver/testdata/scan_ipp.csv.license
+++ b/intelmq/tests/bots/parsers/shadowserver/testdata/scan_ipp.csv.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2020 Thomas Hungenberg
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/shadowserver/testdata/scan_isakmp.csv.license
+++ b/intelmq/tests/bots/parsers/shadowserver/testdata/scan_isakmp.csv.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2019 Guillermo Rodriguez
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/shadowserver/testdata/scan_ldap.csv.license
+++ b/intelmq/tests/bots/parsers/shadowserver/testdata/scan_ldap.csv.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2019 Guillermo Rodriguez
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/shadowserver/testdata/scan_ldap_tcp.csv.license
+++ b/intelmq/tests/bots/parsers/shadowserver/testdata/scan_ldap_tcp.csv.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2019 Guillermo Rodriguez
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/shadowserver/testdata/scan_mdns.csv.license
+++ b/intelmq/tests/bots/parsers/shadowserver/testdata/scan_mdns.csv.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2019 Guillermo Rodriguez
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/shadowserver/testdata/scan_memcached.csv.license
+++ b/intelmq/tests/bots/parsers/shadowserver/testdata/scan_memcached.csv.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2019 Guillermo Rodriguez
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/shadowserver/testdata/scan_mongodb.csv.license
+++ b/intelmq/tests/bots/parsers/shadowserver/testdata/scan_mongodb.csv.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2019 Guillermo Rodriguez
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/shadowserver/testdata/scan_mqtt.csv.license
+++ b/intelmq/tests/bots/parsers/shadowserver/testdata/scan_mqtt.csv.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2020 Thomas Hungenberg
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/shadowserver/testdata/scan_msrdpeudp.csv.license
+++ b/intelmq/tests/bots/parsers/shadowserver/testdata/scan_msrdpeudp.csv.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2021 Sebastian Waldbauer
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/shadowserver/testdata/scan_mssql.csv.license
+++ b/intelmq/tests/bots/parsers/shadowserver/testdata/scan_mssql.csv.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2019 Guillermo Rodriguez
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/shadowserver/testdata/scan_nat_pmp.csv.license
+++ b/intelmq/tests/bots/parsers/shadowserver/testdata/scan_nat_pmp.csv.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2019 Guillermo Rodriguez
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/shadowserver/testdata/scan_netbios.csv.license
+++ b/intelmq/tests/bots/parsers/shadowserver/testdata/scan_netbios.csv.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2019 Guillermo Rodriguez
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/shadowserver/testdata/scan_ntp.csv.license
+++ b/intelmq/tests/bots/parsers/shadowserver/testdata/scan_ntp.csv.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2019 Guillermo Rodriguez
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/shadowserver/testdata/scan_ntpmonitor.csv.license
+++ b/intelmq/tests/bots/parsers/shadowserver/testdata/scan_ntpmonitor.csv.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2019 Guillermo Rodriguez
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/shadowserver/testdata/scan_portmapper.csv.license
+++ b/intelmq/tests/bots/parsers/shadowserver/testdata/scan_portmapper.csv.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2019 Guillermo Rodriguez
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/shadowserver/testdata/scan_qotd.csv.license
+++ b/intelmq/tests/bots/parsers/shadowserver/testdata/scan_qotd.csv.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2019 Guillermo Rodriguez
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/shadowserver/testdata/scan_radmin.csv.license
+++ b/intelmq/tests/bots/parsers/shadowserver/testdata/scan_radmin.csv.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2020 sinus-x
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/shadowserver/testdata/scan_rdp.csv.license
+++ b/intelmq/tests/bots/parsers/shadowserver/testdata/scan_rdp.csv.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2019 Guillermo Rodriguez
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/shadowserver/testdata/scan_redis.csv.license
+++ b/intelmq/tests/bots/parsers/shadowserver/testdata/scan_redis.csv.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2019 Guillermo Rodriguez
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/shadowserver/testdata/scan_rsync.csv.license
+++ b/intelmq/tests/bots/parsers/shadowserver/testdata/scan_rsync.csv.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2019 Guillermo Rodriguez
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/shadowserver/testdata/scan_smb.csv.license
+++ b/intelmq/tests/bots/parsers/shadowserver/testdata/scan_smb.csv.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2019 Guillermo Rodriguez
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/shadowserver/testdata/scan_snmp.csv.license
+++ b/intelmq/tests/bots/parsers/shadowserver/testdata/scan_snmp.csv.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2019 Guillermo Rodriguez
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/shadowserver/testdata/scan_ssdp.csv.license
+++ b/intelmq/tests/bots/parsers/shadowserver/testdata/scan_ssdp.csv.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2019 Guillermo Rodriguez
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/shadowserver/testdata/scan_ssl_freak.csv.license
+++ b/intelmq/tests/bots/parsers/shadowserver/testdata/scan_ssl_freak.csv.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2019 Guillermo Rodriguez
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/shadowserver/testdata/scan_ssl_poodle.csv.license
+++ b/intelmq/tests/bots/parsers/shadowserver/testdata/scan_ssl_poodle.csv.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2019 Guillermo Rodriguez
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/shadowserver/testdata/scan_telnet.csv.license
+++ b/intelmq/tests/bots/parsers/shadowserver/testdata/scan_telnet.csv.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2019 Guillermo Rodriguez
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/shadowserver/testdata/scan_tftp.csv.license
+++ b/intelmq/tests/bots/parsers/shadowserver/testdata/scan_tftp.csv.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2019 Guillermo Rodriguez
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/shadowserver/testdata/scan_ubiquiti.csv.license
+++ b/intelmq/tests/bots/parsers/shadowserver/testdata/scan_ubiquiti.csv.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2019 Guillermo Rodriguez
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/shadowserver/testdata/scan_vnc.csv.license
+++ b/intelmq/tests/bots/parsers/shadowserver/testdata/scan_vnc.csv.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2019 Guillermo Rodriguez
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/shadowserver/testdata/scan_xdmcp.csv.license
+++ b/intelmq/tests/bots/parsers/shadowserver/testdata/scan_xdmcp.csv.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2019 Sebastian Wagner
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/shadowserver/testdata/sinkhole6_http.csv.license
+++ b/intelmq/tests/bots/parsers/shadowserver/testdata/sinkhole6_http.csv.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2019 Sebastian Wagner
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/shadowserver/testdata/sinkhole_dns.csv.license
+++ b/intelmq/tests/bots/parsers/shadowserver/testdata/sinkhole_dns.csv.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2021 Sebastian Wagner
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/shadowserver/testdata/sinkhole_http_drone.csv.license
+++ b/intelmq/tests/bots/parsers/shadowserver/testdata/sinkhole_http_drone.csv.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2019 Guillermo Rodriguez
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/shodan/test_parser.py
+++ b/intelmq/tests/bots/parsers/shodan/test_parser.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2018 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 import base64
 import json

--- a/intelmq/tests/bots/parsers/shodan/tests.json.license
+++ b/intelmq/tests/bots/parsers/shodan/tests.json.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2018 Sebastian Wagner
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/spamhaus/asndrop.txt.license
+++ b/intelmq/tests/bots/parsers/spamhaus/asndrop.txt.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2016 jgedeon120
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/spamhaus/cert.txt.license
+++ b/intelmq/tests/bots/parsers/spamhaus/cert.txt.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2017 Sebastian Wagner
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/spamhaus/drop.txt.license
+++ b/intelmq/tests/bots/parsers/spamhaus/drop.txt.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2016 jgedeon120
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/spamhaus/test_parser_cert.py
+++ b/intelmq/tests/bots/parsers/spamhaus/test_parser_cert.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2015 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 import os
 import unittest

--- a/intelmq/tests/bots/parsers/spamhaus/test_parser_drop.py
+++ b/intelmq/tests/bots/parsers/spamhaus/test_parser_drop.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2015 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import os

--- a/intelmq/tests/bots/parsers/sucuri/test_sucuri.data.license
+++ b/intelmq/tests/bots/parsers/sucuri/test_sucuri.data.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2018 dargen3
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/sucuri/test_sucuri.py
+++ b/intelmq/tests/bots/parsers/sucuri/test_sucuri.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2018 dargen3
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 import codecs
 import os

--- a/intelmq/tests/bots/parsers/surbl/test_surbl.data.license
+++ b/intelmq/tests/bots/parsers/surbl/test_surbl.data.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2018 dargen3
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/surbl/test_surbl.py
+++ b/intelmq/tests/bots/parsers/surbl/test_surbl.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2018 dargen3
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 from os import path
 import unittest

--- a/intelmq/tests/bots/parsers/taichung/recent.html
+++ b/intelmq/tests/bots/parsers/taichung/recent.html
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2020 Sebastian Wagner
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>

--- a/intelmq/tests/bots/parsers/taichung/test_parser.py
+++ b/intelmq/tests/bots/parsers/taichung/test_parser.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2015 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 import base64
 import os

--- a/intelmq/tests/bots/parsers/threatminer/test_threatminer.data.license
+++ b/intelmq/tests/bots/parsers/threatminer/test_threatminer.data.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2018 dargen3
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/threatminer/test_threatminer.py
+++ b/intelmq/tests/bots/parsers/threatminer/test_threatminer.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2018 dargen3
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 import os
 import unittest

--- a/intelmq/tests/bots/parsers/turris/greylist-latest.csv.license
+++ b/intelmq/tests/bots/parsers/turris/greylist-latest.csv.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2016 Sebastian Wagner
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/turris/test_parser.py
+++ b/intelmq/tests/bots/parsers/turris/test_parser.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2015 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 import base64
 import os

--- a/intelmq/tests/bots/parsers/twitter/test_parser.py
+++ b/intelmq/tests/bots/parsers/twitter/test_parser.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2018 Karel
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import os

--- a/intelmq/tests/bots/parsers/twitter/tweet.txt.license
+++ b/intelmq/tests/bots/parsers/twitter/tweet.txt.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2018 Karel
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/vxvault/test_parser.py
+++ b/intelmq/tests/bots/parsers/vxvault/test_parser.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2015 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import unittest

--- a/intelmq/tests/bots/parsers/webinspektor/test_webinspektor.data.license
+++ b/intelmq/tests/bots/parsers/webinspektor/test_webinspektor.data.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2018 dargen3
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/webinspektor/test_webinspektor.py
+++ b/intelmq/tests/bots/parsers/webinspektor/test_webinspektor.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2018 dargen3
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 import os
 import unittest

--- a/intelmq/tests/bots/parsers/zoneh/defacement_accepted.csv.license
+++ b/intelmq/tests/bots/parsers/zoneh/defacement_accepted.csv.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2017 Chris Horsley
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/zoneh/defacement_accepted_RECONSTRUCTED.csv.license
+++ b/intelmq/tests/bots/parsers/zoneh/defacement_accepted_RECONSTRUCTED.csv.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2017 Chris Horsley
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/zoneh/defacement_pending.csv.license
+++ b/intelmq/tests/bots/parsers/zoneh/defacement_pending.csv.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2017 Chris Horsley
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/zoneh/test_zoneh.py
+++ b/intelmq/tests/bots/parsers/zoneh/test_zoneh.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2017 Chris Horsley
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 
 import os

--- a/intelmq/tests/lib/test_bot.py
+++ b/intelmq/tests/lib/test_bot.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2015 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """
 Tests the Bot class itself.

--- a/intelmq/tests/lib/test_bot_output.py
+++ b/intelmq/tests/lib/test_bot_output.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2019 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """
 Test OutputBot specifics

--- a/intelmq/tests/lib/test_collector_bot.py
+++ b/intelmq/tests/lib/test_collector_bot.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2016 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """
 Test with reports

--- a/intelmq/tests/lib/test_exceptions.py
+++ b/intelmq/tests/lib/test_exceptions.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """
 Testing the IntelMQ-specific exceptions

--- a/intelmq/tests/lib/test_expert_bot.py
+++ b/intelmq/tests/lib/test_expert_bot.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2018 Edvard Rejthar
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 import unittest
 
 import intelmq.lib.test as test

--- a/intelmq/tests/lib/test_harmonization.py
+++ b/intelmq/tests/lib/test_harmonization.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2015 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """
 Testing harmonization classes

--- a/intelmq/tests/lib/test_message.py
+++ b/intelmq/tests/lib/test_message.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2015 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """
 Testing the Message classes of intelmq.

--- a/intelmq/tests/lib/test_parser_bot.py
+++ b/intelmq/tests/lib/test_parser_bot.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2016 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 import base64
 import datetime

--- a/intelmq/tests/lib/test_pipeline.py
+++ b/intelmq/tests/lib/test_pipeline.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2015 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- encoding: utf-8 -*-
 """
 Testing the pipeline functions of intelmq.

--- a/intelmq/tests/lib/test_splitreports.py
+++ b/intelmq/tests/lib/test_splitreports.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2016 Bernhard Herzog
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 """
 Tests for intelmq.lib.splitreports
 """

--- a/intelmq/tests/lib/test_upgrades.py
+++ b/intelmq/tests/lib/test_upgrades.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2019 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 """
 Tests the upgrade functions.
 """

--- a/intelmq/tests/lib/test_utils.py
+++ b/intelmq/tests/lib/test_utils.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2015 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- encoding: utf-8 -*-
 """
 Testing the utility functions of intelmq.

--- a/intelmq/tests/test_conf.py
+++ b/intelmq/tests/test_conf.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2015 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # -*- coding: utf-8 -*-
 """
 Tests if configuration in /etc is valid

--- a/intelmq/version.py
+++ b/intelmq/version.py
@@ -1,2 +1,6 @@
+# SPDX-FileCopyrightText: 2016 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 __version_info__ = (3, 0, 0, 'alpha', 1)
 __version__ = '.'.join(map(str, __version_info__))


### PR DESCRIPTION
This was done using reuse, first by listing all the files that are not
reuse lint compliant:
> reuse lint > ../reuse.lst

This list was then modified to remove metainformation and only list
filenames. Also a couple of filenames that need manual modification were
removed.

Then using git and reuse:
```
for file in `cat ../reuse.lst`; do year=`git log --reverse --pretty="format:%ai" $file | head -1 | cut -d "-" -f 1`;  author=`git log --reverse --pretty="format:%an" $file|head -1`; reuse addheader --copyright="$author" --year="$year" --license="AGPL-3.0-or-later" --skip-unrecognised $file; done
```
