### PR TITLE
BUG: ctl: fix default logging path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ CHANGELOG
 - `intelmqctl`:
   - Also honour parameters from environment variables (PR#2068 by Sebastian Wagner, fixes #2063).
   - Fix management actions (start/stop/status/reload/restart) for groups (PR#2086 by Sebastian Wagner, fixes #2085).
+  - Do not use hardcoded logging path in `/opt/intelmq`, use the internal default instead (PR#2092 by Sebastian Wagner, fixes #2091).
 
 ### Contrib
 

--- a/intelmq/bin/intelmqctl.py
+++ b/intelmq/bin/intelmqctl.py
@@ -704,7 +704,7 @@ class IntelMQController():
 
         # set default values for the logging handler
         self.parameters.logging_handler = 'file'
-        self.parameters.logging_path = '/opt/intelmq/var/log'
+        self.parameters.logging_path = DEFAULT_LOGGING_PATH
 
         # Try to get logging_level from defaults configuration, else use default (defined above)
         defaults_loading_exc = None


### PR DESCRIPTION
the default logging path is not opt, it's the constant from the top
`__init__.py`, which is different for deb/rpm packages

fixes certtools/intelmq#2091