### PR TITLE
Make update script less verbose by default

### DIFF
--- a/intelmq/bots/experts/domain_suffix/expert.py
+++ b/intelmq/bots/experts/domain_suffix/expert.py
@@ -66,7 +66,7 @@ class DomainSuffixExpertBot(Bot):
             parsed_args = cls._create_argparser().parse_args()
 
         if parsed_args.update_database:
-            cls.update_database()
+            cls.update_database(verbose=parsed_args.verbose)
 
         else:
             super().run(parsed_args=parsed_args)
@@ -75,10 +75,11 @@ class DomainSuffixExpertBot(Bot):
     def _create_argparser(cls):
         argparser = super()._create_argparser()
         argparser.add_argument("--update-database", action='store_true', help='downloads latest database data')
+        argparser.add_argument("--verbose", action='store_true', help='be verbose')
         return argparser
 
     @classmethod
-    def update_database(cls):
+    def update_database(cls, verbose=False):
         bots = {}
         runtime_conf = get_bots_settings()
         try:
@@ -98,7 +99,8 @@ class DomainSuffixExpertBot(Bot):
         try:
             session = create_request_session()
             url = "https://publicsuffix.org/list/public_suffix_list.dat"
-            print("Downloading the latest database update...")
+            if verbose:
+                print("Downloading the latest database update...")
             response = session.get(url)
 
             if not response.ok:
@@ -114,7 +116,8 @@ class DomainSuffixExpertBot(Bot):
             with open(database_path, "wb") as database:
                 database.write(response.content)
 
-        print("Database updated. Reloading affected bots.")
+        if verbose:
+            print("Database updated. Reloading affected bots.")
 
         ctl = IntelMQController()
         for bot in bots.keys():

--- a/intelmq/bots/experts/maxmind_geoip/expert.py
+++ b/intelmq/bots/experts/maxmind_geoip/expert.py
@@ -94,7 +94,7 @@ class GeoIPExpertBot(Bot):
             parsed_args = cls._create_argparser().parse_args()
 
         if parsed_args.update_database:
-            cls.update_database()
+            cls.update_database(verbose=parsed_args.verbose)
 
         else:
             super().run(parsed_args=parsed_args)
@@ -103,10 +103,11 @@ class GeoIPExpertBot(Bot):
     def _create_argparser(cls):
         argparser = super()._create_argparser()
         argparser.add_argument("--update-database", action='store_true', help='downloads latest database data')
+        argparser.add_argument("--verbose", action='store_true', help='be verbose')
         return argparser
 
     @classmethod
-    def update_database(cls):
+    def update_database(cls, verbose=False):
         bots = {}
         license_key = None
         runtime_conf = get_bots_settings()
@@ -127,7 +128,8 @@ class GeoIPExpertBot(Bot):
                 sys.exit(error)
 
         if not bots:
-            print("Database update skipped. No bots of type {0} present in runtime.conf.".format(__name__))
+            if verbose:
+                print("Database update skipped. No bots of type {0} present in runtime.conf.".format(__name__))
             sys.exit(0)
 
         # we only need to import now, if there are no maxmind_geoip bots, this dependency does not need to be installed
@@ -139,7 +141,8 @@ class GeoIPExpertBot(Bot):
                                                          "is a dependency for the required geoip2 package.")
 
         try:
-            print("Downloading the latest database update...")
+            if verbose:
+                print("Downloading the latest database update...")
             session = create_request_session()
             response = session.get("https://download.maxmind.com/app/geoip_download",
                                    params={
@@ -179,7 +182,8 @@ class GeoIPExpertBot(Bot):
             with open(database_path, "wb") as database:
                 database.write(database_data._buffer)
 
-        print("Database updated. Reloading affected bots.")
+        if verbose:
+            print("Database updated. Reloading affected bots.")
 
         ctl = IntelMQController()
         for bot in bots.keys():

--- a/intelmq/bots/experts/recordedfuture_iprisk/expert.py
+++ b/intelmq/bots/experts/recordedfuture_iprisk/expert.py
@@ -58,7 +58,7 @@ class RecordedFutureIPRiskExpertBot(Bot):
             parsed_args = cls._create_argparser().parse_args()
 
         if parsed_args.update_database:
-            cls.update_database()
+            cls.update_database(verbose=parsed_args.verbose)
 
         else:
             super().run(parsed_args=parsed_args)
@@ -67,10 +67,11 @@ class RecordedFutureIPRiskExpertBot(Bot):
     def _create_argparser(cls):
         argparser = super()._create_argparser()
         argparser.add_argument("--update-database", action='store_true', help='downloads latest database data')
+        argparser.add_argument("--verbose", action='store_true', help='be verbose')
         return argparser
 
     @classmethod
-    def update_database(cls):
+    def update_database(cls, verbose=False):
         bots = {}
         api_token = None
         runtime_conf = get_bots_settings()
@@ -84,11 +85,13 @@ class RecordedFutureIPRiskExpertBot(Bot):
             sys.exit("Database update failed. Your configuration of {0} is missing key {1}.".format(bot, e))
 
         if not bots:
-            print("Database update skipped. No bots of type {0} present in runtime.conf.".format(__name__))
+            if verbose:
+                print("Database update skipped. No bots of type {0} present in runtime.conf.".format(__name__))
             sys.exit(0)
 
         try:
-            print("Downloading the latest database update...")
+            if verbose:
+                print("Downloading the latest database update...")
             session = create_request_session()
             response = session.get("https://api.recordedfuture.com/v2/ip/risklist",
                                    params={
@@ -127,7 +130,8 @@ class RecordedFutureIPRiskExpertBot(Bot):
             with open(database_path, "w") as database:
                 database.write(database_data)
 
-        print("Database updated. Reloading affected bots.")
+        if verbose:
+            print("Database updated. Reloading affected bots.")
 
         ctl = IntelMQController()
         for bot in bots.keys():

--- a/intelmq/bots/experts/tor_nodes/expert.py
+++ b/intelmq/bots/experts/tor_nodes/expert.py
@@ -60,7 +60,7 @@ class TorExpertBot(Bot):
             parsed_args = cls._create_argparser().parse_args()
 
         if parsed_args.update_database:
-            cls.update_database()
+            cls.update_database(verbose=parsed_args.verbose)
 
         else:
             super().run(parsed_args=parsed_args)
@@ -69,10 +69,11 @@ class TorExpertBot(Bot):
     def _create_argparser(cls):
         argparser = super()._create_argparser()
         argparser.add_argument("--update-database", action='store_true', help='downloads latest database data')
+        argparser.add_argument("--verbose", action='store_true', help='be verbose')
         return argparser
 
     @classmethod
-    def update_database(cls):
+    def update_database(cls, verbose=False):
         bots = {}
         runtime_conf = get_bots_settings()
         try:
@@ -84,11 +85,13 @@ class TorExpertBot(Bot):
             sys.exit("Database update failed. Your configuration of {0} is missing key {1}.".format(bot, e))
 
         if not bots:
-            print("Database update skipped. No bots of type {0} present in runtime.conf.".format(__name__))
+            if verbose:
+                print("Database update skipped. No bots of type {0} present in runtime.conf.".format(__name__))
             sys.exit(0)
 
         try:
-            print("Downloading the latest database update...")
+            if verbose:
+                print("Downloading the latest database update...")
             session = create_request_session()
             response = session.get("https://check.torproject.org/exit-addresses")
         except requests.exceptions.RequestException as e:
@@ -107,7 +110,8 @@ class TorExpertBot(Bot):
             with open(database_path, "w") as database:
                 database.write(tor_exits)
 
-        print("Database updated. Reloading affected bots.")
+        if verbose:
+            print("Database updated. Reloading affected bots.")
 
         ctl = IntelMQController()
         for bot in bots.keys():


### PR DESCRIPTION
This introduces a --verbose flag to the experts which use update
functions. The default behaviour now is to *not* print any messages,
which makes the update function less noisy when used with cron.

Fixes #2016

In the long run we should probably move the update logic to the bot class itself.