### PR TITLE
FIX: CodeQL exponential backtracking on strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,7 +94,7 @@ CHANGELOG
   - Decorator `skip_ci` also detects `dpkg-buildpackage` environments by checking the environment variable `DEB_BUILD_ARCH` (PR#2123 by Sebastian Wagner).
 - Also test on Python 3.10 (PR#2140 by Sebastian Wagner).
 - Switch from nosetests to pytest, as the former does not support Python 3.10 (PR#2140 by Sebastian Wagner).
-- CodeQL Github Actions `exponential backtracking on strings` fixed. (PR#2148 by Sebastian Waldbauer)
+- CodeQL Github Actions `exponential backtracking on strings` fixed. (PR#2148 by Sebastian Waldbauer, fixes #2138)
 
 ### Tools
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,7 @@ CHANGELOG
   - Decorator `skip_ci` also detects `dpkg-buildpackage` environments by checking the environment variable `DEB_BUILD_ARCH` (PR#2123 by Sebastian Wagner).
 - Also test on Python 3.10 (PR#2140 by Sebastian Wagner).
 - Switch from nosetests to pytest, as the former does not support Python 3.10 (PR#2140 by Sebastian Wagner).
+- CodeQL Github Actions `exponential backtracking on strings` fixed. (PR#2148 by Sebastian Waldbauer)
 
 ### Tools
 

--- a/intelmq/bots/parsers/sucuri/parser.py
+++ b/intelmq/bots/parsers/sucuri/parser.py
@@ -22,7 +22,7 @@ class MyHTMLParser(HTMLParser):
 
 
 parser = MyHTMLParser()
-remove_comments = re.compile(r"<!--(.|\s|\n)*?-->")
+remove_comments = re.compile(r"<!--.*?-->", re.DOTALL)
 
 
 class SucuriParserBot(ParserBot):


### PR DESCRIPTION
As suggested in #2138, credits @monoidic

Fixes #2138

Signed-off-by: Sebastian Waldbauer <waldbauer@cert.at>

