### PR TITLE
ctl: fix managment of bot groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,7 +61,9 @@ CHANGELOG
 - `intelmq.tests.bots.collectors.mail.test_collector_attach`: Test text attachment (by Sebastian Wagner).
 
 ### Tools
-- `intelmqctl`: Also honour parameters from environment variables (PR#2068 by Sebastian Wagner, fixes #2063).
+- `intelmqctl`:
+  - Also honour parameters from environment variables (PR#2068 by Sebastian Wagner, fixes #2063).
+  - Fix management actions (start/stop/status/reload/restart) for groups (PR#2086 by Sebastian Wagner, fixes #2085).
 
 ### Contrib
 

--- a/intelmq/bin/intelmqctl.py
+++ b/intelmq/bin/intelmqctl.py
@@ -1138,7 +1138,7 @@ Get some debugging output on the settings and the environment (to be extended):
 
     def _configured_bots_list(self, group=None):
         if group is not None:
-            bots = sorted(k_v[0] for k_v in filter(lambda x: x[1]["group"] == BOT_GROUP[group], self.runtime_configuration.items()))
+            bots = sorted(k_v[0] for k_v in filter(lambda bot: bot[0] != 'global' and bot[1]["group"] == BOT_GROUP[group], self.runtime_configuration.items()))
         else:
             bots = sorted(self.runtime_configuration.keys())
         if 'global' in bots:


### PR DESCRIPTION
the global block of the runtime configuration was not excluded in one
block, raising an exception

fixes certtools/intelmq#2085