### PR TITLE
FIX: s/self.parameters/self/ in Shodan collector

### DIFF
--- a/intelmq/bots/collectors/shodan/collector_stream.py
+++ b/intelmq/bots/collectors/shodan/collector_stream.py
@@ -65,12 +65,12 @@ class ShodanStreamCollectorBot(CollectorBot):
                 ReadTimeoutError,
                 APIError) as exc:
             self.__error_count += 1
-            if (self.__error_count > self.parameters.error_max_retries):
+            if (self.__error_count > self.error_max_retries):
                 self.__error_count = 0
                 raise
             else:
                 self.logger.info('Got exception %r, retrying (consecutive error count %d <= %d).',
-                                 exc, self.__error_count, self.parameters.error_max_retries)
+                                 exc, self.__error_count, self.error_max_retries)
 
 
 BOT = ShodanStreamCollectorBot


### PR DESCRIPTION
The `error_max_retries` attribute is no longer accessed via `self.parameters` and the Shodan collector appears to have been missed in the updates.