### PR TITLE
FIX: load pipeline configurations before connecting

### DIFF
--- a/intelmq/lib/bot.py
+++ b/intelmq/lib/bot.py
@@ -563,6 +563,7 @@ class Bot(object):
                                                             load_balance=self.load_balance,
                                                             is_multithreaded=self.is_multithreaded)
 
+            self.__source_pipeline.load_configurations('source')
             self.__source_pipeline.connect()
             self.__current_message = None
             self.logger.debug("Connected to source queue.")
@@ -576,6 +577,7 @@ class Bot(object):
                                                                  load_balance=self.load_balance,
                                                                  is_multithreaded=self.is_multithreaded)
 
+            self.__destination_pipeline.load_configurations('destination')
             self.__destination_pipeline.connect()
             self.logger.debug("Connected to destination queues.")
         else:

--- a/intelmq/lib/pipeline.py
+++ b/intelmq/lib/pipeline.py
@@ -177,6 +177,9 @@ class Pipeline(object):
     def _reject_message(self):
         raise NotImplementedError
 
+    def load_configurations(self, queues_type):
+        raise NotImplementedError
+
 
 class Redis(Pipeline):
     has_internal_queues = True
@@ -405,6 +408,11 @@ class Pythonlist(Pipeline):
         """
         No-op because of the internal queue
         """
+
+    def load_configurations(self, queues_type):
+        '''
+        Nothing to load
+        '''
 
 
 class Amqp(Pipeline):


### PR DESCRIPTION
This appears to fix an issue where the `host` attribute of the pipeline is not set before being accessed while connecting pipelines, causing a bot to fail to start, as shown in this stack trace:
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/dist-packages/intelmq/lib/bot.py", line 208, in __init__
    self.__connect_pipelines()
  File "/usr/local/lib/python3.8/dist-packages/intelmq/lib/bot.py", line 579, in __connect_pipelines
    self.__destination_pipeline.connect()
  File "/usr/local/lib/python3.8/dist-packages/intelmq/lib/pipeline.py", line 204, in connect
    if self.host.startswith("/"):
AttributeError: 'Redis' object has no attribute 'host'
```