### PR TITLE
Shadowserver parser: mapping for Honeypont HTTP Scan and updated Microsoft Sinkhole HTTP

### DIFF
--- a/intelmq/bots/parsers/shadowserver/_config.py
+++ b/intelmq/bots/parsers/shadowserver/_config.py
@@ -506,6 +506,52 @@ microsoft_sinkhole = {
     },
 }
 
+event4_microsoft_sinkhole_http = {
+    'required_fields': [
+        ('time.source', 'timestamp', add_UTC_to_timestamp),
+        ('source.ip', 'src_ip'),
+    ],
+    'optional_fields': [
+        ('source.port', 'src_port'),
+        ('source.asn', 'src_asn', invalidate_zero),
+        ('source.geolocation.cc', 'src_geo'),
+        ('source.geolocation.region', 'src_region'),
+        ('source.geolocation.city', 'src_city'),
+        ('source.reverse_dns', 'src_hostname'),
+        ('extra.source.naics', 'src_naics', convert_int),
+        ('extra.source.sector', 'src_sector', validate_to_none),
+        ('extra.', 'device_vendor', validate_to_none),
+        ('extra.', 'device_type', validate_to_none),
+        ('extra.', 'device_model', validate_to_none),
+        ('destination.ip', 'dst_ip', validate_ip),
+        ('destination.port', 'dst_port', convert_int),
+        ('destination.asn', 'dst_asn', invalidate_zero),
+        ('destination.geolocation.cc', 'dst_geo'),
+        ('destination.geolocation.region', 'dst_region'),
+        ('destination.geolocation.city', 'dst_city'),
+        ('destination.reverse_dns', 'dst_hostname'),
+        ('extra.destination.naics', 'dst_naics', invalidate_zero),
+        ('extra.destination.sector', 'dst_sector', validate_to_none),
+        ('extra.', 'public_source', validate_to_none),
+        ('malware.name', 'infection'),
+        ('extra.', 'family', validate_to_none),
+        ('classification.identifier', 'tag'),  # different values possible in this report
+        ('extra.', 'application', validate_to_none),
+        ('extra.', 'version', validate_to_none),
+        ('extra.', 'http_url', validate_to_none),
+        ('extra.', 'http_host', validate_to_none),
+        ('extra.', 'http_agent', validate_to_none),
+        ('extra.', 'forwarded_by', validate_to_none),
+        ('extra.', 'ssl_cipher', validate_to_none),
+        ('extra.', 'http_referer', validate_to_none),
+        
+    ],
+    'constant_fields': {
+        'classification.taxonomy': 'other',
+        'classification.type': 'other',
+    },
+}
+
 # https://www.shadowserver.org/wiki/pmwiki.php/Services/Open-Redis
 open_redis = {
     'required_fields': [
@@ -2611,6 +2657,68 @@ event4_honeypot_darknet = {
     },
 }
 
+event4_honeypot_http_scan = {
+    'required_fields': [
+        ('time.source', 'timestamp', add_UTC_to_timestamp),
+        ('source.ip', 'src_ip'),
+    ],
+    'optional_fields': [
+        ('source.port', 'src_port'),
+        ('source.asn', 'src_asn', invalidate_zero),
+        ('source.geolocation.cc', 'src_geo'),
+        ('source.geolocation.region', 'src_region'),
+        ('source.geolocation.city', 'src_city'),
+        ('source.reverse_dns', 'src_hostname'),
+        ('extra.source.naics', 'src_naics', convert_int),
+        ('extra.source.sector', 'src_sector', validate_to_none),
+        ('extra.', 'device_vendor', validate_to_none),
+        ('extra.', 'device_type', validate_to_none),
+        ('extra.', 'device_model', validate_to_none),
+        ('destination.ip', 'dst_ip', validate_ip),
+        ('destination.port', 'dst_port', convert_int),
+        ('destination.asn', 'dst_asn', invalidate_zero),
+        ('destination.geolocation.cc', 'dst_geo'),
+        ('destination.geolocation.region', 'dst_region'),
+        ('destination.geolocation.city', 'dst_city'),
+        ('destination.reverse_dns', 'dst_hostname'),
+        ('extra.destination.naics', 'dst_naics', invalidate_zero),
+        ('extra.destination.sector', 'dst_sector', validate_to_none),
+        ('extra.', 'public_source', validate_to_none),
+        ('malware.name', 'infection'),
+        ('extra.', 'family', validate_to_none),
+        ('classification.identifier', 'tag'),  # different values possible in this report
+        ('extra.', 'application', validate_to_none),
+        ('extra.', 'version', validate_to_none),
+        ('extra.', 'event_id', validate_to_none),
+        ('extra.', 'pattern', validate_to_none),
+        ('extra.', 'http_agent', validate_to_none),
+        ('extra.', 'http_request_method', validate_to_none),
+        ('extra.', 'url_scheme', validate_to_none),
+        ('extra.', 'session_tags', validate_to_none),
+        ('extra.', 'vulnerability_enum', validate_to_none),
+        ('extra.', 'vulnerability_class', validate_to_none),
+        ('extra.', 'vulnerability_score', validate_to_none),
+        ('extra.', 'vulnerability_severity', validate_to_none),
+        ('extra.', 'vulnerability_version', validate_to_none),
+        ('extra.', 'threat_framework', validate_to_none),
+        ('extra.', 'threat_tactic_id', validate_to_none),
+        ('extra.', 'threat_technique_id', validate_to_none),
+        ('extra.', 'target_vendor', validate_to_none),
+        ('extra.', 'target_product', validate_to_none),
+        ('extra.', 'target_class', validate_to_none),
+        ('extra.', 'file_md5', validate_to_none),
+        ('extra.', 'file_sha256', validate_to_none),
+        ('extra.', 'request_raw', validate_to_none),
+        ('extra.', 'body_raw', validate_to_none),
+        
+    ],
+    'constant_fields': {
+        'classification.taxonomy': 'other',
+        'classification.type': 'other',
+    },
+}
+
+
 event46_sinkhole = {
     'required_fields': [
         ('time.source', 'timestamp', add_UTC_to_timestamp),
@@ -2845,12 +2953,14 @@ mapping = (
     ('Honeypot-Amplification-DDoS-Events', 'event4_honeypot_ddos_amp', honeypot_ddos_amp),
     ('Honeypot-Brute-Force-Events', 'event4_honeypot_brute_force', honeypot_brute_force),
     ('Honeypot-Darknet', 'event4_honeypot_darknet', event4_honeypot_darknet),
+    ('Honeypot_http_scan', 'event4_honeypot_http_scan', event4_honeypot_http_scan),
     ('ICS-Scanners', 'hp_ics_scan', ics_scanners),
     ('IPv6-Sinkhole-HTTP-Drone', 'sinkhole6_http', ipv6_sinkhole_http_drone),  # legacy (replaced by event46_sinkhole_http)
     ('IP-Spoofer-Events', 'event4_ip_spoofer', event4_ip_spoofer),
     ('Microsoft-Sinkhole', 'microsoft_sinkhole', microsoft_sinkhole),  # legacy (replaced by event46_sinkhole_http)
     ('Microsoft-Sinkhole-Events IPv4', 'event4_microsoft_sinkhole', event46_sinkhole),
     ('Microsoft-Sinkhole-Events-HTTP IPv4', 'event4_microsoft_sinkhole_http', event46_sinkhole_http),
+    ('Microsoft_sinkhole_http', 'event4_microsoft_sinkhole_http', event4_microsoft_sinkhole_http),
     ('NTP-Monitor', 'scan_ntpmonitor', ntp_monitor),
     ('NTP-Version', 'scan_ntp', ntp_version),
     ('Open-Chargen', 'scan_chargen', open_chargen),


### PR DESCRIPTION
Resolved the following error that Could not get a configuration for:
event4_honeypot_http_scan
event4_microsoft_sinkhole_http