### PR TITLE
Add support for new feeds to Dataplane parser

### DIFF
--- a/intelmq/bots/parsers/dataplane/parser.py
+++ b/intelmq/bots/parsers/dataplane/parser.py
@@ -8,57 +8,135 @@
 from intelmq.lib.bot import ParserBot
 from intelmq.lib.message import Event
 
+CATEGORY = {
+    'dnsrd': {
+        'classification.type': 'scanner',
+        'protocol.application': 'dns',
+        'event_description.text': 'Address has been seen performing a DNS recursion desired query to a remote host. '
+                                  'The source report lists hosts that are suspicious of more than just port '
+                                  'scanning. The host may be DNS server cataloging or searching for '
+                                  'hosts to use for DNS-based DDoS amplification.',
+    },
+    'dnsrdany': {
+        'classification.type': 'scanner',
+        'protocol.application': 'dns',
+        'event_description.text': 'Address has been seen performing a DNS recursion desired IN ANY query to a remote host. '
+                                  'The source report lists hosts that are suspicious of more than just port '
+                                  'scanning. The host may be DNS server cataloging or searching for '
+                                  'hosts to use for DNS-based DDoS amplification.',
+    },
+    'dnsversion': {
+        'classification.type': 'scanner',
+        'protocol.application': 'dns',
+        'event_description.text': 'Address has been seen initiating a DNS CH TXT version.bind operation to a remote host. '
+                                  'The source report lists hosts that are suspicious of more than just port '
+                                  'scanning. The host may be DNS server cataloging or searching for '
+                                  'vulnerable DNS servers.',
+    },
+    'proto41': {
+        'classification.type': 'proxy',
+        'protocol.application': '6to4',
+        'event_description.text': 'Address has been detected to offer open IPv6 over IPv4 tunneling. '
+                                  'This could allow for the host to be used a public proxy against IPv6 '
+                                  'hosts.',
+    },
+    'sipquery': {
+        'classification.type': 'brute-force',
+        'protocol.application': 'sip',
+        'event_description.text': 'Address has been seen initiating a SIP OPTIONS query to a remote host. '
+                                  'The source report lists hosts that are suspicious of more than just port '
+                                  'scanning. The host may be SIP server cataloging or conducting various forms '
+                                  'of telephony abuse.',
+    },
+    'sipinvitation': {
+        'classification.type': 'brute-force',
+        'protocol.application': 'sip',
+        'event_description.text': 'Address has been seen initiating a SIP INVITE operation to a remote host. '
+                                  'The source report lists hosts that are suspicious of more than just port '
+                                  'scanning. The host may be SIP client cataloging or conducting various forms '
+                                  'of telephony abuse.',
+    },
+    'sipregistration': {
+        'classification.type': 'brute-force',
+        'protocol.application': 'sip',
+        'event_description.text': 'Address has been seen initiating a SIP REGISTER operation to a remote host. '
+                                  'The source report lists hosts that are suspicious of more than just port '
+                                  'scanning. The host may be SIP client cataloging or conducting various forms '
+                                  'of telephony abuse.',
+    },
+    'smtpdata': {
+        'classification.type': 'scanner',
+        'protocol.application': 'smtp',
+        'event_description.text': 'Address has been seen initiating a SMTP DATA operation to a remote host. '
+                                  'The source report lists hosts that are suspicious of more than just port '
+                                  'scanning. The host may be SMTP server cataloging or conducting various forms '
+                                  'of email abuse.',
+    },
+    'smtpgreet': {
+        'classification.type': 'scanner',
+        'protocol.application': 'smtp',
+        'event_description.text': 'Address has been seen initiating a SMTP HELO/EHLO operation to a remote host. '
+                                  'The source report lists hosts that are suspicious of more than just port '
+                                  'scanning. The host may be SMTP server cataloging or conducting various forms '
+                                  'of email abuse.',
+    },
+    'sshclient': {
+        'classification.type': 'scanner',
+        'protocol.application': 'ssh',
+        'event_description.text': 'Address has been seen initiating an SSH connection to a remote host. The source '
+                                  'report lists hosts that are suspicious of more than just port scanning. '
+                                  'The host may be SSH server cataloging or conducting authentication attack '
+                                  'attempts.',
+    },
+    'sshpwauth': {
+        'classification.type': 'brute-force',
+        'protocol.application': 'ssh',
+        'event_description.text': 'Address has been seen attempting to remotely login to a host using SSH password '
+                                  'authentication. The source report lists hosts that are highly suspicious and '
+                                  'are likely conducting malicious SSH password authentication attacks.',
+    },
+    'telnetlogin': {
+        'classification.type': 'brute-force',
+        'protocol.application': 'telnet',
+        'event_description.text': 'Address has been seen initiating a telnet connection to a remote host. The source '
+                                  'report lists hosts that are suspicious of more than just port scanning. '
+                                  'The host may be telnet server cataloging or conducting authentication attack '
+                                  'attempts.',
+    },
+    'vncrfb': {
+        'classification.type': 'scanner',
+        'protocol.application': 'vnc',
+        'event_description.text': 'Address has been seen initiating a VNC remote buffer session to a remote host. The source '
+                                  'report lists hosts that are suspicious of more than just port scanning. '
+                                  'The host may be VNC/RFB server cataloging or conducting authentication attack '
+                                  'attempts.',
+    },
+}
 
-class DataplaneParserBot(ParserBot):
-    """Parse the Dataplane feeds"""
-    CATEGORY = {
-        'sipquery': {
-            'classification.type': 'brute-force',
-            'protocol.application': 'sip',
-            'event_description.text': 'Address has been seen initiating a SIP OPTIONS query to a remote host. '
-                                      'The source report lists hosts that are suspicious of more than just port '
-                                      'scanning. The host may be SIP server cataloging or conducting various forms '
-                                      'of telephony abuse.',
-        },
-        'sipinvitation': {
-            'classification.type': 'brute-force',
-            'protocol.application': 'sip',
-            'event_description.text': 'Address has been seen initiating a SIP INVITE operation to a remote host. '
-                                      'The source report lists hosts that are suspicious of more than just port '
-                                      'scanning. The host may be SIP client cataloging or conducting various forms '
-                                      'of telephony abuse.',
-        },
-        'sipregistration': {
-            'classification.type': 'brute-force',
-            'protocol.application': 'sip',
-            'event_description.text': 'Address has been seen initiating a SIP REGISTER operation to a remote host. '
-                                      'The source report lists hosts that are suspicious of more than just port '
-                                      'scanning. The host may be SIP client cataloging or conducting various forms '
-                                      'of telephony abuse.',
-        },
-        'sshclient': {
-            'classification.type': 'scanner',
-            'protocol.application': 'ssh',
-            'event_description.text': 'Address has been seen initiating an SSH connection to a remote host. The source '
-                                      'report lists hosts that are suspicious of more than just port scanning.  '
-                                      'The host may be SSH server cataloging or conducting authentication attack '
-                                      'attempts.',
-        },
-        'sshpwauth': {
-            'classification.type': 'brute-force',
-            'protocol.application': 'ssh',
-            'event_description.text': 'Address has been seen attempting to remotely login to a host using SSH password '
-                                      'authentication. The source report lists hosts that are highly suspicious and '
-                                      'are likely conducting malicious SSH password authentication attacks.',
-        }
-    }
 
-    FILE_FORMAT = [
+def _convert_datetime(s: str) -> str:
+    return s.replace(' ', 'T', 1) + '+00:00'
+
+
+FILE_FORMATS = {
+    '_default': [
         ('source.asn', lambda x: x if x != 'NA' else None),
         ('source.as_name', lambda x: x.split()[0] if x != 'NA' else None),
         ('source.ip', lambda x: x),
-        ('time.source', lambda x: x + '+00:00'),
-    ]
+        ('time.source', _convert_datetime),
+    ],
+    'proto41': [
+        ('source.asn', lambda x: x if x != 'NA' else None),
+        ('source.as_name', lambda x: x.split()[0] if x != 'NA' else None),
+        ('source.ip', lambda x: x),
+        ('extra.first_seen', _convert_datetime),
+        ('time.source', _convert_datetime),
+    ],
+}
+
+
+class DataplaneParserBot(ParserBot):
+    """Parse the Dataplane feeds"""
 
     def parse_line(self, line, report):
         if line.startswith('#') or len(line) == 0:
