### PR TITLE
ENH: imap collector: support unverified connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ CHANGELOG
 
 ### Bots
 #### Collectors
+- `intelmq.bots.collectors.mail._lib`: Add support for unverified SSL/STARTTLS connections (PR#2055 by Sebastian Wagner).
 
 #### Parsers
 

--- a/intelmq/bots/collectors/mail/_lib.py
+++ b/intelmq/bots/collectors/mail/_lib.py
@@ -29,6 +29,7 @@ class MailCollectorBot(CollectorBot):
     sent_to = None
     sent_from = None
     subject_regex = None
+    http_verify_cert: bool = True
 
     def init(self):
         if imbox is None:
@@ -41,8 +42,11 @@ class MailCollectorBot(CollectorBot):
 
     def connect_mailbox(self):
         self.logger.debug("Connecting to %s.", self.mail_host)
-        ca_file = self.ssl_ca_certificate
-        ssl_custom_context = ssl.create_default_context(cafile=ca_file)
+        if self.http_verify_cert is True:
+            ca_file = self.ssl_ca_certificate
+            ssl_custom_context = ssl.create_default_context(cafile=ca_file)
+        else:
+            ssl_custom_context = ssl._create_unverified_context()
         mailbox = imbox.Imbox(self.mail_host,
                               self.mail_user,
                               self.mail_password,


### PR DESCRIPTION
use existing standard http_verify_cert parameter to determine if
certificate should be checked or not.
default (backwards-compatible) is to verify the server certificate

cc @th-certbund 