### PR TITLE
ENH: lib/bot: fix behavior for unconfigured bots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ CHANGELOG
   They now reside in `intelmq.lib.processmanager` which also contains an interface definition the processmanager implementations must adhere to.
   Both the processmanagers and the `intelmqctl` script were cleaned up a bit.
   The `LogLevel` and `ReturnType` Enums were added to `intelmq.lib.datatypes`.
+- `intelmq.lib.bot`:
+  - Enhance behaviour if an unconfigured bot is started (PR#2054 by Sebastian Wagner).
 
 ### Development
 


### PR DESCRIPTION
Add `enabled` and `run_mode` as members of the `Bot` class with default values.
Log the system parameters in the same way as default and runtime parameters.
Warn if disallowed system parameters are encountered.
Warn if no configuration could be found in the runtime configuration file for the bot's ID.
Re-initialize logging if logging parameters have been changed by environment variables.