### PR TITLE
Use the YAML unsafe loader instead of the safe loader

### DIFF
--- a/intelmq/lib/pipeline.py
+++ b/intelmq/lib/pipeline.py
@@ -110,14 +110,14 @@ class Pipeline(object):
                 q = {"_default": queues}
             elif type_ is str:
                 q = {"_default": queues.split()}
-            elif type_ is dict:
+            elif isinstance(queues, dict):
                 q = queues
                 q.update({key: (val if isinstance(val, list) else val.split()) for key, val in queues.items()})
             else:
                 raise exceptions.InvalidArgument(
                     'queues', got=queues,
                     expected=["None", "list of strings", "dict (of strings or lists that should have the _default key)"])
-            self.destination_queues = q
+            self.destination_queues = dict(q)
         else:
             raise exceptions.InvalidArgument('queues_type', got=queues_type, expected=['source', 'destination'])
 

--- a/intelmq/lib/utils.py
+++ b/intelmq/lib/utils.py
@@ -51,7 +51,7 @@ import intelmq
 from intelmq.lib.exceptions import DecodingError
 from intelmq import RUNTIME_CONF_FILE
 
-yaml = YAML(typ="safe", pure=True)
+yaml = YAML(typ="unsafe", pure=True)
 
 __all__ = ['base64_decode', 'base64_encode', 'decode', 'encode',
            'load_configuration', 'load_parameters', 'log', 'parse_logline',


### PR DESCRIPTION
This lets us be backwards compatible to JSON and still dump YAML in a
readable format.

Another approach would be to first try to load JSON and only if that fails use yaml with the default loader.