### PR TITLE
BUG: smtp output: add Content-Disposition header for attachments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ CHANGELOG
 #### Outputs
 - `intelmq.bots.outputs.mcafee.output_esm_ip`: Fix access to parameters, the bot wrongly used `self.parameters` (by Sebastian Wagner).
 - `intelmq.bots.outputs.misp.output_api`: Fix access to parameters, the bot wrongly used `self.parameters` (by Sebastian Wagner).
+- `intelmq.bots.outputs.smtp.output`: Add `Content-Disposition`-header to the attachment, fixing the display in Mail Clients as actual attachment (PR#2052 by Sebastian Wagner, fixes #2018).
 
 ### Documentation
 - Various formatting fixes (by Sebastian Wagner).

--- a/intelmq/bots/outputs/smtp/output.py
+++ b/intelmq/bots/outputs/smtp/output.py
@@ -70,7 +70,9 @@ class SMTPOutputBot(Bot):
             if self.text is not None:
                 msg.attach(MIMEText(self.text.format(ev=event)))
             if self.fieldnames:
-                msg.attach(MIMEText(attachment, 'csv'))
+                mime_attachment = MIMEText(attachment, 'csv')
+                mime_attachment.add_header("Content-Disposition", "attachment", filename="events.csv")
+                msg.attach(mime_attachment)
             msg['Subject'] = self.subject.format(ev=event)
             msg['From'] = self.mail_from.format(ev=event)
             msg['To'] = self.mail_to.format(ev=event)

--- a/intelmq/tests/bots/outputs/smtp/test_output.py
+++ b/intelmq/tests/bots/outputs/smtp/test_output.py
@@ -51,6 +51,9 @@ class TestSMTPOutputBot(test.BotTestCase, unittest.TestCase):
 ''')
         self.assertEqual({'from_addr': 'myself', 'to_addrs': ['you', 'yourself']},
                          SENT_MESSAGE[1])
+        # https://github.com/certtools/intelmq/issues/2018
+        self.assertIn(('Content-Disposition', 'attachment; filename="events.csv"'),
+                      SENT_MESSAGE[0].get_payload()[1]._headers)
 
     def test_multiple_recipients_event(self):
         """


### PR DESCRIPTION
fixes display of the attachment in mail clients

fixes certtools/intelmq#2018