### PR TITLE
bug: relief jinja2 version restriction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,12 +75,15 @@ CHANGELOG
 - `intelmq.bots.experts.truncate_by_delimiter.expert`: Cut string if its length is higher than a maximum length (PR#1967 by Marius Karotkis).
 - `intelmq.bots.experts.remove_affix`: Remove prefix or postfix strings from a field (PR#1965 by Marius Karotkis).
 - `intelmq.bots.experts.asn_lookup.expert`: Fixes update-database script on the last few days of a month (PR#2121 by Filip Pokorný, fixes #2088).
+- `intelmq.bots.experts.jinja2.expert`: Lift restriction on requirement jinja2 < 3 (PR#2158 by Sebastian Wagner).
 
 #### Outputs
 - Removed `intelmq.bots.outputs.postgresql`: this bot was marked as deprecated in 2019 announced to be removed in version 3 of IntelMQ (PR#2045 by Birger Schacht).
 - Added `intelmq.bots.outputs.rpz_file.output` to create RPZ files (PR#1962 by Marius Karotkis).
 - Added `intelmq.bots.outputs.bro_file.output` to create Bro intel formatted files (PR#1963 by Marius Karotkis).
-- `intelmq.bots.outputs.templated_smtp.output`: Add new function `from_json()` (which just calls `json.loads()` in the standard Python environment), meaning the Templated SMTP output bot can take strings containing JSON documents and do the formatting itself (PR#2120 by Karl-Johan Karlsson).
+- `intelmq.bots.outputs.templated_smtp.output`:
+  - Add new function `from_json()` (which just calls `json.loads()` in the standard Python environment), meaning the Templated SMTP output bot can take strings containing JSON documents and do the formatting itself (PR#2120 by Karl-Johan Karlsson).
+  - Lift restriction on requirement jinja2 < 3 (PR#2158 by Sebastian Wagner).
 
 ### Documentation
 - Feeds: Add documentation for newly supported dataplane feeds, see above (PR#2102 by Mikk Margus Möll).

--- a/intelmq/bots/experts/jinja/REQUIREMENTS.txt
+++ b/intelmq/bots/experts/jinja/REQUIREMENTS.txt
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: 2022 Sebastian Wagner <sebix@sebix.at>
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+jinja2>=2.11

--- a/intelmq/bots/experts/jinja/expert.py
+++ b/intelmq/bots/experts/jinja/expert.py
@@ -32,7 +32,7 @@ class JinjaExpertBot(Bot):
 
     def init(self):
         if not Template:
-            raise MissingDependencyError("Library 'jinja2' is required, please install it.")
+            raise MissingDependencyError("jinja2")
 
         for field, template in self.fields.items():
             if template.startswith("file:///"):

--- a/intelmq/bots/outputs/templated_smtp/REQUIREMENTS.txt
+++ b/intelmq/bots/outputs/templated_smtp/REQUIREMENTS.txt
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2021 Linköping University <https://liu.se/>
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
-jinja2>=2.11,<3
+jinja2>=2.11


### PR DESCRIPTION
jinja2 version 3 did not introduce breaking changes, so we can remove
the version restriction
add the requirement also for the jinja expert
fix error message on the required library in the jinja expert