@@ -67,18 +145,21 @@ class DataplaneParserBot(ParserBot):
             event = Event(report)
 
             line_contents = line.split('|')
-            if len(line_contents) != len(self.FILE_FORMAT) + 1:
-                raise ValueError('Incorrect format for feed {}, found line: "{}"'.format(event.get('feed.url'), line))
+            feed_name = line_contents[-1].strip()
+            file_format = FILE_FORMATS.get(feed_name) or FILE_FORMATS['_default']
 
-            if line_contents[-1].strip() in self.CATEGORY:
-                event.update(self.CATEGORY[line_contents[-1].strip()])
-            else:
-                raise ValueError('Unknown data feed {}.'.format(line_contents[-1].strip()))
+            if len(line_contents) != len(file_format) + 1:
+                raise ValueError(f'Incorrect format for feed {event.get("feed.url")}, found line: "{line}"')
 
-            for field, setter in zip(line_contents, self.FILE_FORMAT):
-                value = setter[1](field.strip())
+            if feed_name not in CATEGORY:
+                raise ValueError(f'Unknown data feed {feed_name}.')
+
+            event.update(CATEGORY[feed_name])
+
+            for field, (field_name, converter) in zip(line_contents, file_format):
+                value = converter(field.strip())
                 if value is not None:
-                    event.add(setter[0], value)
+                    event.add(field_name, value)
 
             event.add('raw', line)
             yield event

--- a/intelmq/etc/feeds.yaml
+++ b/intelmq/etc/feeds.yaml
@@ -453,7 +453,7 @@ providers:
         collector:
           module: intelmq.bots.collectors.http.collector_http
           parameters:
-            http_url: http://dataplane.org/sshclient.txt
+            http_url: https://dataplane.org/sshclient.txt
             rate_limit: 3600
             name: __FEED__
             provider: __PROVIDER__
@@ -461,7 +461,7 @@ providers:
           module: intelmq.bots.parsers.dataplane.parser
           parameters:
       revision: 2018-01-20
-      documentation: http://dataplane.org/
+      documentation: https://dataplane.org/
       public: true
     SSH Password Authentication:
       description: Entries below consist of fields with identifying characteristics
@@ -474,7 +474,7 @@ providers:
         collector:
           module: intelmq.bots.collectors.http.collector_http
           parameters:
-            http_url: http://dataplane.org/sshpwauth.txt
+            http_url: https://dataplane.org/sshpwauth.txt
             rate_limit: 3600
             name: __FEED__
             provider: __PROVIDER__
@@ -482,7 +482,7 @@ providers:
           module: intelmq.bots.parsers.dataplane.parser
           parameters:
       revision: 2018-01-20
-      documentation: http://dataplane.org/
+      documentation: https://dataplane.org/
       public: true
     SIP Query:
       description: Entries consist of fields with identifying characteristics of a
@@ -495,7 +495,7 @@ providers:
         collector:
           module: intelmq.bots.collectors.http.collector_http
           parameters:
-            http_url: http://dataplane.org/sipquery.txt
+            http_url: https://dataplane.org/sipquery.txt
             rate_limit: 3600
             name: __FEED__
             provider: __PROVIDER__
@@ -503,7 +503,7 @@ providers:
           module: intelmq.bots.parsers.dataplane.parser
           parameters:
       revision: 2018-01-20
-      documentation: http://dataplane.org/
+      documentation: https://dataplane.org/
       public: true
     SIP Registration:
       description: Entries consist of fields with identifying characteristics of a
@@ -516,7 +516,7 @@ providers:
         collector:
           module: intelmq.bots.collectors.http.collector_http
           parameters:
-            http_url: http://dataplane.org/sipregistration.txt
+            http_url: https://dataplane.org/sipregistration.txt
             rate_limit: 3600
             name: __FEED__
             provider: __PROVIDER__
@@ -524,7 +524,173 @@ providers:
           module: intelmq.bots.parsers.dataplane.parser
           parameters:
       revision: 2018-01-20
-      documentation: http://dataplane.org/
+      documentation: https://dataplane.org/
+      public: true
+    DNS Recursion Desired:
+      description: Entries consist of fields with identifying characteristics of a
+        source IP address that has been seen performing a DNS recursion desired query
+        to a remote host. This report lists hosts that are suspicious of more than just
+        port scanning. The host may be DNS server cataloging or searching for hosts
+        to use for DNS-based DDoS amplification.
+      additional_information:
+      bots:
+        collector:
+          module: intelmq.bots.collectors.http.collector_http
+          parameters:
+            http_url: https://dataplane.org/dnsrd.txt
+            rate_limit: 3600
+            name: __FEED__
+            provider: __PROVIDER__
+        parser:
+          module: intelmq.bots.parsers.dataplane.parser
+          parameters:
+      revision: 2021-09-09
+      documentation: https://dataplane.org/
+      public: true
+    DNS Recursion Desired ANY:
+      description: Entries consist of fields with identifying characteristics of a
+        source IP address that has been seen performing a DNS recursion desired IN ANY query
+        to a remote host. This report lists hosts that are suspicious of more than just
+        port scanning. The host may be DNS server cataloging or searching for hosts
+        to use for DNS-based DDoS amplification.
+      additional_information:
+      bots:
+        collector:
+          module: intelmq.bots.collectors.http.collector_http
+          parameters:
+            http_url: https://dataplane.org/dnsrdany.txt
+            rate_limit: 3600
+            name: __FEED__
+            provider: __PROVIDER__
+        parser:
+          module: intelmq.bots.parsers.dataplane.parser
+          parameters:
+      revision: 2021-09-09
+      documentation: https://dataplane.org/
+      public: true
+    DNS Version:
+      description: Entries consist of fields with identifying characteristics of a
+        source IP address that has been seen performing a DNS CH TXT version.bind query
+        to a remote host. This report lists hosts that are suspicious of more than just
+        port scanning. The host may be DNS server cataloging or searching for vulnerable
+        DNS servers.
+      additional_information:
+      bots:
+        collector:
+          module: intelmq.bots.collectors.http.collector_http
+          parameters:
+            http_url: https://dataplane.org/dnsversion.txt
+            rate_limit: 3600
+            name: __FEED__
+            provider: __PROVIDER__
+        parser:
+          module: intelmq.bots.parsers.dataplane.parser
+          parameters:
+      revision: 2021-09-09
+      documentation: https://dataplane.org/
+      public: true
+    Protocol 41:
+      description: Entries consist of fields with identifying characteristics of a
+        host that has been detected to offer open IPv6 over IPv4 tunneling.
+        This could allow for the host to be used a public proxy against IPv6 hosts.
+      additional_information:
+      bots:
+        collector:
+          module: intelmq.bots.collectors.http.collector_http
+          parameters:
+            http_url: https://dataplane.org/proto41.txt
+            rate_limit: 3600
+            name: __FEED__
+            provider: __PROVIDER__
+        parser:
+          module: intelmq.bots.parsers.dataplane.parser
+          parameters:
+      revision: 2021-09-09
+      documentation: https://dataplane.org/
+      public: true
+    SMTP Greet:
+      description: Entries consist of fields with identifying characteristics of a
+        host that has been seen initiating a SMTP HELO/EHLO operation to a remote host.
+        The source report lists hosts that are suspicious of more than just port
+        scanning. The host may be SMTP server cataloging or conducting various forms
+        of email abuse.
+      additional_information:
+      bots:
+        collector:
+          module: intelmq.bots.collectors.http.collector_http
+          parameters:
+            http_url: https://dataplane.org/smtpgreet.txt
+            rate_limit: 3600
+            name: __FEED__
+            provider: __PROVIDER__
+        parser:
+          module: intelmq.bots.parsers.dataplane.parser
+          parameters:
+      revision: 2021-09-09
+      documentation: https://dataplane.org/
+      public: true
+    SMTP Data:
+      description: Entries consist of fields with identifying characteristics of a
+        host that has been seen initiating a SMTP DATA operation to a remote host.
+        The source report lists hosts that are suspicious of more than just port
+        scanning. The host may be SMTP server cataloging or conducting various forms
+        of email abuse.
+      additional_information:
+      bots:
+        collector:
+          module: intelmq.bots.collectors.http.collector_http
+          parameters:
+            http_url: https://dataplane.org/smtpdata.txt
+            rate_limit: 3600
+            name: __FEED__
+            provider: __PROVIDER__
+        parser:
+          module: intelmq.bots.parsers.dataplane.parser
+          parameters:
+      revision: 2021-09-09
+      documentation: https://dataplane.org/
+      public: true
+    Telnet Login:
+      description: Entries consist of fields with identifying characteristics of a
+        host that has been seen initiating a telnet connection to a remote host.
+        The source report lists hosts that are suspicious of more than just port
+        scanning. The host may be telnet server cataloging or conducting
+        authentication attack attempts.
+      additional_information:
+      bots:
+        collector:
+          module: intelmq.bots.collectors.http.collector_http
+          parameters:
+            http_url: https://dataplane.org/telnetlogin.txt
+            rate_limit: 3600
+            name: __FEED__
+            provider: __PROVIDER__
+        parser:
+          module: intelmq.bots.parsers.dataplane.parser
+          parameters:
+      revision: 2021-09-09
+      documentation: https://dataplane.org/
+      public: true
+    VNC/RFB Login:
+      description: Entries consist of fields with identifying characteristics of a
+        host that has been seen initiating a VNC remote buffer session to a remote host.
+        The source report lists hosts that are suspicious of more than just port
+        scanning. The host may be VNC/RFB server cataloging or conducting
+        authentication attack attempts.
+      additional_information:
+      bots:
+        collector:
+          module: intelmq.bots.collectors.http.collector_http
+          parameters:
+            http_url: https://dataplane.org/vncrfb.txt
+            rate_limit: 3600
+            name: __FEED__
+            provider: __PROVIDER__
+        parser:
+          module: intelmq.bots.parsers.dataplane.parser
+          parameters:
+      revision: 2021-09-09
+      documentation: https://dataplane.org/
       public: true
   Turris:
     Greylist:

