### PR TITLE
Docs: 2 new entries for feeds whishlist, small note in install docs regarding openSUSE leap 15.3

### DIFF
--- a/docs/dev/feeds-wishlist.rst
+++ b/docs/dev/feeds-wishlist.rst
@@ -28,6 +28,7 @@ This list evolved from the issue :issue:`Contribute: Feeds List (#384) <384>`.
 - List of potentially interesting data sources:
 
   - `Abuse.ch SSL Blacklists <https://sslbl.abuse.ch/blacklist/>`_
+  - `AbuseIPDB <https://www.abuseipdb.com/pricing>`_
   - `Adblock Plus <https://adblockplus.org/en/subscriptions>`_
   - `apivoid IP Reputation API <https://www.apivoid.com/api/ip-reputation/>`_
   - `Anomali Limo Free Intel Feed <https://www.anomali.com/resources/limo>`_
@@ -80,6 +81,7 @@ This list evolved from the issue :issue:`Contribute: Feeds List (#384) <384>`.
   - `Neo23x0 signature-base <https://github.com/Neo23x0/signature-base/tree/master/iocs>`_
   - `OpenBugBounty <https://www.openbugbounty.org/>`_
   - `Phishing Army <https://phishing.army/>`_
+  - `Phishstats <https://phishstats.info/>`_, offers JSON ("API) and CSV download.
   - `Project Honeypot (#284) <http://www.projecthoneypot.org/list_of_ips.php?rss=1>`_
   - `RST Threat Feed <https://rstcloud.net/>`_ (offers a free and a commercial feed)
   - `SANS ISC <https://isc.sans.edu/api/>`_

--- a/docs/user/installation.rst
+++ b/docs/user/installation.rst
@@ -121,7 +121,7 @@ These are the operating systems which are currently supported by packages:
 * **Fedora 33**
 * **Fedora 34**
 * **openSUSE Leap 15.2**
-* **openSUSE Leap 15.3**
+* **openSUSE Leap 15.3** (make sure the ``openSUSE:Backports:SLE-15-SP3`` repository is enabled)
 * **openSUSE Tumbleweed**
 * **Ubuntu 18.04** (enable the universe repositories by appending `universe` in `/etc/apt/sources.list` to `deb http://[...].archive.ubuntu.com/ubuntu/ bionic main` first)
 * **Ubuntu 20.04** (enable the universe repositories by appending `universe` in `/etc/apt/sources.list` to `deb http://[...].archive.ubuntu.com/ubuntu/ focal main` first)


### PR DESCRIPTION

@wagner-certat
DOC: dev/feeds whishlist: add two potential feeds
0c5c400
@wagner-certat
DOC: install: note on leap 15.3
9fef258

falcon and hug are in backports, both are required for the API

