### PR TITLE
ENH: use the upstream ansible tasks playbook

### DIFF
--- a/.github/workflows/ansible-tests.yml
+++ b/.github/workflows/ansible-tests.yml
@@ -33,4 +33,4 @@ jobs:
         path: ./src/intelmq-vagrant
 
     - name: Run ansible tests
-      run: buildah run -v ${GITHUB_WORKSPACE}/src:/src $(buildah from docker.io/debian:buster-slim) /src/intelmq/.github/workflows/scripts/ansible.sh
+      run: podman run -e CI=${CI} -v ${GITHUB_WORKSPACE}/src:/src docker.io/debian:buster-slim /src/intelmq/.github/workflows/scripts/ansible.sh

--- a/.github/workflows/scripts/ansible-playbook.yml
+++ b/.github/workflows/scripts/ansible-playbook.yml
@@ -72,25 +72,5 @@
         state: started
         name: "{{webserver}}"
 
-    # Store the intelmq version in a variable
-    - name: Get intelmq version
-      command: intelmqctl --version
-      register: intelmqversion
-    - name: Set intelmq_version fact
-      set_fact:
-        intelmq_version={{ intelmqversion.stdout }}
-    - name: Set intelmq_major_version fact
-      set_fact:
-        intelmq_major_version={{ intelmqversion.stdout[:1] }}
-    - name: Print version
-      debug:
-        msg: IntelMQ Version {{ intelmq_version }} and IntelMQ Major Version {{ intelmq_major_version }}
-
-    - name: Run configuration upgrade
-      command: intelmqctl upgrade-config -u v300_pipeline_file_removal -f
-      when:
-        intelmq_major_version == '3'
-
-    - name: Run CLI tests
-      include: "{{ item }}"
-      loop: "{{ query('fileglob', '/src/intelmq-vagrant/ansible/tasks/cli/*.yml') | sort }}"
+    - name: Run tasks
+      include: "tasks.yml"


### PR DESCRIPTION
This makes the ansible workflow follow the upstream playbook more
closely, which reduces duplicate code.