--- a/intelmq/tests/bots/parsers/dataplane/dnsrd.txt
+++ b/intelmq/tests/bots/parsers/dataplane/dnsrd.txt
@@ -1,0 +1,65 @@
+# DataPlane.org - for operators, by operators
+# dnsrd
+# 2021-08-27 10:00 - 2021-09-03 10:00
+#
+# The dnsrd report is free for non-commercial use ONLY.  If you wish
+# to discuss commercial use of this service, please contact us at
+# info@dataplane.org.  Redistribution of the dnsrd report in whole or
+# in part without the express permission of DataPlane is expressly
+# prohibited.
+#
+# This report is made possible through the generous support of people
+# like you.  Sensor, processing, and distribution systems require
+# non-free resources to setup and maintain.  We are always looking for
+# financial contributions to help pay the bills and hosting to increase
+# visibility.  If you find what we do useful, please consider supporting
+# us.
+#
+# This report is informational.  It is not a block list, but some may
+# choose to use it to actively protect their networks and systems.  The
+# report is provided on an as-is basis with no expressed warranty or
+# guarantee of accuracy.  Use of this data is at your own risk.  If you
+# have questions about this report do not hesitate to contact us.
+#
+# Entries below are records of source IP addresses that have been
+# identified as sending recursive DNS queries.
+# Each entry is sorted according to a route originating ASN.  An entry
+# for the IP address is listed only once even if there are multiple
+# origin AS (MOAS) announcements for the covering prefix.  We use the
+# PyASN IP address to ASN mapping service to construct an origin AS
+# number and name.  For details about PyASN, see:
+#
+#   <https://pypi.org/project/pyasn/>.
+#
+# The report format is as follows:
+#
+# ASN  |  ASname  |  ipaddr  |  lastseen  |  category
+#
+# Each field is described below.  Please note any special formatting
+# rules to aid in processing this file with automated tools and scripts.
+# Blank lines may be present to improve the visual display of this file.
+# Lines beginning with a hash ('#') character are comment lines.  All
+# other lines are report entries.  Each field is separated by a pipe
+# symbol ('|') and at least two whitespace characters on either side.
+#
+#   ASN        Autonomous system number originating a route for the
+#              entry IP address. Note, 4-byte ASNs are supported and
+#              will be displayed as a 32-bit integer.  NA is shown if
+#              an origin ASN cannot be found.
+#
+#   ASname     A descriptive network name for the associated ASN.  The
+#              name is truncated to 30 characters.  NA is shown if an
+#              AS name cannot be found.
+#
+#   ipaddr     The IPv4 address that is being reported.
+#
+#   lastseen   A last seen timestamp formatted as YYYY-mm-dd HH:MM:SS
+#              in UTC time.
+#
+#   category   Descriptive tag name for this entry.  For this report,
+#              the text dnsrd will appear.
+#
+# A commented footer section shows an aggregate count of ASNs and
+# addresses seen in the current report.
+#
+174          |  COGENT-174                      |  185.142.236.35   |  2021-08-31 10:07:10  |  dnsrd

--- a/intelmq/tests/bots/parsers/dataplane/dnsrd.txt.license
+++ b/intelmq/tests/bots/parsers/dataplane/dnsrd.txt.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2021 Mikk Margus Möll <mikk@cert.ee>
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/dataplane/dnsrdany.txt
+++ b/intelmq/tests/bots/parsers/dataplane/dnsrdany.txt
@@ -1,0 +1,65 @@
+# DataPlane.org - for operators, by operators
+# dnsrdany
+# 2021-08-27 11:00 - 2021-09-03 11:00
+#
+# The dnsrdany report is free for non-commercial use ONLY.  If you wish
+# to discuss commercial use of this service, please contact us at
+# info@dataplane.org.  Redistribution of the dnsrdany report in whole or
+# in part without the express permission of DataPlane is expressly
+# prohibited.
+#
+# This report is made possible through the generous support of people
+# like you.  Sensor, processing, and distribution systems require
+# non-free resources to setup and maintain.  We are always looking for
+# financial contributions to help pay the bills and hosting to increase
+# visibility.  If you find what we do useful, please consider supporting
+# us.
+#
+# This report is informational.  It is not a block list, but some may
+# choose to use it to actively protect their networks and systems.  The
+# report is provided on an as-is basis with no expressed warranty or
+# guarantee of accuracy.  Use of this data is at your own risk.  If you
+# have questions about this report do not hesitate to contact us.
+#
+# Entries below are records of source IP addresses that have been
+# identified as sending recursive DNS IN ANY queries.
+# Each entry is sorted according to a route originating ASN.  An entry
+# for the IP address is listed only once even if there are multiple
+# origin AS (MOAS) announcements for the covering prefix.  We use the
+# PyASN IP address to ASN mapping service to construct an origin AS
+# number and name.  For details about PyASN, see:
+#
+#   <https://pypi.org/project/pyasn/>.
+#
+# The report format is as follows:
+#
+# ASN  |  ASname  |  ipaddr  |  lastseen  |  category
+#
+# Each field is described below.  Please note any special formatting
+# rules to aid in processing this file with automated tools and scripts.
+# Blank lines may be present to improve the visual display of this file.
+# Lines beginning with a hash ('#') character are comment lines.  All
+# other lines are report entries.  Each field is separated by a pipe
+# symbol ('|') and at least two whitespace characters on either side.
+#
+#   ASN        Autonomous system number originating a route for the
+#              entry IP address. Note, 4-byte ASNs are supported and
+#              will be displayed as a 32-bit integer.  NA is shown if
+#              an origin ASN cannot be found.
+#
+#   ASname     A descriptive network name for the associated ASN.  The
+#              name is truncated to 30 characters.  NA is shown if an
+#              AS name cannot be found.
+#
+#   ipaddr     The IPv4 address that is being reported.
+#
+#   lastseen   A last seen timestamp formatted as YYYY-mm-dd HH:MM:SS
+#              in UTC time.
+#
+#   category   Descriptive tag name for this entry.  For this report,
+#              the text dnsrdany will appear.
+#
+# A commented footer section shows an aggregate count of ASNs and
+# addresses seen in the current report.
+#
+209          |  CENTURYLINK-US-LEGACY-QWEST     |  63.224.250.215   |  2021-08-30 07:08:00  |  dnsrdany

