### PR TITLE
BUG: filter: handle empty string not_after & not_before

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ CHANGELOG
 
 #### Experts
 - `intelmq.bots.experts.gethostbyname.expert`: Handle numeric values for the `gaierrors_to_ignore` parameter (PR#2073 by Sebastian Wagner, fixes #2072).
+- `intelmq.bots.experts.filter.expert`: Fix handling of empty-string parameters `not_after` and `not_before` (PR#2075 by Sebastian Wagner, fixes #2074).
 
 #### Outputs
 - `intelmq.bots.outputs.mcafee.output_esm_ip`: Fix access to parameters, the bot wrongly used `self.parameters` (by Sebastian Wagner).

--- a/intelmq/bots/experts/filter/expert.py
+++ b/intelmq/bots/experts/filter/expert.py
@@ -43,9 +43,9 @@ class FilterExpertBot(Bot):
             return absolute
 
     def init(self):
-        if self.not_after is not None:
+        if self.not_after:
             self.not_after = self.parse_timeattr(self.not_after)
-        if self.not_before is not None:
+        if self.not_before:
             self.not_before = self.parse_timeattr(self.not_before)
 
         self.filter = True

--- a/intelmq/tests/bots/experts/filter/test_empty_string_parameters.py
+++ b/intelmq/tests/bots/experts/filter/test_empty_string_parameters.py
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: 2021 Sebastian Wagner
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+# -*- coding: utf-8 -*-
+
+import unittest
+
+import intelmq.lib.test as test
+from intelmq.bots.experts.filter.expert import FilterExpertBot
+from .test_extra import EXAMPLE_INPUT
+
+
+class TestFilterExpertBot(test.BotTestCase, unittest.TestCase):
+    """
+    A TestCase for FilterExpertBot.
+    """
+
+    @classmethod
+    def set_bot(cls):
+        cls.bot_reference = FilterExpertBot
+        cls.input_message = EXAMPLE_INPUT
+        cls.sysconfig = {'filter_key': 'source.asn',
+                         'filter_value': '',
+                         'filter_action': 'drop',
+                         'not_before': '',
+                         'not_after': ''}
+
+    def test_empty_string_parameters(self):
+        self.run_bot()
+        # we actually only need to check if the bot does not fail
+        self.assertMessageEqual(0, EXAMPLE_INPUT)
+
+
+if __name__ == '__main__':  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
if any of these two parameters contained empty strings, the bot
initialization failed

fixes certtools/intelmq#2074