### PR TITLE
ENH: Mixin & once behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ CHANGELOG
 - `intelmq.lib.bot`:
   - Handle `InvalidValue` exceptions upon message retrieval by dumping the message instead of repeating endlessly (#1765, PR#1766 by Filip Pokorný).
   - Rewrite of the parameter loading and handling, getting rid of the `parameters` member (PR#1729 by Birger Schacht).
+  - New function `once` will run once after bot start. Useful for one-time after-start data preparation or cleanups. (PR#1968 by Sebastian Waldbauer).
 - `intelmq.lib.exceptions`:
   - `InvalidValue`: Add optional parameter `object` (PR#1766 by Filip Pokorný).
 - `intelmq.lib.utils`:

--- a/intelmq/lib/bot.py
+++ b/intelmq/lib/bot.py
@@ -199,6 +199,7 @@ class Bot(object):
             self.__load_harmonization_configuration()
 
             self._parse_common_parameters()
+            super().__init__()
             self.init()
 
             if not self.__instance_id:
@@ -224,7 +225,6 @@ class Bot(object):
             self.stop()
             raise
         self.logger.info("Bot initialization completed.")
-        super().__init__()
 
         self.__stats_cache = cache.Cache(host=self.statistics_host,
                                          port=self.statistics_port,
@@ -275,12 +275,17 @@ class Bot(object):
     def shutdown(self):
         pass
 
+    def once(self):
+        pass
+
     def start(self, starting: bool = True, error_on_pipeline: bool = True,
               error_on_message: bool = False, source_pipeline: Optional[str] = None,
               destination_pipeline: Optional[str] = None):
 
         self.__source_pipeline = source_pipeline
         self.__destination_pipeline = destination_pipeline
+
+        self.once()
 
         while True:
             try:


### PR DESCRIPTION
Mixins are initialized before the bot init, this is mandatory
for the mixins, because mixins have to be initialized before
the bot gets initialized. Otherwise the bot would raise errors
because mixins cant access data.

once() is a newly introduced function and will run once after bot
start. This function can be used for some after start cleanups or
pre-data collection from pipelines.