--- a/intelmq/tests/bots/parsers/dataplane/dnsrdany.txt.license
+++ b/intelmq/tests/bots/parsers/dataplane/dnsrdany.txt.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2021 Mikk Margus Möll <mikk@cert.ee>
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/dataplane/dnsversion.txt
+++ b/intelmq/tests/bots/parsers/dataplane/dnsversion.txt
@@ -1,0 +1,65 @@
+# DataPlane.org - for operators, by operators
+# dnsversion
+# 2021-08-27 11:00 - 2021-09-03 11:00
+#
+# The dnsversion report is free for non-commercial use ONLY.  If you wish
+# to discuss commercial use of this service, please contact us at
+# info@dataplane.org.  Redistribution of the dnsversion report in whole or
+# in part without the express permission of DataPlane is expressly
+# prohibited.
+#
+# This report is made possible through the generous support of people
+# like you.  Sensor, processing, and distribution systems require
+# non-free resources to setup and maintain.  We are always looking for
+# financial contributions to help pay the bills and hosting to increase
+# visibility.  If you find what we do useful, please consider supporting
+# us.
+#
+# This report is informational.  It is not a block list, but some may
+# choose to use it to actively protect their networks and systems.  The
+# report is provided on an as-is basis with no expressed warranty or
+# guarantee of accuracy.  Use of this data is at your own risk.  If you
+# have questions about this report do not hesitate to contact us.
+#
+# Entries below are records of source IP addresses that have been
+# identified as sending DNS CH TXT VERSION.BIND queries.
+# Each entry is sorted according to a route originating ASN.  An entry
+# for the IP address is listed only once even if there are multiple
+# origin AS (MOAS) announcements for the covering prefix.  We use the
+# PyASN IP address to ASN mapping service to construct an origin AS
+# number and name.  For details about PyASN, see:
+#
+#   <https://pypi.org/project/pyasn/>.
+#
+# The report format is as follows:
+#
+# ASN  |  ASname  |  ipaddr  |  lastseen  |  category
+#
+# Each field is described below.  Please note any special formatting
+# rules to aid in processing this file with automated tools and scripts.
+# Blank lines may be present to improve the visual display of this file.
+# Lines beginning with a hash ('#') character are comment lines.  All
+# other lines are report entries.  Each field is separated by a pipe
+# symbol ('|') and at least two whitespace characters on either side.
+#
+#   ASN        Autonomous system number originating a route for the
+#              entry IP address. Note, 4-byte ASNs are supported and
+#              will be displayed as a 32-bit integer.  NA is shown if
+#              an origin ASN cannot be found.
+#
+#   ASname     A descriptive network name for the associated ASN.  The
+#              name is truncated to 30 characters.  NA is shown if an
+#              AS name cannot be found.
+#
+#   ipaddr     The IPv4 address that is being reported.
+#
+#   lastseen   A last seen timestamp formatted as YYYY-mm-dd HH:MM:SS
+#              in UTC time.
+#
+#   category   Descriptive tag name for this entry.  For this report,
+#              the text dnsversion will appear.
+#
+# A commented footer section shows an aggregate count of ASNs and
+# addresses seen in the current report.
+#
+174          |  COGENT-174                      |  185.142.236.35   |  2021-08-31 10:07:09  |  dnsversion

--- a/intelmq/tests/bots/parsers/dataplane/dnsversion.txt.license
+++ b/intelmq/tests/bots/parsers/dataplane/dnsversion.txt.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2021 Mikk Margus Möll <mikk@cert.ee>
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/dataplane/proto41.txt
+++ b/intelmq/tests/bots/parsers/dataplane/proto41.txt
@@ -1,0 +1,72 @@
+# DataPlane.org - for operators, by operators
+# proto41
+# 2021-08-27 08:00 - 2021-09-03 08:00
+#
+# The proto41 report is free for non-commercial use ONLY.  If you wish
+# to discuss commercial use of this service, please contact us at
+# info@dataplane.org.  Redistribution of the proto41 report in whole or
+# in part without the express permission of DataPlane is expressly
+# prohibited.
+#
+# This report is made possible through the generous support of people
+# like you.  Sensor, processing, and distribution systems require
+# non-free resources to setup and maintain.  We are always looking for
+# financial contributions to help pay the bills and hosting to increase
+# visibility.  If you find what we do useful, please consider supporting
+# us.
+#
+# This report is informational.  It is not a block list, but some may
+# choose to use it to actively protect their networks and systems.  The
+# report is provided on an as-is basis with no expressed warranty or
+# guarantee of accuracy.  Use of this data is at your own risk.  If you
+# have questions about this report do not hesitate to contact us.
+#
+# Entries below are records of source IP addresses that have been
+# identified as an open IPv4 protocol 41 relay (i.e. IPv6 over IPv4).
+# To read more about the IPv4 protocol feed see:
+#
+#   <https://dataplane.org/jtk/blog/2020/12/prot41-feed/>
+#
+# Each entry is sorted according to a route originating ASN.  An entry
+# for the IP address is listed only once even if there are multiple
+# origin AS (MOAS) announcements for the covering prefix.  We use the
+# PyASN IP address to ASN mapping service to construct an origin AS
+# number and name.  For details about PyASN, see:
+#
+#   <https://pypi.org/project/pyasn/>.
+#
+# The report format is as follows:
+#
+# ASN  |  ASname  |  ipaddr  |  firstseen  |  lastseen  |  category
+#
+# Each field is described below.  Please note any special formatting
+# rules to aid in processing this file with automated tools and scripts.
+# Blank lines may be present to improve the visual display of this file.
+# Lines beginning with a hash ('#') character are comment lines.  All
+# other lines are report entries.  Each field is separated by a pipe
+# symbol ('|') and at least two whitespace characters on either side.
+#
+#   ASN        Autonomous system number originating a route for the
+#              entry IP address. Note, 4-byte ASNs are supported and
+#              will be displayed as a 32-bit integer.  NA is shown if
+#              an origin ASN cannot be found.
+#
+#   ASname     A descriptive network name for the associated ASN.  The
+#              name is truncated to 30 characters.  NA is shown if an
+#              AS name cannot be found.
+#
+#   ipaddr     The IPv4 address that is being reported.
+#
+#   firstseen  A first seen timestamp formatted as YYYY-mm-dd HH:MM:SS
+#              in UTC time.
+#
+#   lastseen   A last seen timestamp formatted as YYYY-mm-dd HH:MM:SS
+#              in UTC time.
+#
+#   category   Descriptive tag name for this entry.  For this report,
+#              the text proto41 will appear.
+#
+# A commented footer section shows an aggregate count of ASNs and
+# addresses seen in the current report.
+#
+1            |  LVLT-1                          |  45.6.192.1       |  2021-08-28 05:00:18  |  2021-08-28 05:00:18  |  proto41

