### PR TITLE
Compare "output" fields as JSON objects, not strings

### DIFF
--- a/intelmq/lib/test.py
+++ b/intelmq/lib/test.py
@@ -535,6 +535,10 @@ class BotTestCase(object):
             del event_dict['time.observation']
         if 'time.observation' in expected:
             del expected['time.observation']
+        if 'output' in event_dict:
+            event_dict['output'] = json.loads(event_dict['output'])
+        if 'output' in expected:
+            expected['output'] = json.loads(expected['output'])
 
         self.assertDictEqual(expected, event_dict)
 


### PR DESCRIPTION
The `output` field in the harmonization is defined as a ["unicode string[] with JSON objects"](https://github.com/certtools/intelmq/blob/06d70e3ba82f80074492a05a049f61a91bb40115/intelmq/lib/harmonization.py#L905). [lib.test.BotTestCase.assertMessageEqual()](https://github.com/certtools/intelmq/blob/06d70e3ba82f80074492a05a049f61a91bb40115/intelmq/lib/test.py#L516) does not special-case the `output` field (as it does with `time.observation`), leading it to be treated as a string and compared according to string equivalence. However, according to [the JSON spec](https://www.json.org/json-en.html), "[a]n object is an unordered set of name/value pairs".

This leads to two objects differing only in the order of their fields when serialized comparing as different according to IntelMQ, when they should have been equal according to JSON.

This patch parses `output` fields into Python dictionaries before comparing them to ensure the comparison is unordered.

This patch should not cause any previously working tests to fail, since any two JSON objects that serialize to equal strings (and thus passed the tests before this patch) must be equal JSON objects when parsed.

As an illustration, consider this test program:
```python
import unittest
import json
import intelmq.lib.test as test
from intelmq.lib.bot import Bot

OUTPUT_1 = {
    "__type": "Event",
    "output": '{"a": 1, "b": 2}'
}

OUTPUT_2 = {
    "__type": "Event",
    "output": '{"b": 2, "a": 1}'
}

class NullExpertBot(Bot):
    def process(self):
        event = self.receive_message()
        self.send_message(event)
        self.acknowledge_message()

class TestJSONField(test.BotTestCase, unittest.TestCase):
    @classmethod
    def set_bot(cls):
        cls.bot_reference = NullExpertBot

    def test_json(self):
        self.assertDictEqual(json.loads(OUTPUT_1["output"]),
                             json.loads(OUTPUT_2["output"]))

    def test_output(self):
        self.input_message = OUTPUT_1
        self.run_bot()
        self.assertMessageEqual(0, OUTPUT_2)

if __name__ == '__main__':
    unittest.main()
```
`test_json` always succeeds. Before this patch, `test_output` fails with:
```
AssertionError: {'__type': 'Event', 'output': '{"b": 2, "a": 1}'} != {'output': '{"a": 1, "b": 2}', '__type': 'Event'}
- {'__type': 'Event', 'output': '{"b": 2, "a": 1}'}
?                                       --------

+ {'__type': 'Event', 'output': '{"a": 1, "b": 2}'}
?                                 ++++++++
```
With this patch, `test_output` succeeds.