### PR TITLE
DOC: feeds.yaml: fix HIBP nginx config

### DIFF
--- a/intelmq/etc/feeds.yaml
+++ b/intelmq/etc/feeds.yaml
@@ -1883,23 +1883,23 @@ providers:
         A minimal nginx configuration could look like:
             .. code-block::
 
-               server {
-                   listen 443 ssl http2;
-                   server_name [your host name];
-                   client_max_body_size 50M;
-                   
-                   ssl_certificate [path to your key];
-                   ssl_certificate_key [path to your certificate];
-                   
-                   location /[your private url] {
-                        if ($http_authorization != '[your private password]') {
-                            return 403;
-                        }
-                        proxy_pass http://localhost:5001/intelmq/push;
-                        proxy_read_timeout 30;
-                        proxy_connect_timeout 30;
-                    }
-               }
+                  server {
+                      listen 443 ssl http2;
+                      server_name [your host name];
+                      client_max_body_size 50M;
+                      
+                      ssl_certificate [path to your key];
+                      ssl_certificate_key [path to your certificate];
+                      
+                      location /[your private url] {
+                           if ($http_authorization != '[your private password]') {
+                               return 403;
+                           }
+                           proxy_pass http://localhost:5001/intelmq/push;
+                           proxy_read_timeout 30;
+                           proxy_connect_timeout 30;
+                       }
+                  }
       bots:
         collector:
           module: intelmq.bots.collectors.api.collector_api


### PR DESCRIPTION
the HIBP Enterprise feed snippet's nginx example configuration was
missing three additional whitespaces of indentation to be rendered as
code

Before:
![image](https://user-images.githubusercontent.com/199050/143778435-305aa488-9cfa-4a6c-bf48-9862c9d572bb.png)
Now:
![image](https://user-images.githubusercontent.com/199050/143778444-97de20fe-b756-48f0-9f91-87a54a90d57f.png)