--- a/intelmq/tests/bots/parsers/dataplane/proto41.txt.license
+++ b/intelmq/tests/bots/parsers/dataplane/proto41.txt.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2021 Mikk Margus Möll <mikk@cert.ee>
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/dataplane/smtpdata.txt
+++ b/intelmq/tests/bots/parsers/dataplane/smtpdata.txt
@@ -1,0 +1,69 @@
+# DataPlane.org - for operators, by operators
+# smtpdata
+# 2021-08-27 11:00 - 2021-09-03 11:00
+#
+# The smtpdata report is free for non-commercial use ONLY.  If you wish
+# to discuss commercial use of this service, please contact us at
+# info@dataplane.org.  Redistribution of the smtpdata report in whole or
+# in part without the express permission of DataPlane is expressly
+# prohibited.
+#
+# This report is made possible through the generous support of people
+# like you.  Sensor, processing, and distribution systems require
+# non-free resources to setup and maintain.  We are always looking for
+# financial contributions to help pay the bills and hosting to increase
+# visibility.  If you find what we do useful, please consider supporting
+# us.
+#
+# This report is informational.  It is not a block list, but some may
+# choose to use it to actively protect their networks and systems.  The
+# report is provided on an as-is basis with no expressed warranty or
+# guarantee of accuracy.  Use of this data is at your own risk.  If you
+# have questions about this report do not hesitate to contact us.
+#
+# Entries below are records of source IP addresses that have been
+# identified as SMTP clients sending DATA commands.
+# To read more about the SMTP data feed see:
+#
+#   <https://dataplane.org/jtk/blog/2021/01/smtp-feeds/>
+#
+# Each entry is sorted according to a route originating ASN.  An entry
+# for the IP address is listed only once even if there are multiple
+# origin AS (MOAS) announcements for the covering prefix.  We use the
+# PyASN IP address to ASN mapping service to construct an origin AS
+# number and name.  For details about PyASN, see:
+#
+#   <https://pypi.org/project/pyasn/>.
+#
+# The report format is as follows:
+#
+# ASN  |  ASname  |  ipaddr  |  lastseen  |  category
+#
+# Each field is described below.  Please note any special formatting
+# rules to aid in processing this file with automated tools and scripts.
+# Blank lines may be present to improve the visual display of this file.
+# Lines beginning with a hash ('#') character are comment lines.  All
+# other lines are report entries.  Each field is separated by a pipe
+# symbol ('|') and at least two whitespace characters on either side.
+#
+#   ASN        Autonomous system number originating a route for the
+#              entry IP address. Note, 4-byte ASNs are supported and
+#              will be displayed as a 32-bit integer.  NA is shown if
+#              an origin ASN cannot be found.
+#
+#   ASname     A descriptive network name for the associated ASN.  The
+#              name is truncated to 30 characters.  NA is shown if an
+#              AS name cannot be found.
+#
+#   ipaddr     The IPv4 address that is being reported.
+#
+#   lastseen   A last seen timestamp formatted as YYYY-mm-dd HH:MM:SS
+#              in UTC time.
+#
+#   category   Descriptive tag name for this entry.  For this report,
+#              the text smtpdata will appear.
+#
+# A commented footer section shows an aggregate count of ASNs and
+# addresses seen in the current report.
+#
+3216         |  SOVAM-AS PJSC "Vimpelcom"       |  213.234.207.188  |  2021-08-31 13:52:46  |  smtpdata

--- a/intelmq/tests/bots/parsers/dataplane/smtpdata.txt.license
+++ b/intelmq/tests/bots/parsers/dataplane/smtpdata.txt.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2021 Mikk Margus Möll <mikk@cert.ee>
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/dataplane/smtpgreet.txt
+++ b/intelmq/tests/bots/parsers/dataplane/smtpgreet.txt
@@ -1,0 +1,69 @@
+# DataPlane.org - for operators, by operators
+# smtpgreet
+# 2021-08-27 11:00 - 2021-09-03 11:00
+#
+# The smtpgreet report is free for non-commercial use ONLY.  If you wish
+# to discuss commercial use of this service, please contact us at
+# info@dataplane.org.  Redistribution of the smtpgreet report in whole or
+# in part without the express permission of DataPlane is expressly
+# prohibited.
+#
+# This report is made possible through the generous support of people
+# like you.  Sensor, processing, and distribution systems require
+# non-free resources to setup and maintain.  We are always looking for
+# financial contributions to help pay the bills and hosting to increase
+# visibility.  If you find what we do useful, please consider supporting
+# us.
+#
+# This report is informational.  It is not a block list, but some may
+# choose to use it to actively protect their networks and systems.  The
+# report is provided on an as-is basis with no expressed warranty or
+# guarantee of accuracy.  Use of this data is at your own risk.  If you
+# have questions about this report do not hesitate to contact us.
+#
+# Entries below are records of source IP addresses that have been
+# identified as SMTP clients issuing unsolicited HELO or EHLO commands.
+# To read more about the SMTP greet feed see:
+#
+#   <https://dataplane.org/jtk/blog/2021/01/smtp-feeds/>
+#
+# Each entry is sorted according to a route originating ASN.  An entry
+# for the IP address is listed only once even if there are multiple
+# origin AS (MOAS) announcements for the covering prefix.  We use the
+# PyASN IP address to ASN mapping service to construct an origin AS
+# number and name.  For details about PyASN, see:
+#
+#   <https://pypi.org/project/pyasn/>.
+#
+# The report format is as follows:
+#
+# ASN  |  ASname  |  ipaddr  |  lastseen  |  category
+#
+# Each field is described below.  Please note any special formatting
+# rules to aid in processing this file with automated tools and scripts.
+# Blank lines may be present to improve the visual display of this file.
+# Lines beginning with a hash ('#') character are comment lines.  All
+# other lines are report entries.  Each field is separated by a pipe
+# symbol ('|') and at least two whitespace characters on either side.
+#
+#   ASN        Autonomous system number originating a route for the
+#              entry IP address. Note, 4-byte ASNs are supported and
+#              will be displayed as a 32-bit integer.  NA is shown if
+#              an origin ASN cannot be found.
+#
+#   ASname     A descriptive network name for the associated ASN.  The
+#              name is truncated to 30 characters.  NA is shown if an
+#              AS name cannot be found.
+#
+#   ipaddr     The IPv4 address that is being reported.
+#
+#   lastseen   A last seen timestamp formatted as YYYY-mm-dd HH:MM:SS
+#              in UTC time.
+#
+#   category   Descriptive tag name for this entry.  For this report,
+#              the text smtpgreet will appear.
+#
+# A commented footer section shows an aggregate count of ASNs and
+# addresses seen in the current report.
+#
+174          |  COGENT-174                      |  185.142.236.34   |  2021-09-02 16:08:38  |  smtpgreet

--- a/intelmq/tests/bots/parsers/dataplane/smtpgreet.txt.license
+++ b/intelmq/tests/bots/parsers/dataplane/smtpgreet.txt.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2021 Mikk Margus Möll <mikk@cert.ee>
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/dataplane/telnetlogin.txt
+++ b/intelmq/tests/bots/parsers/dataplane/telnetlogin.txt
@@ -1,0 +1,69 @@
+# DataPlane.org - for operators, by operators
+# telnetlogin
+# 2021-08-27 11:00 - 2021-09-03 11:00
+#
+# The telnetlogin report is free for non-commercial use ONLY.  If you wish
+# to discuss commercial use of this service, please contact us at
+# info@dataplane.org.  Redistribution of the telnetlogin report in whole or
+# in part without the express permission of DataPlane is expressly
+# prohibited.
+#
+# This report is made possible through the generous support of people
+# like you.  Sensor, processing, and distribution systems require
+# non-free resources to setup and maintain.  We are always looking for
+# financial contributions to help pay the bills and hosting to increase
+# visibility.  If you find what we do useful, please consider supporting
+# us.
+#
+# This report is informational.  It is not a block list, but some may
+# choose to use it to actively protect their networks and systems.  The
+# report is provided on an as-is basis with no expressed warranty or
+# guarantee of accuracy.  Use of this data is at your own risk.  If you
+# have questions about this report do not hesitate to contact us.
+#
+# Entries below are records of source IP addresses that have been
+# identified as attempting login via TELNET password authentication.
+# To read more about the TELNET login feed see:
+#
+#   <https://dataplane.org/jtk/blog/2021/03/telnetlogin/>
+#
+# Each entry is sorted according to a route originating ASN.  An entry
+# for the IP address is listed only once even if there are multiple
+# origin AS (MOAS) announcements for the covering prefix.  We use the
+# PyASN IP address to ASN mapping service to construct an origin AS
+# number and name.  For details about PyASN, see:
+#
+#   <https://pypi.org/project/pyasn/>.
+#
+# The report format is as follows:
+#
+# ASN  |  ASname  |  ipaddr  |  lastseen  |  category
+#
+# Each field is described below.  Please note any special formatting
+# rules to aid in processing this file with automated tools and scripts.
+# Blank lines may be present to improve the visual display of this file.
+# Lines beginning with a hash ('#') character are comment lines.  All
+# other lines are report entries.  Each field is separated by a pipe
+# symbol ('|') and at least two whitespace characters on either side.
+#
+#   ASN        Autonomous system number originating a route for the
+#              entry IP address. Note, 4-byte ASNs are supported and
+#              will be displayed as a 32-bit integer.  NA is shown if
+#              an origin ASN cannot be found.
+#
+#   ASname     A descriptive network name for the associated ASN.  The
+#              name is truncated to 30 characters.  NA is shown if an
+#              AS name cannot be found.
+#
+#   ipaddr     The IPv4 address that is being reported.
+#
+#   lastseen   A last seen timestamp formatted as YYYY-mm-dd HH:MM:SS
+#              in UTC time.
+#
+#   category   Descriptive tag name for this entry.  For this report,
+#              the text telnetlogin will appear.
+#
+# A commented footer section shows an aggregate count of ASNs and
+# addresses seen in the current report.
+#
+1            |  LVLT-1                          |  24.220.77.46     |  2021-08-31 23:50:46  |  telnetlogin

