### PR TITLE
Minor updates to shadowserver _config

### DIFF
--- a/intelmq/bots/parsers/shadowserver/_config.py
+++ b/intelmq/bots/parsers/shadowserver/_config.py
@@ -2887,6 +2887,7 @@ mapping = (
     ('SSL-POODLE-Vulnerable-Servers', 'scan_ssl_poodle', ssl_poodle_vulnerable_servers),
     ('Sandbox-URL', 'cwsandbox_url', sandbox_url),
     ('Sinkhole-DNS', 'sinkhole_dns', sinkhole_dns),
+    ('Sinkhole-Events', 'event4_sinkhole', event46_sinkhole),
     ('Sinkhole-Events IPv4', 'event4_sinkhole', event46_sinkhole),
     ('Sinkhole-Events IPv6', 'event6_sinkhole', event46_sinkhole),
     ('Sinkhole-Events-HTTP IPv4', 'event4_sinkhole_http', event46_sinkhole_http),

--- a/intelmq/bots/parsers/shadowserver/_config.py
+++ b/intelmq/bots/parsers/shadowserver/_config.py
@@ -1162,6 +1162,7 @@ drone = {
         # classification.identifier will be set to (harmonized) malware name by modify expert
     },
 }
+
 drone_spam = {
     'required_fields': [
         ('time.source', 'timestamp', add_UTC_to_timestamp),
@@ -2611,6 +2612,8 @@ event4_honeypot_darknet = {
     },
 }
 
+# https://www.shadowserver.org/what-we-do/network-reporting/microsoft-sinkhole-events-report/
+# https://www.shadowserver.org/what-we-do/network-reporting/sinkhole-events-report/
 event46_sinkhole = {
     'required_fields': [
         ('time.source', 'timestamp', add_UTC_to_timestamp),
@@ -2652,6 +2655,8 @@ event46_sinkhole = {
     },
 }
 
+# https://www.shadowserver.org/what-we-do/network-reporting/microsoft-sinkhole-http-events-report/
+# https://www.shadowserver.org/what-we-do/network-reporting/sinkhole-http-events-report/
 event46_sinkhole_http = {
     'required_fields': [
         ('time.source', 'timestamp', add_UTC_to_timestamp),
@@ -2720,6 +2725,7 @@ def scan_exchange_identifier(field):
     return 'vulnerable-exchange-server'
 
 
+# https://www.shadowserver.org/what-we-do/network-reporting/vulnerable-exchange-server-report/
 scan_exchange = {
     'required_fields': [
         ('time.source', 'timestamp', add_UTC_to_timestamp),

--- a/intelmq/bots/parsers/shadowserver/_config.py
+++ b/intelmq/bots/parsers/shadowserver/_config.py
@@ -2881,8 +2881,8 @@ mapping = (
     ('SSL-POODLE-Vulnerable-Servers', 'scan_ssl_poodle', ssl_poodle_vulnerable_servers),
     ('Sandbox-URL', 'cwsandbox_url', sandbox_url),
     ('Sinkhole-DNS', 'sinkhole_dns', sinkhole_dns),
-    ('Sinkhole-Events', 'event4_sinkhole', event46_sinkhole),
-    ('Sinkhole-Events', 'event6_sinkhole', event46_sinkhole),
+    ('Sinkhole-Events IPv4', 'event4_sinkhole', event46_sinkhole),
+    ('Sinkhole-Events IPv6', 'event6_sinkhole', event46_sinkhole),
     ('Sinkhole-Events-HTTP IPv4', 'event4_sinkhole_http', event46_sinkhole_http),
     ('Sinkhole-Events-HTTP IPv6', 'event6_sinkhole_http', event46_sinkhole_http),
     ('Sinkhole-HTTP-Drone', 'sinkhole_http_drone', sinkhole_http_drone),  # legacy (replaced by event46_sinkhole_http)


### PR DESCRIPTION
This PR gives the IPv4 and IPv6 versions of the sinkhole feeds different feednames, and adds comments with links to Shadowserver's feed documentation to `event46_sinkhole` and `event46_sinkhole_http` similarly to those on the other mappings.