### PR TITLE
Docs: Remove dead IRC channel

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -71,7 +71,6 @@ IntelMQ is a community project depending on your contributions. Please consider 
 - Have a look at our `Developers Guide <https://intelmq.readthedocs.io/en/latest/dev/guide.html>`_ for documentation.
 - Subscribe to the `Intelmq-dev Mailing list <https://lists.cert.at/cgi-bin/mailman/listinfo/intelmq-dev>`_ to get answers to your development questions:
 - The `Github issues <https://github.com/certtools/intelmq/issues/>`_ lists all the open feature requests, bug reports and ideas.
-- Some developers are also on IRC: `channel #intelmq on irc.freenode.net <ircs://chat.freenode.net:6697/intelmq>`__.
 
 ====================================
 Incident Handling Automation Project

--- a/README.rst
+++ b/README.rst
@@ -51,6 +51,11 @@ It follows the following basic meta-guidelines:
 -  Code readability: test with unexperienced programmers
 -  Communicate clearly
 
+============
+Getting Help
+============
+
+IntelMQ's documentation is available at `intelmq.readthedocs.io <https://intelmq.readthedocs.io/>`_.
 
 For support questions please reach out on the `the intelmq-users mailing list <https://lists.cert.at/cgi-bin/mailman/listinfo/intelmq-users>`_
 

--- a/docs/user/introduction.rst
+++ b/docs/user/introduction.rst
@@ -82,6 +82,5 @@ Contribute
 **********
 
 - Subscribe to the |intelmq-developers-list-link|
-- IRC: server: irc.freenode.net, channel: \#intelmq
 - Via `GitHub issues <github.com/certtools/intelmq/issues/>`_
 - Via `Pull requests <github.com/certtools/intelmq/pulls>`_ (please have a look at the :doc:`/dev/guide` first)


### PR DESCRIPTION
- doc: remove IRC, the channel is dead
  and freenode is abandoned by the FOSS community as well
- readme: add section "getting help"