--- a/intelmq/tests/bots/parsers/dataplane/telnetlogin.txt.license
+++ b/intelmq/tests/bots/parsers/dataplane/telnetlogin.txt.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2021 Mikk Margus Möll <mikk@cert.ee>
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/dataplane/test_parser.py
+++ b/intelmq/tests/bots/parsers/dataplane/test_parser.py
@@ -10,122 +10,158 @@ import unittest
 import intelmq.lib.test as test
 import intelmq.lib.utils as utils
 
-from intelmq.bots.parsers.dataplane.parser import DataplaneParserBot
+from intelmq.bots.parsers.dataplane.parser import DataplaneParserBot, CATEGORY
 
-with open(os.path.join(os.path.dirname(__file__), 'sipinvitation.txt')) as handle:
-    SIP_INVITE_FILE = handle.read()
+feed_name_map = {
+    'dnsrd': 'DNS Recursion Desired',
+    'dnsrdany': 'DNS Recursion Desired IN ANY',
+    'dnsversion': 'DNS CH TXT version.bind',
+    'proto41': 'Protocol 41',
+    'sipquery': 'SIP Query',
+    'sipinvitation': 'SIP Invitation',
+    'sipregistration': 'SIP Registration',
+    'smtpdata': 'SMTP DATA',
+    'smtpgreet': 'SMTP HELO/EHLO',
+    'sshclient': 'SSH Client',
+    'sshpwauth': 'SSH Password Authentication',
+    'telnetlogin': 'Telnet Login',
+    'vncrfb': 'VNC/RFB Login',
+}
 
-with open(os.path.join(os.path.dirname(__file__), 'sipquery.txt')) as handle:
-    SIP_QUERY_FILE = handle.read()
+feed_names = list(feed_name_map)
 
-with open(os.path.join(os.path.dirname(__file__), 'sipregistration.txt')) as handle:
-    SIP_REGISTER_FILE = handle.read()
+file_data = {}
 
-with open(os.path.join(os.path.dirname(__file__), 'sshclient.txt')) as handle:
-    SSH_CLIENT_FILE = handle.read()
+REPORTS = {}
+for feed_name in feed_names:
+    report = {
+        'feed.url': f'https://dataplane.org/{feed_name}.txt',
+        'feed.name': feed_name_map[feed_name],
+        '__type': 'Report',
+        'time.observation': '2021-09-01T06:27:26+00:00',
+    }
 
-with open(os.path.join(os.path.dirname(__file__), 'sshpwauth.txt')) as handle:
-    SSH_AUTH_FILE = handle.read()
+    with open(os.path.join(os.path.dirname(__file__), f'{feed_name}.txt')) as fd:
+        report['raw'] = utils.base64_encode(fd.read())
 
-SIP_INVITE_REPORT = {'feed.url': 'http://dataplane.org/sipinvitation.txt',
-                     'feed.name': 'SIP Invitation',
-                     '__type': 'Report',
-                     'raw': utils.base64_encode(SIP_INVITE_FILE),
-                     'time.observation': '2016-12-07T06:27:26+00:00'
-                     }
+    REPORTS[feed_name] = report
 
-SIP_INVITE_EVENT = {'feed.url': 'http://dataplane.org/sipinvitation.txt',
-                    'feed.name': 'SIP Invitation',
-                    '__type': 'Event',
-                    'time.observation': '2016-12-07T06:27:26+00:00',
-                    'raw': 'ODU2MCAgICAgICAgIHwgIE9ORUFORE9ORS1BUyBCcmF1ZXJzdHJhc3NlIDQ4LCAgfCAgIDc0LjIwOC4xNDkuMjMxICB8ICAyMDE2LTEyLTA1IDE2OjA4OjI5ICB8ICBzaXBpbnZpdGF0aW9u',
-                    'event_description.text': 'Address has been seen initiating a SIP INVITE operation to a remote host. '
-                                              'The source report lists hosts that are suspicious of more than just port '
-                                              'scanning. The host may be SIP client cataloging or conducting various forms '
-                                              'of telephony abuse.',
-                    'source.asn': 8560,
-                    'source.ip': '74.208.149.231',
-                    'source.as_name': 'ONEANDONE-AS',
-                    'time.source': '2016-12-05T16:08:29+00:00',
-                    'protocol.application': 'sip',
-                    'classification.type': 'brute-force',
-                    }
 
-SIP_QUERY_REPORT = {'feed.url': 'http://dataplane.org/sipquery.txt',
-                    'feed.name': 'SIP Query',
-                    '__type': 'Report',
-                    'raw': utils.base64_encode(SIP_QUERY_FILE),
-                    'time.observation': '2016-12-07T06:27:26+00:00'
-                    }
+EVENTS = {feed_name: report.copy() for feed_name, report in REPORTS.items()}
 
-SIP_QUERY_EVENT = {'feed.url': 'http://dataplane.org/sipquery.txt',
-                   'feed.name': 'SIP Query',
-                   '__type': 'Event',
-                   'time.observation': '2016-12-07T06:27:26+00:00',
-                   'raw': 'MjA5ICAgICAgICAgIHwgIENFTlRVUllMSU5LLVVTLUxFR0FDWS1RV0VTVCAtICAgfCAgICAgIDY1LjE1Ny40Mi42ICB8ICAyMDE2LTEyLTA1IDE0OjAxOjIxICB8ICBzaXBxdWVyeQ==',
-                   'event_description.text': 'Address has been seen initiating a SIP OPTIONS query to a remote host. '
-                                             'The source report lists hosts that are suspicious of more than just port '
-                                             'scanning. The host may be SIP server cataloging or conducting various forms '
-                                             'of telephony abuse.',
-                   'source.asn': 209,
-                   'source.ip': '65.157.42.6',
-                   'source.as_name': 'CENTURYLINK-US-LEGACY-QWEST',
-                   'time.source': '2016-12-05T14:01:21+00:00',
-                   'protocol.application': 'sip',
-                   'classification.type': 'brute-force',
-                   }
+for feed_name, event in EVENTS.items():
+    event.update(CATEGORY[feed_name])
+    event['__type'] = 'Event'
 
-SIP_REGISTER_REPORT = {'feed.url': 'http://dataplane.org/sipregistration.txt',
-                       'feed.name': 'SIP Registration',
-                       '__type': 'Report',
-                       'raw': utils.base64_encode(SIP_REGISTER_FILE),
-                       'time.observation': '2016-12-07T06:27:26+00:00'
-                       }
+EVENTS['dnsrd'].update({
+    'raw': 'MTc0ICAgICAgICAgIHwgIENPR0VOVC0xNzQgICAgICAgICAgICAgICAgICAgICAgfCAgMTg1LjE0Mi4yMzYuMzUgICB8ICAyMDIxLTA4LTMxIDEwOjA3OjEwICB8ICBkbnNyZA==',
+    'source.as_name': 'COGENT-174',
+    'source.asn': 174,
+    'source.ip': '185.142.236.35',
+    'time.source': '2021-08-31T10:07:10+00:00',
+})
 
