### PR TITLE
FIX: Use the default loader of ruamel yaml

### DIFF
--- a/intelmq/lib/pipeline.py
+++ b/intelmq/lib/pipeline.py
@@ -105,15 +105,15 @@ class Pipeline(object):
                 q = {"_default": queues}
             elif type_ is str:
                 q = {"_default": queues.split()}
-            elif type_ is dict:
+            elif isinstance(queues, dict):
                 q = queues
                 for key, val in queues.items():
-                    q[key] = val if type(val) is list else val.split()
+                    q[key] = val if isinstance(val, list) else str(val).split()
             else:
                 raise exceptions.InvalidArgument(
                     'queues', got=queues,
                     expected=["None", "list of strings", "dict (of strings or lists that should have the _default key)"])
-            self.destination_queues = q
+            self.destination_queues = dict(q)
         else:
             raise exceptions.InvalidArgument('queues_type', got=queues_type, expected=['source', 'destination'])
 

--- a/intelmq/lib/utils.py
+++ b/intelmq/lib/utils.py
@@ -50,7 +50,7 @@ import intelmq
 from intelmq.lib.exceptions import DecodingError
 from intelmq import RUNTIME_CONF_FILE
 
-yaml = YAML(typ="safe", pure=True)
+yaml = YAML(pure=True)
 
 __all__ = ['base64_decode', 'base64_encode', 'decode', 'encode',
            'load_configuration', 'load_parameters', 'log', 'parse_logline',


### PR DESCRIPTION
Ruamel YAML defaults to the rt (round-trip) loader, which preservs
comments.
