### PR TITLE
FIX/ENH: HttpMixin refactored and various fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,12 @@ CHANGELOG
   The `LogLevel` and `ReturnType` Enums were added to `intelmq.lib.datatypes`.
 - `intelmq.lib.bot`:
   - Enhance behaviour if an unconfigured bot is started (PR#2054 by Sebastian Wagner).
+  - Remove `http_*` variables and moved them into HTTPMixin (PR#2151 by Sebastian Waldbauer, fixes #2150).
+  - Remove `set_request_parameters` in favor of HTTPMixin (PR#2151 by Sebastian Waldbauer).
+- `intelmq.lib.mixins.http`:
+  - Added missing variables types and simplified code (PR#2151 by Sebastian Waldbauer).
+- `intelmq.lib.pipeline`:
+  - Removed trying to import requests, its a core library specified in setup.py (PR#2151 by Sebastian Waldbauer).
 
 ### Development
 
@@ -39,6 +45,10 @@ CHANGELOG
 
 #### Collectors
 - `intelmq.bots.collectors.mail._lib`: Add support for unverified SSL/STARTTLS connections (PR#2055 by Sebastian Wagner).
+- `intelmq.bots.collectors.github_api`: Removed requests dependency in favor of HttpMixin (PR#2151 by Sebastian Waldbauer).
+- `intelmq.bots.collectors.collector_azure`: Added HttpMixin (PR#2151 by Sebastian Waldbauer).
+- `intelmq.bots.collectors.shodan.collector_stream`: Removed `set_request_paramters()` in favor of HttpMixin (PR#2151 by Sebastian Waldbauer).
+
 
 #### Parsers
 - `intelmq.bots.parsers.alienvault.parser_otx`: Save CVE data in `extra.cve` instead of `extra.CVE` due to the field name restriction on lower-case characters  (PR#2059 by Sebastian Wagner).
@@ -75,12 +85,21 @@ CHANGELOG
 - `intelmq.bots.experts.truncate_by_delimiter.expert`: Cut string if its length is higher than a maximum length (PR#1967 by Marius Karotkis).
 - `intelmq.bots.experts.remove_affix`: Remove prefix or postfix strings from a field (PR#1965 by Marius Karotkis).
 - `intelmq.bots.experts.asn_lookup.expert`: Fixes update-database script on the last few days of a month (PR#2121 by Filip Pokorný, fixes #2088).
+- `intelmq.bots.experts.do_portal`: Removed requests dependency in favor of HTTPMixin (PR#2151 by Sebastian Waldbauer).
+- `intelmq.bots.experts.http.*`: Using HTTPMixin instead of `create_request_session` (PR#2151 by Sebastian Waldbauer).
+- `intelmq.bots.experts.national_cert_contact_certat`: Using HttpMixin instead of `requests` library (PR#2151 by Sebastian Waldbauer).
+- `intelmq.bots.experts.rdap`: Removed requests dependency & `create_request_session` in favor of HTTPMixin (PR#2151 by Sebastian Waldbauer).
+- `intelmq.bots.experts.ripe`: Simplified code & uses HTTPMixin (PR#2151 by Sebastian Waldbauer).
+- `intelmq.bots.experts.splunk_saved_search`: Simplified & uses HTTPMixin (PR#2151 by Sebastian Waldbauer).
+- `intelmq.bots.experts.tuency`: Removed `create_request_session` in favor of HTTPMixin (PR#2151 by Sebastian Waldbauer).
 
 #### Outputs
 - Removed `intelmq.bots.outputs.postgresql`: this bot was marked as deprecated in 2019 announced to be removed in version 3 of IntelMQ (PR#2045 by Birger Schacht).
 - Added `intelmq.bots.outputs.rpz_file.output` to create RPZ files (PR#1962 by Marius Karotkis).
 - Added `intelmq.bots.outputs.bro_file.output` to create Bro intel formatted files (PR#1963 by Marius Karotkis).
 - `intelmq.bots.outputs.templated_smtp.output`: Add new function `from_json()` (which just calls `json.loads()` in the standard Python environment), meaning the Templated SMTP output bot can take strings containing JSON documents and do the formatting itself (PR#2120 by Karl-Johan Karlsson).
+- `intelmq.bots.outputs.elasticsearch`: Uses HttpMixin (PR#2151 by Sebastian Waldbauer).
+- `intelmq.bots.outputs.restapi`: Using HttpMixin instead of importing `requests` (PR#2151 by Sebastian Waldbauer).
 
 ### Documentation
 - Feeds: Add documentation for newly supported dataplane feeds, see above (PR#2102 by Mikk Margus Möll).
@@ -95,6 +114,7 @@ CHANGELOG
 - Also test on Python 3.10 (PR#2140 by Sebastian Wagner).
 - Switch from nosetests to pytest, as the former does not support Python 3.10 (PR#2140 by Sebastian Wagner).
 - CodeQL Github Actions `exponential backtracking on strings` fixed. (PR#2148 by Sebastian Waldbauer, fixes #2138)
+- Replaced `MagicMock` & `patch` with `requests_mock` (PR#2151 by Sebastian Waldbauer).
 
 ### Tools
 

--- a/intelmq/bots/collectors/github_api/REQUIREMENTS.txt
+++ b/intelmq/bots/collectors/github_api/REQUIREMENTS.txt
@@ -1,4 +1,0 @@
-# SPDX-FileCopyrightText: 2019 Tomas Bellus
-# SPDX-License-Identifier: AGPL-3.0-or-later
-
-requests

--- a/intelmq/bots/collectors/mail/collector_mail_url.py
+++ b/intelmq/bots/collectors/mail/collector_mail_url.py
@@ -8,6 +8,7 @@ Uses the common mail iteration method from the lib file.
 """
 import io
 import re
+from requests import exceptions
 
 from intelmq.lib.mixins import HttpMixin
 from intelmq.lib.splitreports import generate_reports
@@ -50,7 +51,7 @@ class MailURLCollectorBot(MailCollectorBot, HttpMixin):
                 self.logger.info("Downloading report from %r.", url)
                 try:
                     resp = self.http_get(url)
-                except requests.exceptions.Timeout:
+                except exceptions.Timeout:
                     self.logger.error("Request timed out %i times in a row." %
                                       self.http_timeout_max_tries)
                     erroneous = True

--- a/intelmq/bots/collectors/microsoft/collector_azure.py
+++ b/intelmq/bots/collectors/microsoft/collector_azure.py
@@ -11,7 +11,7 @@ import io
 
 from intelmq.lib.bot import CollectorBot
 from intelmq.lib.exceptions import MissingDependencyError
-from intelmq.lib.mixins import CacheMixin
+from intelmq.lib.mixins import CacheMixin, HttpMixin
 
 try:
     from azure.storage.blob import ContainerClient
@@ -23,7 +23,7 @@ except ImportError:
     create_configuration = None  # noqa
 
 
-class MicrosoftAzureCollectorBot(CollectorBot, CacheMixin):
+class MicrosoftAzureCollectorBot(CollectorBot, CacheMixin, HttpMixin):
     "Fetch data blobs from a Microsoft Azure container"
     connection_string: str = "<insert your connection string here>"
     container_name: str = "<insert the container name>"

--- a/intelmq/bots/collectors/shodan/collector_stream.py
+++ b/intelmq/bots/collectors/shodan/collector_stream.py
@@ -19,6 +19,7 @@ from requests.exceptions import ChunkedEncodingError, ConnectionError
 from typing import List
 
 from intelmq.lib.bot import CollectorBot
+from intelmq.lib.mixins import HttpMixin
 
 try:
     import shodan
@@ -27,7 +28,7 @@ except ImportError:
     shodan = None
 
 
-class ShodanStreamCollectorBot(CollectorBot):
+class ShodanStreamCollectorBot(CollectorBot, HttpMixin):
     "Collect the Shodan stream from the Shodan API"
     api_key: str = "<INSERT your API key>"
     countries: List[str] = []
@@ -36,7 +37,7 @@ class ShodanStreamCollectorBot(CollectorBot):
         if shodan is None:
             raise ValueError("Library 'shodan' is needed but not installed.")
 
-        self.set_request_parameters()
+        self.setup()
         if tuple(int(v) for v in pkg_resources.get_distribution("shodan").version.split('.')) <= (1, 8, 1):
             if self.proxy:
                 raise ValueError('Proxies are given but shodan-python > 1.8.1 is needed for proxy support.')

--- a/intelmq/bots/experts/geohash/expert.py
+++ b/intelmq/bots/experts/geohash/expert.py
@@ -9,6 +9,7 @@ https://pypi.org/project/geolib/
 https://github.com/joyanujoy/geolib
 '''
 from intelmq.lib.bot import ExpertBot
+from intelmq.lib.exceptions import MissingDependencyError
 
 try:
     from geolib import geohash
@@ -23,7 +24,7 @@ class GeohashExpertBot(ExpertBot):
 
     def init(self):
         if not geohash:
-            raise ValueError("Library 'geolib' is required, please install it.")
+            raise MissingDependencyError("geolib")
 
     def process(self):
         event = self.receive_message()

--- a/intelmq/bots/experts/http/expert_content.py
+++ b/intelmq/bots/experts/http/expert_content.py
@@ -7,10 +7,10 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 from typing import List
 
 from intelmq.lib.bot import ExpertBot
-from intelmq.lib.utils import create_request_session
+from intelmq.lib.mixins import HttpMixin
 
 
-class HttpContentExpertBot(ExpertBot):
+class HttpContentExpertBot(ExpertBot, HttpMixin):
     """
     Test if a given string is part of the content for a given URL
 
@@ -29,8 +29,7 @@ class HttpContentExpertBot(ExpertBot):
     __session = None
 
     def init(self):
-        self.set_request_parameters()
-        self.__session = create_request_session(self)
+        self.__session = self.http_session()
 
     def process(self):
         event = self.receive_message()

--- a/intelmq/bots/experts/http/expert_status.py
+++ b/intelmq/bots/experts/http/expert_status.py
@@ -8,9 +8,10 @@ from typing import List
 
 from intelmq.lib.bot import ExpertBot
 from intelmq.lib.utils import create_request_session
+from intelmq.lib.mixins import HttpMixin
 
 
-class HttpStatusExpertBot(ExpertBot):
+class HttpStatusExpertBot(ExpertBot, HttpMixin):
     """
     Fetch the HTTP Status for a given URL
 
@@ -31,8 +32,7 @@ class HttpStatusExpertBot(ExpertBot):
         event = self.receive_message()
 
         if self.field in event:
-            self.set_request_parameters()
-            session = create_request_session(self)
+            session = self.http_session()
 
             try:
                 response = session.get(event[self.field])

--- a/intelmq/bots/experts/national_cert_contact_certat/expert.py
+++ b/intelmq/bots/experts/national_cert_contact_certat/expert.py
@@ -20,30 +20,22 @@ Options:
 """
 
 from intelmq.lib.bot import ExpertBot
+from intelmq.lib.mixins import HttpMixin
 from intelmq.lib.utils import create_request_session
 from intelmq.lib.exceptions import MissingDependencyError
-
-try:
-    import requests
-except ImportError:
-    requests = None
 
 
 URL = 'https://contacts.cert.at/cgi-bin/abuse-nationalcert.pl'
 
 
-class NationalCERTContactCertATExpertBot(ExpertBot):
+class NationalCERTContactCertATExpertBot(ExpertBot, HttpMixin):
     """Add country and abuse contact information from the CERT.at national CERT Contact Database. Set filter to true if you want to filter out events for Austria. Set overwrite_cc to true if you want to overwrite an existing country code value"""
     filter: bool = False
     http_verify_cert: bool = True
     overwrite_cc: bool = False
 
     def init(self):
-        if requests is None:
-            raise MissingDependencyError("requests")
-
-        self.set_request_parameters()
-        self.session = create_request_session(self)
+        self.session = self.http_session()
 
     def process(self):
         event = self.receive_message()

--- a/intelmq/bots/experts/tuency/expert.py
+++ b/intelmq/bots/experts/tuency/expert.py
@@ -17,18 +17,18 @@ Example response:
 {"ip":{"destinations":[{"source":"portal","name":"Thurner","contacts":[{"email":"test@example.vom"}]}]},"domain":{"destinations":[{"source":"portal","name":"Thurner","contacts":[{"email":"abuse@example.at"}]}]},"suppress":true,"interval":{"unit":"immediate","length":1}}
 """
 
+from intelmq.lib.mixins import HttpMixin
 from intelmq.lib.bot import ExpertBot
-from intelmq.lib.utils import create_request_session, parse_relative
+from intelmq.lib.utils import parse_relative
 
 
-class TuencyExpertBot(ExpertBot):
+class TuencyExpertBot(ExpertBot, HttpMixin):
     url: str  # Path to the tuency instance
     authentication_token: str
     overwrite: bool = True
 
     def init(self):
-        self.set_request_parameters()
-        self.session = create_request_session(self)
+        self.session = self.http_session()
         self.session.headers["Authorization"] = f"Bearer {self.authentication_token}"
         self.url = f"{self.url}intelmq/lookup"
 

--- a/intelmq/lib/bot.py
+++ b/intelmq/lib/bot.py
@@ -76,12 +76,6 @@ class Bot:
     error_max_retries: int = 3
     error_procedure: str = "pass"
     error_retry_delay: int = 15
-    http_proxy: Optional[str] = None
-    http_timeout_max_tries: int = 3
-    http_timeout_sec: int = 30
-    http_user_agent: str = "Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36"
-    http_verify_cert: Union[bool, str] = True
-    https_proxy: Optional[str] = None
     instances_threads: int = 0
     load_balance: bool = False
     log_processed_messages_count: int = 500
@@ -851,37 +845,6 @@ class Bot:
         instance = cls(parsed_args.bot_id)
         if not instance.is_multithreaded:
             instance.start()
-
-    def set_request_parameters(self):
-        self.http_header: dict = getattr(self, 'http_header', {})
-        self.http_verify_cert: bool = getattr(self, 'http_verify_cert', True)
-        self.ssl_client_cert: Optional[str] = getattr(self, 'ssl_client_certificate', None)
-
-        if (hasattr(self, 'http_username') and
-                hasattr(self, 'http_password') and
-                self.http_username):
-            self.auth = (self.http_username,
-                         self.http_password)
-        else:
-            self.auth = None
-
-        if self.http_proxy and self.https_proxy:
-            self.proxy = {'http': self.http_proxy,
-                          'https': self.https_proxy}
-        elif self.http_proxy or self.https_proxy:
-            self.logger.warning('Only %s_proxy seems to be set.'
-                                'Both http and https proxies must be set.',
-                                'http' if self.http_proxy else 'https')
-            self.proxy = {}
-        else:
-            self.proxy = {}
-
-        self.http_timeout_sec: Optional[int] = getattr(self, 'http_timeout_sec', None)
-        self.http_timeout_max_tries: int = getattr(self, 'http_timeout_max_tries', 1)
-        # Be sure this is always at least 1
-        self.http_timeout_max_tries = self.http_timeout_max_tries if self.http_timeout_max_tries >= 1 else 1
-
-        self.http_header['User-agent'] = self.http_user_agent
 
     @staticmethod
     def check(parameters: dict) -> Optional[List[List[str]]]:

--- a/intelmq/lib/mixins/http.py
+++ b/intelmq/lib/mixins/http.py
@@ -7,12 +7,8 @@ Based on `create_request_session` in intelmq.lib.utils and
 `set_request_parameters` in intelmq.lib.bot.Bot
 """
 
-from intelmq.lib.exceptions import MissingDependencyError
-
-try:
-    import requests
-except ImportError:
-    requests = None
+import requests
+from typing import Optional
 
 
 class TimeoutHTTPAdapter(requests.adapters.HTTPAdapter):
@@ -41,12 +37,12 @@ class HttpMixin:
     http_header: dict = {}
     http_user_agent: str = "Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36"
     http_verify_cert: bool = True
-    http_proxy = None
-    https_proxy = None
+    http_proxy: Optional[str] = None
+    https_proxy: Optional[str] = None
     http_timeout_max_tries: int = 3
     http_timeout_sec: int = 30
-    http_username = None
-    http_password = None
+    http_username: str = None
+    http_password: str = None
 
     def __init__(self, **kwargs):
         self.logger.debug("Running HTTP Mixin initialization.")
@@ -55,9 +51,6 @@ class HttpMixin:
 
     def setup(self):
         self.logger.debug("Setting up HTTP Mixin.")
-        if requests is None:
-            raise MissingDependencyError("requests")
-
         self.__session = requests.Session()
 
         # tls settings

--- a/intelmq/lib/pipeline.py
+++ b/intelmq/lib/pipeline.py
@@ -7,6 +7,7 @@ import time
 from itertools import chain
 from typing import Dict, Optional
 import ssl
+import requests
 
 import redis
 
@@ -18,10 +19,6 @@ __all__ = ['Pipeline', 'PipelineFactory', 'Redis', 'Pythonlist', 'Amqp']
 
 try:
     import pika
-    try:
-        import requests
-    except ImportError:
-        requests = None
 except ImportError:
     pika = None
 
@@ -588,9 +585,6 @@ class Amqp(Pipeline):
             auth = (self.username, self.password)
         else:
             auth = ('guest', 'guest')
-        if requests is None:
-            self.logger.error("Library 'requests' is needed to get queue status. Please install it.")
-            return {}
         response = requests.get(self.monitoring_url + 'api/queues', auth=auth,
                                 timeout=5)
         if response.status_code == 401:

--- a/intelmq/tests/bots/experts/ripe/test_expert.py
+++ b/intelmq/tests/bots/experts/ripe/test_expert.py
@@ -70,10 +70,10 @@ GEOLOCA_OUTPUT3 = {"__type": "Event",
                    "source.geolocation.city": "Lansing",
                    "source.geolocation.latitude": 42.7348,
                    "source.geolocation.longitude": -84.6245
-                   }
+                  }
 INDEX_ERROR = {"__type": "Event",
                "source.ip": "228.66.141.189",
-               }
+              }
 
 @test.skip_internet()
 class TestRIPEExpertBot(test.BotTestCase, unittest.TestCase):
@@ -83,7 +83,7 @@ class TestRIPEExpertBot(test.BotTestCase, unittest.TestCase):
 
     def tearDown(self):
         if self.bot is not None:
-            self.bot.http_session.close()
+            pass
 
     @classmethod
     def set_bot(cls):
@@ -94,7 +94,7 @@ class TestRIPEExpertBot(test.BotTestCase, unittest.TestCase):
                          'query_ripe_stat_asn': False,
                          'redis_cache_db': 4,
                          'query_ripe_stat_geolocation': False,
-                         }
+                        }
         cls.use_cache = True
 
     def test_db_ipv4_lookup(self):
@@ -128,7 +128,7 @@ class TestRIPEExpertBot(test.BotTestCase, unittest.TestCase):
                       'query_ripe_stat_asn': True,
                       'query_ripe_stat_ip': True,
                       'query_ripe_stat_geolocation': False,
-                      }
+                     }
         self.input_message = EMPTY_INPUT
         self.prepare_bot(parameters=parameters)
         old = self.bot.QUERY['stat']
@@ -186,11 +186,11 @@ class TestRIPEExpertBot(test.BotTestCase, unittest.TestCase):
         """ Test RIPE DB IP for errors. """
         self.input_message = EXAMPLE_INPUT
         self.prepare_bot(parameters={'query_ripe_db_asn': False,
-                                      'query_ripe_db_ip': True,
-                                      'query_ripe_stat_ip': False,
-                                      'query_ripe_stat_asn': False,
-                                      'query_ripe_stat_geolocation': False,
-                                      })
+                                     'query_ripe_db_ip': True,
+                                     'query_ripe_stat_ip': False,
+                                     'query_ripe_stat_asn': False,
+                                     'query_ripe_stat_geolocation': False,
+                                    })
         old = self.bot.QUERY['db_ip']
         self.bot.QUERY['db_ip'] = 'http://localhost/{}'
         mocker.get('/93.184.216.34', status_code=404)
@@ -211,7 +211,7 @@ class TestRIPEExpertBot(test.BotTestCase, unittest.TestCase):
                                   'query_ripe_stat_ip': True,
                                   'query_ripe_stat_asn': False,
                                   'query_ripe_stat_geolocation': False,
-                                  })
+                                })
         self.assertMessageEqual(0, EMPTY_REPLACED)
         self.assertEqual(self.cache.get('stat:127.0.0.1'), b'__no_contact')
         self.cache.flushdb()  # collides with test_ripe_stat_errors
@@ -224,7 +224,7 @@ class TestRIPEExpertBot(test.BotTestCase, unittest.TestCase):
                                   'query_ripe_stat_ip': False,
                                   'query_ripe_stat_asn': False,
                                   'query_ripe_stat_geolocation': False,
-                                  })
+                                })
         self.assertMessageEqual(0, DB_404_AS)
 
     @unittest.expectedFailure
@@ -234,7 +234,7 @@ class TestRIPEExpertBot(test.BotTestCase, unittest.TestCase):
                                   'query_ripe_db_ip': False,
                                   'query_ripe_stat_ip': False,
                                   'query_ripe_stat_asn': True,
-                                  })
+                                })
         self.assertMessageEqual(0, GEOLOCA_OUTPUT1)
 
     @unittest.expectedFailure
@@ -245,7 +245,7 @@ class TestRIPEExpertBot(test.BotTestCase, unittest.TestCase):
                                   'query_ripe_db_ip': False,
                                   'query_ripe_stat_ip': False,
                                   'query_ripe_stat_asn': True,
-                                  })
+                                })
         self.assertMessageEqual(0, GEOLOCA_OUTPUT1)
 
     @unittest.expectedFailure
@@ -255,7 +255,7 @@ class TestRIPEExpertBot(test.BotTestCase, unittest.TestCase):
                                   'query_ripe_db_ip': False,
                                   'query_ripe_stat_ip': False,
                                   'query_ripe_stat_asn': True,
-                                  })
+                                })
         self.assertMessageEqual(0, GEOLOCA_OUTPUT3)
 
     def test_index_error(self):

--- a/intelmq/tests/bots/outputs/restapi/test_output.py
+++ b/intelmq/tests/bots/outputs/restapi/test_output.py
@@ -22,6 +22,7 @@ def request_callback(expected):
     return callback
 
 
+@requests_mock.Mocker()
 class TestRestAPIOutputBot(test.BotTestCase, unittest.TestCase):
 
     @classmethod
@@ -36,26 +37,24 @@ class TestRestAPIOutputBot(test.BotTestCase, unittest.TestCase):
         cls.default_input_message = {'__type': 'Event',
                                      'source.ip': '10.0.0.1'}
 
-    @requests_mock.Mocker()
     def test_event(self, mocker):
         """
         Test if data is posted correctly to webserver.
         """
         mocker.post('http://localhost/',
                     text=request_callback({'source': {'ip': '10.0.0.1'}}),
-                    request_headers={'Authorization': 'Basic dXNlcm5hbWU6cGFzc3dvcmQ=',
-                                     'Content-Type': 'application/json; charset=utf-8'})
+                    headers={'Authorization': 'Basic dXNlcm5hbWU6cGFzc3dvcmQ=',
+                             'Content-Type': 'application/json; charset=utf-8'})
         self.run_bot()
 
-    @requests_mock.Mocker()
     def test_status_check(self, mocker):
         """
         Test if response from webserver is correctly validated.
         """
         mocker.post('http://localhost/',
-                    status_code=500,
-                    request_headers={'Authorization': 'Basic dXNlcm5hbWU6cGFzc3dvcmQ=',
-                                     'Content-Type': 'application/json; charset=utf-8'})
+                     status_code=500,
+                     headers={'Authorization': 'Basic dXNlcm5hbWU6cGFzc3dvcmQ=',
+                              'Content-Type': 'application/json; charset=utf-8'})
         self.run_bot(allowed_error_count=1)
         self.assertLogMatches('requests.exceptions.HTTPError: 500 Server Error: None for url: http://localhost/',
                               'ERROR')


### PR DESCRIPTION
**General**
Removed 'requests' MissingDependencyError, because requests is a core lib from intelmq
Removed HTTP variables from Bot class in favor of HttpMixin
Removed trying to import requests in pipeline, its a core lib from intelmq
Added additional configuration variables to HttpMixin ( from Bot class )

**Bots**
GitHub API is now using HttpMixin
MS Azure Collector is now using HttpMixin
DO-Portal Expert is now using HttpMixin
GeoHash using MissingDependencyError instead of ValueError (consistency)
HttpContentExpert is now using HttpMixin
HttpStatusExpert is now using HttpMixin
NationalCERTContactCertATExpert is now using HttpMixin
RDAPExpert is now using HttpMixin
RIPEExpert is now using HttpMixin
SplunkSavedSearchExpert is now using HttpMixin
TuencyExpert is now using HttpMixin
RestAPIOutput is now using HttpMixin

**Bot tests**
GitHub API Collector is now using requests_mock instead of MagicMock (consistency)
RestAPI Output is now using correct headers

Fixes #2150
Fixes #2137