-SIP_REGISTER_EVENT = {'feed.url': 'http://dataplane.org/sipregistration.txt',
-                      'feed.name': 'SIP Registration',
-                      '__type': 'Event',
-                      'time.observation': '2016-12-07T06:27:26+00:00',
-                      'raw': 'ODU2MCAgICAgICAgIHwgIE9ORUFORE9ORS1BUyBCcmF1ZXJzdHJhc3NlIDQ4LCAgfCAgIDc0LjIwOC4xNTIuMjA4ICB8ICAyMDE2LTEyLTA0IDIzOjE0OjAxICB8ICBzaXByZWdpc3RyYXRpb24=',
-                      'event_description.text': 'Address has been seen initiating a SIP REGISTER operation to a remote host. '
-                                                'The source report lists hosts that are suspicious of more than just port '
-                                                'scanning. The host may be SIP client cataloging or conducting various forms '
-                                                'of telephony abuse.',
-                      'source.asn': 8560,
-                      'source.ip': '74.208.152.208',
-                      'source.as_name': 'ONEANDONE-AS',
-                      'time.source': '2016-12-04T23:14:01+00:00',
-                      'protocol.application': 'sip',
-                      'classification.type': 'brute-force',
-                      }
+EVENTS['dnsrdany'].update({
+    'raw': 'MjA5ICAgICAgICAgIHwgIENFTlRVUllMSU5LLVVTLUxFR0FDWS1RV0VTVCAgICAgfCAgNjMuMjI0LjI1MC4yMTUgICB8ICAyMDIxLTA4LTMwIDA3OjA4OjAwICB8ICBkbnNyZGFueQ==',
+    'source.as_name': 'CENTURYLINK-US-LEGACY-QWEST',
+    'source.asn': 209,
+    'source.ip': '63.224.250.215',
+    'time.source': '2021-08-30T07:08:00+00:00',
+})
 
-SSH_CLIENT_REPORT = {'feed.url': 'http://dataplane.org/sshclient.txt',
-                     'feed.name': 'SSH Client',
-                     '__type': 'Report',
-                     'raw': utils.base64_encode(SSH_CLIENT_FILE),
-                     'time.observation': '2016-12-07T06:27:26+00:00'
-                     }
+EVENTS['dnsversion'].update({
+    'raw': 'MTc0ICAgICAgICAgIHwgIENPR0VOVC0xNzQgICAgICAgICAgICAgICAgICAgICAgfCAgMTg1LjE0Mi4yMzYuMzUgICB8ICAyMDIxLTA4LTMxIDEwOjA3OjA5ICB8ICBkbnN2ZXJzaW9u',
+    'source.as_name': 'COGENT-174',
+    'source.asn': 174,
+    'source.ip': '185.142.236.35',
+    'time.source': '2021-08-31T10:07:09+00:00',
+})
 
