### PR TITLE
FIX: Fixes Blueliv collector requirements

### DIFF
--- a/intelmq/bots/collectors/blueliv/REQUIREMENTS.txt
+++ b/intelmq/bots/collectors/blueliv/REQUIREMENTS.txt
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2016 Sebastian Wagner
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
-git+git://github.com/Blueliv/api-python-sdk
+git+https://github.com/Blueliv/api-python-sdk


### PR DESCRIPTION
This PR fixes the following error (when running `pip3 install -r intelmq/bots/collectors/blueliv/REQUIREMENTS.txt`):

```
Collecting git+git://github.com/Blueliv/api-python-sdk (from -r /tmp/intelmq/intelmq/bots/collectors/blueliv/REQUIREMENTS.txt (line 1))
  Cloning git://github.com/Blueliv/api-python-sdk to /tmp/pip-req-build-uiy3i5_1
  Running command git clone -q git://github.com/Blueliv/api-python-sdk /tmp/pip-req-build-uiy3i5_1
  fatal: remote error:
    The unauthenticated git protocol on port 9418 is no longer supported.
  Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
ERROR: Command errored out with exit status 128: git clone -q git://github.com/Blueliv/api-python-sdk /tmp/pip-req-build-uiy3i5_1 Check the logs for full command output.
```