### PR TITLE
ENH: lib/bot: Init pipeline before init call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ CHANGELOG
 - `intelmq.lib.bot`:
   - Handle `InvalidValue` exceptions upon message retrieval by dumping the message instead of repeating endlessly (#1765, PR#1766 by Filip Pokorný).
   - Rewrite of the parameter loading and handling, getting rid of the `parameters` member (PR#1729 by Birger Schacht).
+  - The pipeline is now initialized before the call of `init` to allow bots accessing data directly on startup/initialization for cleanup or maintenance tasks (PR#1982 by Sebastian Wagner).
 - `intelmq.lib.exceptions`:
   - `InvalidValue`: Add optional parameter `object` (PR#1766 by Filip Pokorný).
 - `intelmq.lib.utils`:

--- a/intelmq/lib/bot.py
+++ b/intelmq/lib/bot.py
@@ -199,6 +199,9 @@ class Bot(object):
             self.__load_harmonization_configuration()
 
             self._parse_common_parameters()
+
+            super().__init__()
+            self.__connect_pipelines()
             self.init()
 
             if not self.__instance_id:
@@ -224,7 +227,6 @@ class Bot(object):
             self.stop()
             raise
         self.logger.info("Bot initialization completed.")
-        super().__init__()
 
         self.__stats_cache = cache.Cache(host=self.statistics_host,
                                          port=self.statistics_port,
@@ -267,7 +269,6 @@ class Bot(object):
         self.logger.handlers = []  # remove all existing handlers
         self.__sighup.clear()
         self.__init__(self.__bot_id_full, sighup_event=self.__sighup)
-        self.__connect_pipelines()
 
     def init(self):
         pass

--- a/intelmq/lib/pipeline.py
+++ b/intelmq/lib/pipeline.py
@@ -338,8 +338,11 @@ class Pythonlist(Pipeline):
     state = {}  # type: Dict[str, list]
 
     def connect(self):
-        if self.raise_on_connect:
-            raise exceptions.PipelineError('Connect failed as requested')
+        try:
+            if self.parameters.raise_on_connect:
+                raise exceptions.PipelineError('Connect failed as requested')
+        except AttributeError:
+            pass
 
     def disconnect(self):
         pass

--- a/intelmq/lib/test.py
+++ b/intelmq/lib/test.py
@@ -68,15 +68,7 @@ def mocked_config(bot_id='test-bot', sysconfig={}, group=None, module=None):
 
 
 def mocked_get_global_settings():
-    return {"destination_pipeline_broker": "pythonlist",
-            "redis_cache_host": os.getenv('INTELMQ_PIPELINE_HOST', 'localhost'),
-            "redis_cache_port": 6379,
-            "redis_cache_db": 4,
-            "redis_cache_ttl": 10,
-            "redis_cache_password": os.environ.get('INTELMQ_TEST_REDIS_PASSWORD'),
-            "source_pipeline_broker": "pythonlist",
-            "testing": True,
-            }
+    return BOT_CONFIG
 
 
 def skip_database():
@@ -205,7 +197,8 @@ class BotTestCase(object):
                                                                 queue_name.strip('_'))
                                   for queue_name in destination_queues}
 
-        config = self.sysconfig.copy()
+        config = BOT_CONFIG.copy()
+        config.update(self.sysconfig)
         config.update(parameters)
         config['destination_queues'] = destination_queues
         self.mocked_config = mocked_config(self.bot_id,
@@ -214,14 +207,10 @@ class BotTestCase(object):
                                            module=self.bot_reference.__module__,
                                            )
 
-        self.resulting_config = BOT_CONFIG.copy()
-        self.resulting_config.update(self.sysconfig)
-        self.resulting_config.update(parameters)
-
         self.logger = utils.log(self.bot_id,
                                 log_path=False, stream=self.log_stream,
                                 log_format_stream=utils.LOG_FORMAT,
-                                log_level=self.resulting_config['logging_level'])
+                                log_level=config['logging_level'])
         self.logger_handlers_backup = self.logger.handlers
 
         parameters = Parameters()


### PR DESCRIPTION
allows bots accessing data directly on startup/initialization for cleanup or maintenance tasks
this required small adaptions in the test code, and shortens its code a
bit

related: certtools/intelmq#1968
related: certtools/intelmq#1959

@waldbauer-certat  please verify if this solves your issue