-SSH_CLIENT_EVENT = [{'feed.url': 'http://dataplane.org/sshclient.txt',
+EVENTS['proto41'].update({
+    'extra.first_seen': '2021-08-28T05:00:18+00:00',
+    'raw': 'MSAgICAgICAgICAgIHwgIExWTFQtMSAgICAgICAgICAgICAgICAgICAgICAgICAgfCAgNDUuNi4xOTIuMSAgICAgICB8ICAyMDIxLTA4LTI4IDA1OjAwOjE4ICB8ICAyMDIxLTA4LTI4IDA1OjAwOjE4ICB8ICBwcm90bzQx',
+    'source.as_name': 'LVLT-1',
+    'source.asn': 1,
+    'source.ip': '45.6.192.1',
+    'time.source': '2021-08-28T05:00:18+00:00',
+})
+
+EVENTS['sipquery'].update({
+    'raw': 'MjA5ICAgICAgICAgIHwgIENFTlRVUllMSU5LLVVTLUxFR0FDWS1RV0VTVCAtICAgfCAgICAgIDY1LjE1Ny40Mi42ICB8ICAyMDE2LTEyLTA1IDE0OjAxOjIxICB8ICBzaXBxdWVyeQ==',
+    'source.as_name': 'CENTURYLINK-US-LEGACY-QWEST',
+    'source.asn': 209,
+    'source.ip': '65.157.42.6',
+    'time.source': '2016-12-05T14:01:21+00:00',
+})
+
+EVENTS['sipinvitation'].update({
+    'raw': 'ODU2MCAgICAgICAgIHwgIE9ORUFORE9ORS1BUyBCcmF1ZXJzdHJhc3NlIDQ4LCAgfCAgIDc0LjIwOC4xNDkuMjMxICB8ICAyMDE2LTEyLTA1IDE2OjA4OjI5ICB8ICBzaXBpbnZpdGF0aW9u',
+    'source.as_name': 'ONEANDONE-AS',
+    'source.asn': 8560,
+    'source.ip': '74.208.149.231',
+    'time.source': '2016-12-05T16:08:29+00:00',
+})
+
+EVENTS['sipregistration'].update({
+    'raw': 'ODU2MCAgICAgICAgIHwgIE9ORUFORE9ORS1BUyBCcmF1ZXJzdHJhc3NlIDQ4LCAgfCAgIDc0LjIwOC4xNTIuMjA4ICB8ICAyMDE2LTEyLTA0IDIzOjE0OjAxICB8ICBzaXByZWdpc3RyYXRpb24=',
+    'source.as_name': 'ONEANDONE-AS',
+    'source.asn': 8560,
+    'source.ip': '74.208.152.208',
+    'time.source': '2016-12-04T23:14:01+00:00',
+})
+
+EVENTS['smtpdata'].update({
+    'raw': 'MzIxNiAgICAgICAgIHwgIFNPVkFNLUFTIFBKU0MgIlZpbXBlbGNvbSIgICAgICAgfCAgMjEzLjIzNC4yMDcuMTg4ICB8ICAyMDIxLTA4LTMxIDEzOjUyOjQ2ICB8ICBzbXRwZGF0YQ==',
+    'source.as_name': 'SOVAM-AS',
+    'source.asn': 3216,
+    'source.ip': '213.234.207.188',
+    'time.source': '2021-08-31T13:52:46+00:00',
+})
+
+EVENTS['smtpgreet'].update({
+    'raw': 'MTc0ICAgICAgICAgIHwgIENPR0VOVC0xNzQgICAgICAgICAgICAgICAgICAgICAgfCAgMTg1LjE0Mi4yMzYuMzQgICB8ICAyMDIxLTA5LTAyIDE2OjA4OjM4ICB8ICBzbXRwZ3JlZXQ=',
+    'source.as_name': 'COGENT-174',
+    'source.asn': 174,
+    'source.ip': '185.142.236.34',
+    'time.source': '2021-09-02T16:08:38+00:00',
+})
+
+EVENTS['telnetlogin'].update({
+    'raw': 'MSAgICAgICAgICAgIHwgIExWTFQtMSAgICAgICAgICAgICAgICAgICAgICAgICAgfCAgMjQuMjIwLjc3LjQ2ICAgICB8ICAyMDIxLTA4LTMxIDIzOjUwOjQ2ICB8ICB0ZWxuZXRsb2dpbg==',
+    'source.as_name': 'LVLT-1',
+    'source.asn': 1,
+    'source.ip': '24.220.77.46',
+    'time.source': '2021-08-31T23:50:46+00:00',
+})
+
+EVENTS['vncrfb'].update({
+    'raw': 'MyAgICAgICAgICAgIHwgIE1JVC1HQVRFV0FZUyAgICAgICAgICAgICAgICAgICAgfCAgMTI4LjMxLjAuMTMgICAgICB8ICAyMDIxLTA5LTAzIDEwOjAzOjAzICB8ICB2bmNyZmI=',
+    'source.as_name': 'MIT-GATEWAYS',
+    'source.asn': 3,
+    'source.ip': '128.31.0.13',
+    'time.source': '2021-09-03T10:03:03+00:00',
+})
+
+SSH_CLIENT_EVENT = [{'feed.url': 'https://dataplane.org/sshclient.txt',
                      'feed.name': 'SSH Client',
                      '__type': 'Event',
                      'time.observation': '2016-12-07T06:27:26+00:00',
                      'raw': 'TkEgICAgICAgICAgIHwgIE5BICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgfCAgICAgICA1LjE1Ny43LjgyICB8ICAyMDE2LTEyLTAxIDIwOjQxOjA5ICB8ICBzc2hjbGllbnQ=',
                      'event_description.text': 'Address has been seen initiating an SSH connection to a remote host. The source '
-                                               'report lists hosts that are suspicious of more than just port scanning.  The host '
+                                               'report lists hosts that are suspicious of more than just port scanning. The host '
                                                'may be SSH server cataloging or conducting authentication attack attempts.',
                      'source.ip': '5.157.7.82',
                      'time.source': '2016-12-01T20:41:09+00:00',
                      'protocol.application': 'ssh',
                      'classification.type': 'scanner',
                      },
-                    {'feed.url': 'http://dataplane.org/sshclient.txt',
+                    {'feed.url': 'https://dataplane.org/sshclient.txt',
                      'feed.name': 'SSH Client',
                      '__type': 'Event',
                      'time.observation': '2016-12-07T06:27:26+00:00',
                      'raw': 'Mzk0NDcyICAgICAgIHwgIFNXT0ktQVNOIC0gU1dPSSwgVVMgICAgICAgICAgICAgfCAgMTA0LjI0MS4yMzIuMjM4ICB8ICAyMDE2LTEyLTA1IDAxOjQ5OjE5ICB8ICBzc2hjbGllbnQ=',
                      'event_description.text': 'Address has been seen initiating an SSH connection to a remote host. The source '
-                                               'report lists hosts that are suspicious of more than just port scanning.  The host '
+                                               'report lists hosts that are suspicious of more than just port scanning. The host '
                                                'may be SSH server cataloging or conducting authentication attack attempts.',
                      'source.asn': 394472,
                      'source.ip': '104.241.232.238',
@@ -135,14 +171,7 @@ SSH_CLIENT_EVENT = [{'feed.url': 'http://dataplane.org/sshclient.txt',
                      'classification.type': 'scanner',
                      }]
 
-SSH_AUTH_REPORT = {'feed.url': 'http://dataplane.org/sshpwauth.txt',
-                   'feed.name': 'SSH Password Authentication',
-                   '__type': 'Report',
-                   'raw': utils.base64_encode(SSH_AUTH_FILE),
-                   'time.observation': '2016-12-07T06:27:26+00:00'
-                   }
-
-SSH_AUTH_EVENT = [{'feed.url': 'http://dataplane.org/sshpwauth.txt',
+SSH_AUTH_EVENT = [{'feed.url': 'https://dataplane.org/sshpwauth.txt',
                    'feed.name': 'SSH Password Authentication',
                    '__type': 'Event',
                    'time.observation': '2016-12-07T06:27:26+00:00',
@@ -155,7 +184,7 @@ SSH_AUTH_EVENT = [{'feed.url': 'http://dataplane.org/sshpwauth.txt',
                    'protocol.application': 'ssh',
                    'classification.type': 'brute-force',
                    },
-                  {'feed.url': 'http://dataplane.org/sshpwauth.txt',
+                  {'feed.url': 'https://dataplane.org/sshpwauth.txt',
                    'feed.name': 'SSH Password Authentication',
                    '__type': 'Event',
                    'time.observation': '2016-12-07T06:27:26+00:00',
@@ -178,36 +207,28 @@ class TestDataplaneParserBot(test.BotTestCase, unittest.TestCase):
     @classmethod
     def set_bot(cls):
         cls.bot_reference = DataplaneParserBot
-        cls.default_input_message = SIP_INVITE_REPORT
 
-    def test_sip_invite(self):
-        self.run_bot()
-        self.assertMessageEqual(0, SIP_INVITE_EVENT)
-
-    def test_sip_query(self):
-        self.input_message = SIP_QUERY_REPORT
-        self.run_bot()
-        self.assertMessageEqual(0, SIP_QUERY_EVENT)
-
-    def test_sip_register(self):
-        self.input_message = SIP_REGISTER_REPORT
-        self.run_bot()
-        self.assertMessageEqual(0, SIP_REGISTER_EVENT)
+    def test_feeds(self):
+        for feed_name in set(feed_names) - {'sshclient', 'sshpwauth'}:
+            self.input_message = REPORTS[feed_name]
+            self.run_bot()
+            self.assertMessageEqual(0, EVENTS[feed_name])
 
     def test_ssh_client(self):
-        self.input_message = SSH_CLIENT_REPORT
+        self.input_message = REPORTS['sshclient']
         self.allowed_error_count = 1
         self.run_bot()
         self.allowed_error_count = 0
-        self.assertLogMatches('.*Incorrect format for feed http://dataplane.org/sshclient.txt.*', 'ERROR')
+        self.assertLogMatches('.*Incorrect format for feed https://dataplane.org/sshclient.txt.*', 'ERROR')
         self.assertMessageEqual(0, SSH_CLIENT_EVENT[0])
         self.assertMessageEqual(1, SSH_CLIENT_EVENT[1])
 
     def test_ssh_auth(self):
-        self.input_message = SSH_AUTH_REPORT
+        self.input_message = REPORTS['sshpwauth']
         self.run_bot()
         self.assertMessageEqual(0, SSH_AUTH_EVENT[0])
         self.assertMessageEqual(1, SSH_AUTH_EVENT[1])
+
 
 if __name__ == '__main__':  # pragma: no cover
     unittest.main()

--- a/intelmq/tests/bots/parsers/dataplane/vncrfb.txt
+++ b/intelmq/tests/bots/parsers/dataplane/vncrfb.txt
@@ -1,0 +1,69 @@
+# DataPlane.org - for operators, by operators
+# vncrfb
+# 2021-08-27 11:00 - 2021-09-03 11:00
+#
+# The vncrfb report is free for non-commercial use ONLY.  If you wish
+# to discuss commercial use of this service, please contact us at
+# info@dataplane.org.  Redistribution of the vncrfb report in whole or
+# in part without the express permission of DataPlane is expressly
+# prohibited.
+#
+# This report is made possible through the generous support of people
+# like you.  Sensor, processing, and distribution systems require
+# non-free resources to setup and maintain.  We are always looking for
+# financial contributions to help pay the bills and hosting to increase
+# visibility.  If you find what we do useful, please consider supporting
+# us.
+#
+# This report is informational.  It is not a block list, but some may
+# choose to use it to actively protect their networks and systems.  The
+# report is provided on an as-is basis with no expressed warranty or
+# guarantee of accuracy.  Use of this data is at your own risk.  If you
+# have questions about this report do not hesitate to contact us.
+#
+# Entries below are records of source IP addresses that have been
+# identified as initiating VNC remote frame buffer sessions.
+# To read more about VNC issues see:
+#
+#   <https://dataplane.org/vnc-tac.html>
+#
+# Each entry is sorted according to a route originating ASN.  An entry
+# for the IP address is listed only once even if there are multiple
+# origin AS (MOAS) announcements for the covering prefix.  We use the
+# PyASN IP address to ASN mapping service to construct an origin AS
+# number and name.  For details about PyASN, see:
+#
+#   <https://pypi.org/project/pyasn/>.
+#
+# The report format is as follows:
+#
+# ASN  |  ASname  |  ipaddr  |  lastseen  |  category
+#
+# Each field is described below.  Please note any special formatting
+# rules to aid in processing this file with automated tools and scripts.
+# Blank lines may be present to improve the visual display of this file.
+# Lines beginning with a hash ('#') character are comment lines.  All
+# other lines are report entries.  Each field is separated by a pipe
+# symbol ('|') and at least two whitespace characters on either side.
+#
+#   ASN        Autonomous system number originating a route for the
+#              entry IP address. Note, 4-byte ASNs are supported and
+#              will be displayed as a 32-bit integer.  NA is shown if
+#              an origin ASN cannot be found.
+#
+#   ASname     A descriptive network name for the associated ASN.  The
+#              name is truncated to 30 characters.  NA is shown if an
+#              AS name cannot be found.
+#
+#   ipaddr     The IPv4 address that is being reported.
+#
+#   lastseen   A last seen timestamp formatted as YYYY-mm-dd HH:MM:SS
+#              in UTC time.
+#
+#   category   Descriptive tag name for this entry.  For this report,
+#              the text vncrfb will appear.
+#
+# A commented footer section shows an aggregate count of ASNs and
+# addresses seen in the current report.
+#
+3            |  MIT-GATEWAYS                    |  128.31.0.13      |  2021-09-03 10:03:03  |  vncrfb

--- a/intelmq/tests/bots/parsers/dataplane/vncrfb.txt.license
+++ b/intelmq/tests/bots/parsers/dataplane/vncrfb.txt.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2021 Mikk Margus Möll <mikk@cert.ee>
+SPDX-License-Identifier: AGPL-3.0-or-later


### PR DESCRIPTION
This PR adds support for all of the currently available Dataplane feeds, i.e dns{rd{,any},version}, proto41, smtp{data,greet}, telnetlogin and vncrfb, in addition to the ones currently supported.
Some general code changes to the parser were also made.
Tests for the newly supported feeds were also added, along with a rework of the tests.