### PR TITLE
FIX: performance issue because of re-loading harmonization file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,34 @@
 CHANGELOG
 ==========
 
+3.0.2 (2021-09-09)
+------------------
+
+### Configuration
+
+### Core
+- `intelmq.lib.bot.CollectorBot`: Fixed an issue with within the `new_report` function, which re-loads the harmonization file after a new incoming dataset, which leads to cpu drain and decreased performance (PR#2106 by Sebastian Sebastian, fixes #2098).
+
+### Bots
+#### Collectors
+
+#### Parsers
+
+#### Experts
+
+#### Outputs
+
+### Documentation
+
+### Packaging
+
+### Tests
+
+### Tools
+
+### Known issues
+
+
 3.0.1 (2021-09-02)
 ------------------
 

--- a/intelmq/lib/bot.py
+++ b/intelmq/lib/bot.py
@@ -1210,7 +1210,7 @@ class CollectorBot(Bot):
         super().send_message(*messages, path=path)
 
     def new_report(self):
-        return libmessage.Report()
+        return libmessage.Report(harmonization=self.harmonization)
 
 
 class SQLBot(Bot):


### PR DESCRIPTION
The harmonization file had been loaded within each new report, this nearly kills the CPU, because it has to open the file, parse the file & load it in the memory.

