### PR TITLE
FIX: change copyright header syntax in md files

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,6 @@
-..
+<!-- comment
    SPDX-License-Identifier: AGPL-3.0-or-later
+-->
 
 # Please read the notes below and replace them with the description of you pull request
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
-..
+<!-- comment
    SPDX-FileCopyrightText: 2015-2021 Sebastian Wagner
    SPDX-License-Identifier: AGPL-3.0-or-later
+-->
 
 CHANGELOG
 ==========

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
-..
+<!-- comment
    SPDX-FileCopyrightText: 2015-2021 Sebastian Wagner
    SPDX-License-Identifier: AGPL-3.0-or-later
+-->
 
 NEWS
 ====

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,7 @@
-..
+<!-- comment
    SPDX-FileCopyrightText: 2015-2021 Sebastian Wagner
    SPDX-License-Identifier: AGPL-3.0-or-later
+-->
 
 IntelMQ Security Notes
 ======================

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,7 @@
-..
+<!-- comment
    SPDX-FileCopyrightText: 2020 Birger Schacht
    SPDX-License-Identifier: AGPL-3.0-or-later
+-->
 
 # Documentation at readthedocs!
 


### PR DESCRIPTION
Closes #1972
