### PR TITLE
ENH: small refactor of upgrade functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ CHANGELOG
 ### Core
 - `intelmq.lib.upgrades`:
   - Refactor upgrade functions global configuration handling removing the old-style defaults configuration (PR#2058 by Sebastian Wagner).
+  - Pass version history as parameter to upgrade functions (PR#2058 by Sebastian Wagner).
 
 ### Development
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ CHANGELOG
 ### Configuration
 
 ### Core
+- `intelmq.lib.upgrades`:
+  - Refactor upgrade functions global configuration handling removing the old-style defaults configuration (PR#2058 by Sebastian Wagner).
 
 ### Development
 

--- a/docs/user/upgrade.rst
+++ b/docs/user/upgrade.rst
@@ -120,7 +120,11 @@ Check your installation and configuration to detect any problems:
    intelmqctl upgrade-config
    intelmqctl check
 
-## Start IntelMQ
+``intelmqctl upgrade-config`` supports upgrades from one IntelMQ version to the succeeding.
+If you skip one or more IntelMQ versions, some automatic upgrades *may not* work and manual intervention *may* be necessary.
+
+Start IntelMQ
+-------------
 
 .. code-block:: bash
 

--- a/intelmq/bin/intelmqctl.py
+++ b/intelmq/bin/intelmqctl.py
@@ -1671,7 +1671,8 @@ Get some debugging output on the settings and the environment (to be extended):
                 return 1, 'error'
             try:
                 retval, runtime_new, harmonization_new = getattr(
-                    upgrades, function)(runtime, harmonization, dry_run)
+                    upgrades, function)(runtime, harmonization, dry_run,
+                                        version_history=state['version_history'])
                 # Handle changed configurations
                 if retval is True and not dry_run:
                     utils.write_configuration(RUNTIME_CONF_FILE, runtime_new,
@@ -1777,7 +1778,8 @@ Get some debugging output on the settings and the environment (to be extended):
                               "time": datetime.datetime.now().isoformat()
                               }
                     try:
-                        retval, runtime, harmonization = function(runtime, harmonization, dry_run)
+                        retval, runtime, harmonization = function(runtime, harmonization, dry_run,
+                                                                  version_history=state['version_history'])
                     except Exception:
                         self.logger.exception('%s: Upgrade failed, please report this bug '
                                               'with the traceback.', docstring)

--- a/intelmq/tests/lib/test_upgrades.py
+++ b/intelmq/tests/lib/test_upgrades.py
@@ -13,7 +13,8 @@ import intelmq.lib.upgrades as upgrades
 from intelmq.lib.utils import load_configuration
 
 
-V202 = {"test-collector": {
+V202 = {"global": {},
+"test-collector": {
     "group": "Collector",
     "module": "intelmq.bots.collectors.http.collector_http",
     "parameters": {
@@ -34,7 +35,8 @@ V202 = {"test-collector": {
     },
 },
 }
-V202_EXP = {"test-collector": {
+V202_EXP = {"global": {},
+"test-collector": {
     "group": "Collector",
     "module": "intelmq.bots.collectors.http.collector_http",
     "parameters": {
@@ -58,7 +60,8 @@ V202_EXP = {"test-collector": {
 },
 }
 
-DEP_110 = {"n6-collector": {
+DEP_110 = {"global": {},
+"n6-collector": {
     "group": "Collector",
     "module": "intelmq.bots.collectors.n6.collector_stomp",
     "parameters": {
@@ -79,7 +82,8 @@ DEP_110 = {"n6-collector": {
     },
 }
 }
-DEP_110_EXP = {"n6-collector": {
+DEP_110_EXP = {"global": {},
+"n6-collector": {
     "group": "Collector",
     "module": "intelmq.bots.collectors.stomp.collector",
     "parameters": {
@@ -99,7 +103,8 @@ DEP_110_EXP = {"n6-collector": {
         "query_ripe_stat_ip": True,
     },
 }}
-V210 = {"test-collector": {
+V210 = {"global": {},
+"test-collector": {
     "group": "Collector",
     "module": "intelmq.bots.collectors.rt.collector_rt",
     "parameters": {
@@ -148,7 +153,8 @@ V210 = {"test-collector": {
     }
 }
 }
-V210_EXP = {"test-collector": {
+V210_EXP = {"global": {},
+"test-collector": {
     "group": "Collector",
     "module": "intelmq.bots.collectors.rt.collector_rt",
     "parameters": {
@@ -199,7 +205,8 @@ V210_EXP = {"test-collector": {
     }
 }
 }
-V213 = {"mail-collector": {
+V213 = {"global": {},
+"mail-collector": {
     "group": "Collector",
     "module": "intelmq.bots.collectors.mail.collector_mail_attach",
     "parameters": {
@@ -215,7 +222,8 @@ V213 = {"mail-collector": {
     }
 }
 }
-V213_EXP = {"mail-collector": {
+V213_EXP = {"global": {},
+"mail-collector": {
     "group": "Collector",
     "module": "intelmq.bots.collectors.mail.collector_mail_attach",
     "parameters": {
@@ -231,26 +239,28 @@ V213_EXP = {"mail-collector": {
 }
 }
 V220_MISP_VERIFY_FALSE = {
+"global": {"http_verify_cert": True},
 "misp-collector": {
         "module": "intelmq.bots.collectors.misp.collector",
         "parameters": {
                 "misp_verify": False}}}
 V220_MISP_VERIFY_NULL = {
+"global": {"http_verify_cert": True},
 "misp-collector": {
         "module": "intelmq.bots.collectors.misp.collector",
         "parameters": {}}}
 V220_MISP_VERIFY_TRUE = {
+"global": {"http_verify_cert": True},
 "misp-collector": {
         "module": "intelmq.bots.collectors.misp.collector",
         "parameters": {
                 "misp_verify": True}}}
 V220_HTTP_VERIFY_FALSE = {
+"global": {"http_verify_cert": True},
 "misp-collector": {
         "module": "intelmq.bots.collectors.misp.collector",
         "parameters": {
                 "http_verify_cert": False}}}
-DEFAULTS_HTTP_VERIFY_TRUE = {
-        "http_verify_cert": True}
 HARM = load_configuration(pkg_resources.resource_filename('intelmq',
                                                           'etc/harmonization.conf'))
 V210_HARM = deepcopy(HARM)
@@ -261,7 +271,8 @@ WRONG_TYPE = deepcopy(HARM)
 WRONG_TYPE['event']['source.asn']['type'] = 'String'
 WRONG_REGEX = deepcopy(HARM)
 WRONG_REGEX['event']['protocol.transport']['iregex'] = 'foobar'
-V213_FEED = {"zeus-collector": {
+V213_FEED = {"global": {},
+"zeus-collector": {
     "group": "Collector",
     "module": "intelmq.bots.collectors.http.collector_http",
     "parameters": {
@@ -336,7 +347,7 @@ V213_FEED = {"zeus-collector": {
     "module": "intelmq.bots.parsers.nothink.parser",
 },
 }
-V220_FEED = {
+V220_FEED = {"global": {},
 "urlvir-hosts-collector": {
     "group": "Collector",
     "module": "intelmq.bots.collectors.http.collector_http",
@@ -349,7 +360,7 @@ V220_FEED = {
     "module": "intelmq.bots.parsers.urlvir.parser",
 },
 }
-V221_FEED = {
+V221_FEED = {"global": {},
 "abusech-urlhaus-columns-string-parser": {
     "parameters": {
         "column_regex_search": {},
@@ -385,7 +396,7 @@ V221_FEED = {
     "module": "intelmq.bots.parsers.generic.parser_csv",
 }
 }
-V221_FEED_OUT = {
+V221_FEED_OUT = {"global": {},
 "abusech-urlhaus-columns-string-parser": {
     "parameters": {
         "column_regex_search": {},
@@ -405,7 +416,7 @@ V221_FEED_OUT = {
 }
 }
 V221_FEED_OUT['abusech-urlhaus-columns-dict-parser'] = V221_FEED_OUT['abusech-urlhaus-columns-string-parser']
-V221_FEED_2 = {
+V221_FEED_2 = {"global": {},
 "hphosts-collector": {
     "group": "Collector",
     "module": "intelmq.bots.collectors.http.collector_http",
@@ -419,17 +430,20 @@ V221_FEED_2 = {
 },
 }
 V222 = {
+"global": {},
 "shadowserver-parser": {
     "module": "intelmq.bots.parsers.shadowserver.parser",
     "parameters": {
         "feedname": "Blacklisted-IP"}}}
 V222_OUT = {
+"global": {},
 "shadowserver-parser": {
     "module": "intelmq.bots.parsers.shadowserver.parser",
     "parameters": {
         "feedname": "Blocklist"}}}
 
 V230_IN = {
+"global": {},
 "urlhaus-parser": {
     "module": "intelmq.bots.parsers.generic.parser_csv",
     "parameters": {
@@ -438,6 +452,7 @@ V230_IN = {
 }
 }
 V230_IN_BOTH = {
+"global": {},
 "urlhaus-parser": {
     "module": "intelmq.bots.parsers.generic.parser_csv",
     "parameters": {
@@ -447,6 +462,7 @@ V230_IN_BOTH = {
 }
 }
 V230_OUT = {
+"global": {},
 "urlhaus-parser": {
     "module": "intelmq.bots.parsers.generic.parser_csv",
     "parameters": {
@@ -455,6 +471,7 @@ V230_OUT = {
 }
 }
 V230_MALWAREDOMAINLIST_IN = {
+"global": {},
 "malwaredomainlist-parser": {
     "module": "intelmq.bots.parsers.malwaredomainlist.parser",
     "parameters": {
@@ -468,6 +485,7 @@ V230_MALWAREDOMAINLIST_IN = {
     }
 }
 V233_FEODOTRACKER_BROWSE_IN = {
+"global": {},
 'Feodo-tracker-browse-parser': {
     'module': "intelmq.bots.parsers.html_table.parser",
     'parameters': {
@@ -479,6 +497,7 @@ V233_FEODOTRACKER_BROWSE_IN = {
 }
 }
 V233_FEODOTRACKER_BROWSE_OUT = {
+"global": {},
 'Feodo-tracker-browse-parser': {
     'module': "intelmq.bots.parsers.html_table.parser",
     'parameters': {
@@ -490,6 +509,7 @@ V233_FEODOTRACKER_BROWSE_OUT = {
 }
 }
 V301_MALWAREDOMAINS_IN = {
+"global": {},
 "malwaredomains-parser": {
     "module": "intelmq.bots.parsers.malwaredomains.parser",
     "parameters": {
@@ -505,7 +525,7 @@ V301_MALWAREDOMAINS_IN = {
 def generate_function(function):
     def test_function(self):
         """ Test if no errors happen for upgrade function %s. """ % function.__name__
-        function({}, {}, {}, dry_run=True)
+        function({'global': {}}, {}, dry_run=True)
     return test_function
 
 
@@ -533,66 +553,64 @@ class TestUpgradeLib(unittest.TestCase):
 
     def test_v110_deprecations(self):
         """ Test v110_deprecations """
-        result = upgrades.v110_deprecations({}, DEP_110, {}, False)
+        result = upgrades.v110_deprecations(DEP_110, {}, False)
         self.assertTrue(result[0])
-        self.assertEqual(DEP_110_EXP, result[2])
+        self.assertEqual(DEP_110_EXP, result[1])
 
     def test_v202_fixes(self):
         """ Test v202_feed_name """
-        result = upgrades.v202_fixes({}, V202, {}, False)
+        result = upgrades.v202_fixes(V202, {}, False)
         self.assertTrue(result[0])
-        self.assertEqual(V202_EXP, result[2])
+        self.assertEqual(V202_EXP, result[1])
 
     def test_v210_deprecations(self):
         """ Test v210_deprecations """
-        result = upgrades.v210_deprecations({}, V210, {}, True)
+        result = upgrades.v210_deprecations(V210, {}, True)
         self.assertTrue(result[0])
-        self.assertEqual(V210_EXP, result[2])
+        self.assertEqual(V210_EXP, result[1])
 
     def test_harmonization(self):
         """ Test harmonization: Addition of extra to report """
-        result = upgrades.harmonization({}, {}, V210_HARM, False)
+        result = upgrades.harmonization({}, V210_HARM, False)
         self.assertTrue(result[0])
-        self.assertEqual(HARM, result[3])
+        self.assertEqual(HARM, result[2])
 
     def test_v220_configuration(self):
         """ Test v220_configuration. """
-        result = upgrades.v220_configuration(DEFAULTS_HTTP_VERIFY_TRUE,
-                                               V220_MISP_VERIFY_TRUE, {}, False)
+        result = upgrades.v220_configuration(V220_MISP_VERIFY_TRUE, {}, False)
         self.assertTrue(result[0])
-        self.assertEqual(V220_MISP_VERIFY_NULL, result[2])
-        result = upgrades.v220_configuration(DEFAULTS_HTTP_VERIFY_TRUE,
-                                               V220_MISP_VERIFY_FALSE, {}, False)
+        self.assertEqual(V220_MISP_VERIFY_NULL, result[1])
+        result = upgrades.v220_configuration(V220_MISP_VERIFY_FALSE, {}, False)
         self.assertTrue(result[0])
-        self.assertEqual(V220_HTTP_VERIFY_FALSE, result[2])
+        self.assertEqual(V220_HTTP_VERIFY_FALSE, result[1])
 
     def test_missing_report_harmonization(self):
         """ Test missing report in harmonization """
-        result = upgrades.harmonization({}, {}, MISSING_REPORT, False)
+        result = upgrades.harmonization({}, MISSING_REPORT, False)
         self.assertTrue(result[0])
-        self.assertEqual(HARM, result[3])
+        self.assertEqual(HARM, result[2])
 
     def test_wrong_type_harmonization(self):
         """ Test wrong type in harmonization """
-        result = upgrades.harmonization({}, {}, WRONG_TYPE, False)
+        result = upgrades.harmonization({}, WRONG_TYPE, False)
         self.assertTrue(result[0])
-        self.assertEqual(HARM, result[3])
+        self.assertEqual(HARM, result[2])
 
     def test_wrong_regex_harmonization(self):
         """ Test wrong regex in harmonization """
-        result = upgrades.harmonization({}, {}, WRONG_REGEX, False)
+        result = upgrades.harmonization({}, WRONG_REGEX, False)
         self.assertTrue(result[0])
-        self.assertEqual(HARM, result[3])
+        self.assertEqual(HARM, result[2])
 
     def test_v213_deprecations(self):
         """ Test v213_fixes """
-        result = upgrades.v213_deprecations({}, V213, {}, False)
+        result = upgrades.v213_deprecations(V213, {}, False)
         self.assertTrue(result[0])
-        self.assertEqual(V213_EXP, result[2])
+        self.assertEqual(V213_EXP, result[1])
 
     def test_v213_feed_changes(self):
         """ Test v213_feed_changes """
-        result = upgrades.v213_feed_changes({}, V213_FEED, {}, False)
+        result = upgrades.v213_feed_changes(V213_FEED, {}, False)
         self.assertEqual('A discontinued feed "Zeus Tracker" has been found '
                          'as bot zeus-collector. '
                          'The discontinued feed "Bitcash.cz" has been found '
@@ -613,91 +631,91 @@ class TestUpgradeLib(unittest.TestCase):
                          'affected bots are nothink-parser. '
                          'Remove affected bots yourself.',
                          result[0])
-        self.assertEqual(V213_FEED, result[2])
+        self.assertEqual(V213_FEED, result[1])
 
     def test_v220_feed_changes(self):
         """ Test v213_feed_changes """
-        result = upgrades.v220_feed_changes({}, V220_FEED, {}, False)
+        result = upgrades.v220_feed_changes(V220_FEED, {}, False)
         self.assertEqual('A discontinued feed "URLVir" has been found '
                          'as bot urlvir-hosts-collector. '
                          'The removed parser "URLVir" has been found '
                          'as bot urlvir-parser. '
                          'Remove affected bots yourself.',
                          result[0])
-        self.assertEqual(V220_FEED, result[2])
+        self.assertEqual(V220_FEED, result[1])
 
     def test_v221_feed_changes(self):
         """ Test v221_feeds_1 """
-        result = upgrades.v221_feed_changes({}, V221_FEED, {}, False)
+        result = upgrades.v221_feed_changes(V221_FEED, {}, False)
         self.assertTrue(result[0])
-        self.assertEqual(V221_FEED_OUT, result[2])
+        self.assertEqual(V221_FEED_OUT, result[1])
 
     def test_v221_feed_changes_2(self):
         """ Test v213_feed_changes """
-        result = upgrades.v221_feed_changes({}, V221_FEED_2, {}, False)
+        result = upgrades.v221_feed_changes(V221_FEED_2, {}, False)
         self.assertEqual('A discontinued feed "HP Hosts File" has been found '
                          'as bot hphosts-collector. '
                          'The removed parser "HP Hosts" has been found '
                          'as bot hphosts-parser. '
                          'Remove affected bots yourself.',
                          result[0])
-        self.assertEqual(V221_FEED_2, result[2])
+        self.assertEqual(V221_FEED_2, result[1])
 
     def test_v222_feed_changes(self):
         """ Test v222_feed_changes """
-        result = upgrades.v222_feed_changes({}, V222, {}, False)
+        result = upgrades.v222_feed_changes(V222, {}, False)
         self.assertTrue(result[0])
-        self.assertEqual(V222_OUT, result[2])
+        self.assertEqual(V222_OUT, result[1])
 
     def test_v230_csv_parser_parameter_fix(self):
         """ Test v230_feed_fix """
-        result = upgrades.v230_csv_parser_parameter_fix({}, V230_IN, {}, False)
+        result = upgrades.v230_csv_parser_parameter_fix(V230_IN, {}, False)
         self.assertTrue(result[0])
-        self.assertEqual(V230_OUT, result[2])
+        self.assertEqual(V230_OUT, result[1])
 
         # with also the new fixed parameter
-        result = upgrades.v230_csv_parser_parameter_fix({}, V230_IN_BOTH, {}, False)
+        result = upgrades.v230_csv_parser_parameter_fix(V230_IN_BOTH, {}, False)
         self.assertTrue(result[0])
-        self.assertEqual(V230_OUT, result[2])
+        self.assertEqual(V230_OUT, result[1])
 
         # with new parameter, no change
-        result = upgrades.v230_csv_parser_parameter_fix({}, V230_OUT, {}, False)
+        result = upgrades.v230_csv_parser_parameter_fix(V230_OUT, {}, False)
         self.assertIsNone(result[0])
-        self.assertEqual(V230_OUT, result[2])
+        self.assertEqual(V230_OUT, result[1])
 
     def test_v230_deprecations(self):
         """ Test v230_deprecations """
-        result = upgrades.v230_deprecations({}, V230_MALWAREDOMAINLIST_IN, {}, False)
+        result = upgrades.v230_deprecations(V230_MALWAREDOMAINLIST_IN, {}, False)
         self.assertTrue(result[0])
         self.assertEqual('A discontinued bot "Malware Domain List Parser" has been found as bot '
                          'malwaredomainlist-parser. Remove affected bots yourself.',
                          result[0])
-        self.assertEqual(V230_MALWAREDOMAINLIST_IN, result[2])
+        self.assertEqual(V230_MALWAREDOMAINLIST_IN, result[1])
 
     def test_v230_feed_changes(self):
         """ Test v230_feed_changes """
-        result = upgrades.v230_feed_changes({}, V230_MALWAREDOMAINLIST_IN, {}, False)
+        result = upgrades.v230_feed_changes(V230_MALWAREDOMAINLIST_IN, {}, False)
         self.assertTrue(result[0])
         self.assertEqual('A discontinued feed "Malware Domain List" has been found as bot '
                          'malwaredomainlist-collector. Remove affected bots yourself.',
                          result[0])
-        self.assertEqual(V230_MALWAREDOMAINLIST_IN, result[2])
+        self.assertEqual(V230_MALWAREDOMAINLIST_IN, result[1])
 
     def test_v233_feodotracker_browse(self):
         """ Test v233_feodotracker_browse """
-        result = upgrades.v233_feodotracker_browse({}, V233_FEODOTRACKER_BROWSE_IN, {}, False)
+        result = upgrades.v233_feodotracker_browse(V233_FEODOTRACKER_BROWSE_IN, {}, False)
         self.assertTrue(result[0])
-        self.assertEqual(V233_FEODOTRACKER_BROWSE_OUT, result[2])
+        self.assertEqual(V233_FEODOTRACKER_BROWSE_OUT, result[1])
 
     def test_v301_feed_changes(self):
         """ Test v301_feed_changes """
-        result = upgrades.v301_deprecations({}, V301_MALWAREDOMAINS_IN, {}, False)
+        result = upgrades.v301_deprecations(V301_MALWAREDOMAINS_IN, {}, False)
         self.assertTrue(result[0])
         self.assertEqual('A discontinued bot "Malware Domains Parser" has been found as bot '
                          'malwaredomains-parser. A discontinued bot "Malware Domains Collector" '
                          'has been found as bot malwaredomains-collector. Remove affected bots yourself.',
                          result[0])
-        self.assertEqual(V301_MALWAREDOMAINS_IN, result[2])
+        self.assertEqual(V301_MALWAREDOMAINS_IN, result[1])
 
 for name in upgrades.__all__:
     setattr(TestUpgradeLib, 'test_function_%s' % name,

--- a/intelmq/tests/lib/test_upgrades.py
+++ b/intelmq/tests/lib/test_upgrades.py
@@ -525,7 +525,8 @@ V301_MALWAREDOMAINS_IN = {
 def generate_function(function):
     def test_function(self):
         """ Test if no errors happen for upgrade function %s. """ % function.__name__
-        function({'global': {}}, {}, dry_run=True)
+        function({'global': {}}, {}, dry_run=True,
+                 version_history=())
     return test_function
 
 


### PR DESCRIPTION
merge defaults and runtime configuration, only using the new format with
the global parameters
add **kwargs to the upgrade functions to allow adding more paramters
without breaking the old functions
handle the global parameters in all functions and update the tests
accordingly

Independent of this change, config-upgrade issues may appear in regards
to the defaults config file if intelmq versions are skipped.

pass `version_history` to functions
this allows the upgrade functions to determine if this is a new
installation or an upgraded intelmq instance