### PR TITLE
BUG: lib/bot: handle empty dict in destination_queues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ CHANGELOG
 ### Core
 - `intelmq.lib.bot_debugger`: Fix accessing the bot's destination queues (PR#2027 by Mikk Margus Möll).
 - `intelmq.lib.pipeline`: Fix handling of `load_balance` parameter (PR#2027 by Mikk Margus Möll).
-- `intelmq.lib.utils`: YAML configuration loader: Use ruamel's `*unsafe* loader to enable backwards-compatibility with JSON, preserve comments and dump files in a readable format (PR#2041 by Birger Schacht, fixes #2003).
+- `intelmq.lib.bot`: Fix handling of parameter `destination_queues` if value is an empty dictionary (PR#2051 by Sebastian Wagner, fixes #2034).
 
 ### Development
 

--- a/intelmq/lib/bot.py
+++ b/intelmq/lib/bot.py
@@ -64,7 +64,7 @@ class Bot(object):
     destination_pipeline_host: str = "127.0.0.1"
     destination_pipeline_password: Optional[str] = None
     destination_pipeline_port: int = 6379
-    destination_queues: Optional[dict] = None
+    destination_queues: dict = {}
     error_dump_message: bool = True
     error_log_exception: bool = True
     error_log_message: bool = False
@@ -389,7 +389,7 @@ class Bot(object):
                                 warnings.warn("Message will be removed from the pipeline and not dumped to the disk. "
                                               "Set `error_dump_message` to true to save the message on disk. "
                                               "This warning is only shown once in the runtime of a bot.")
-                            if self.destination_queues and '_on_error' in self.destination_queues:
+                            if '_on_error' in self.destination_queues:
                                 self.send_message(self.__current_message, path='_on_error')
 
                             if message_to_dump or self.__current_message:
@@ -567,7 +567,7 @@ class Bot(object):
             self.__current_message = None
             self.logger.debug("Connected to source queue.")
 
-        if self.destination_queues is not None:
+        if self.destination_queues:
             self.logger.debug("Loading destination pipeline and queues %r.", self.destination_queues)
             self.__destination_pipeline = PipelineFactory.create(logger=self.logger,
                                                                  direction="destination",


### PR DESCRIPTION
the manager (or any user in the file directly) sets destination_queues
to an empty dict. the check `is not None` did not catch empty dicts,
initializing the destination pipeline even when no queues were defined.
The check is now more lax and the code handles empty dicts normally,
making them also the default value instead of None.

fixes certtools/intelmq#2034

@monoidic please check if that solves your observed error