### PR TITLE
ENH: replace copy2 with pathlib

### DIFF
--- a/intelmq/lib/utils.py
+++ b/intelmq/lib/utils.py
@@ -241,7 +241,8 @@ def write_configuration(configuration_filepath: str,
         if content == old_content:
             return None
     if not new and backup:
-        shutil.copy2(configuration_filepath, configuration_filepath + '.bak')
+        config = pathlib.Path(configuration_filepath)
+        pathlib.Path(configuration_filepath + '.bak').write_text(config.read_text())
     with open(configuration_filepath, 'w') as handle:
         if useyaml:
             yaml.dump(content, handle)


### PR DESCRIPTION
copy2 tries to copy file attributes. This leads to problems when we try
to use the write_configuration function from code that runs under
another user, even when the user is in the intelmq group.
Simple copying the content of the file should be enough, though.
