### PR TITLE
Add JSON parser function to Jinja2 templates

### DIFF
--- a/docs/user/bots.rst
+++ b/docs/user/bots.rst
@@ -4226,6 +4226,17 @@ Templates are in Jinja2 format with the event provided in the variable "event". 
 
 See the Jinja2 documentation at https://jinja.palletsprojects.com/ .
 
+As an extension to the Jinja2 environment, the function "from_json" is
+available for parsing JSON strings into Python structures. This is
+useful if you want to handle complicated structures in the "output"
+field of an event. In that case, you would start your template with a
+line like::
+
+   {%- set output = from_json(event['output']) %}
+
+and can then use "output" as a regular Python object in the rest of
+the template.
+
 Attachments are template strings, especially useful for sending
 structured data. E.g. to send a JSON document including "malware.name"
 and all other fields starting with "source."::

--- a/intelmq/bots/outputs/templated_smtp/output.py
+++ b/intelmq/bots/outputs/templated_smtp/output.py
@@ -14,6 +14,17 @@ Templates are in Jinja2 format with the event provided in the variable
 
 See the Jinja2 documentation at https://jinja.palletsprojects.com/ .
 
+As an extension to the Jinja2 environment, the function "from_json" is
+available for parsing JSON strings into Python structures. This is
+useful if you want to handle complicated structures in the "output"
+field of an event. In that case, you would start your template with a
+line like:
+
+   {%- set output = from_json(event['output']) %}
+
+and can then use "output" as a regular Python object in the rest of
+the template.
+
 Attachments are template strings, especially useful for sending
 structured data. E.g. to send a JSON document including "malware.name"
 and all other fields starting with "source.":
@@ -79,7 +90,7 @@ verify_cert: boolean, default true, whether to verify the server
 
 """
 
-import io
+import json
 import smtplib
 import ssl
 from typing import List, Optional
@@ -138,8 +149,11 @@ class TemplatedSMTPOutputBot(OutputBot):
             "from": Template(self.mail_from),
             "to": Template(self.mail_to),
             "body": Template(self.body),
-            "attachments": []
         }
+        for tmpl in self.templates.values():
+            tmpl.globals.update({"from_json": json.loads})
+
+        self.templates["attachments"] = []
         for att in self.attachments:
             if "content-type" not in att:
                 self.logger.error("Attachment does not have a content-type, ignoring: %s.", att)
@@ -155,6 +169,8 @@ class TemplatedSMTPOutputBot(OutputBot):
                 "text": Template(att["text"]),
                 "name": Template(att["name"])
             }
+            for tmpl in attachment_template.values():
+                tmpl.globals.update({"from_json": json.loads})
             self.templates["attachments"].append(attachment_template)
 
     def process(self):


### PR DESCRIPTION
In our use cases, we sometimes have some JSON data that we want to format nicely for sending to another system via e-mail. We currently do that by having entire expert bots just to format the data into a string to go in the `output` field of a message, which seems wasteful.

With this patch, the Jinja2 template environment gains a function `from_json()` (which just calls `json.loads()` in the standard Python environment), meaning the Templated SMTP output bot can take strings containing JSON documents and do the formatting itself.