### PR TITLE
API collector: Optionally use UNIX sockets instead of TCP sockets, fix #1986

### DIFF
--- a/intelmq/bots/collectors/api/collector_api.py
+++ b/intelmq/bots/collectors/api/collector_api.py
@@ -42,7 +42,7 @@ class APICollectorBot(CollectorBot):
     __is_multithreadable: bool = False
     use_socket = False
     socket_path = '/tmp/imq_api_default_socket'
-    _server: Optional[HTTPServer] = None
+    _server: Optional['HTTPServer'] = None
     _unix_socket: Optional[socket.socket] = None
     _eventLoopThread: Optional[Thread] = None
 


### PR DESCRIPTION
The first commit adds the option of using UNIX sockets instead of TCP sockets for the API collector, which has performance benefits, and the second fixes an issue with the collector if the collector is reloaded.