### PR TITLE
Core fixes

### DIFF
--- a/intelmq/lib/bot_debugger.py
+++ b/intelmq/lib/bot_debugger.py
@@ -109,7 +109,7 @@ class BotDebugger:
             if self.instance.group == "Output":
                 self.outputappend("Output bots can't send message.")
                 return
-            if not bool(self.instance._Bot__destination_queues):
+            if not bool(self.instance.destination_queues):
                 self.outputappend("Bot has no destination queues.")
                 return
             if msg:


### PR DESCRIPTION
This PR fixes two issues:
* `bot_debugger` attempts to access a bot's private `destination_queues` attribute, despite it being public now
* changes in the passing of pipeline parameters made the `load_balance` parameter not work