### PR TITLE
codespell: Exclude coverage output

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -32,8 +32,8 @@ exclude =
     intelmq/tests/
 
 [codespell]
-skip = *.csv,*.data,*.svg,./docs/_build,.eggs,.git,testfile.txt,dga.txt,*.txt,*.json
-ignore-words-list = crypted,ba,nwe,ether
+skip = *.csv,*.data,*.svg,./docs/_build,.eggs,.git,testfile.txt,dga.txt,*.txt,*.json,./cover
+ignore-words-list = crypted,ba,nwe
 exclude-file = .github/workflows/codespell.excludelines
 
 [metadata]


### PR DESCRIPTION
Exclude .cover, that's where the HTML report of code coverage is placed
and this can be ignored
remove the exclusion of name "ether", it's nowhere in the code anyway