### PR TITLE
ENH: utils: list_bots: strip descriptions

### DIFF
--- a/intelmq/lib/utils.py
+++ b/intelmq/lib/utils.py
@@ -876,7 +876,7 @@ def list_all_bots() -> dict:
 
             bots[file.parts[2].capitalize()[:-1]][name] = {
                 "module": mod.__name__,
-                "description": "Missing description" if not getattr(mod.BOT, '__doc__', None) else textwrap.dedent(mod.BOT.__doc__),
+                "description": "Missing description" if not getattr(mod.BOT, '__doc__', None) else textwrap.dedent(mod.BOT.__doc__).strip(),
                 "parameters": keys,
             }
     return bots


### PR DESCRIPTION
some bots' doc string contain newlines at the beginning or the end of
the string depending on how the comment is formatted. These newlines are
just confusing in the UI, so remove them.