### PR TITLE
SQL: add MSSQL support and allow storing only a subset of event fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ CHANGELOG
 - `intelmq.lib.message`:
   - Fix and pre-compile the regular expression for harmonization key names and also check keys in the `extra.` namespace (PR#2059 by Sebastian Wagner, fixes #1807).
 - `intelmq.lib.bot.SQLBot` was replaced by an SQLMixin in `intelmq.lib.mixins.SQLMixin`. The Generic DB Lookup Expert bot and the SQLOutput bot were updated accordingly.
+  - Added support for MSSQL (PR#2171 by Karl-Johan Karlsson).
+  - Added optional reconnect delay parameter (PR#2171 by Karl-Johan Karlsson).
 - Added an ExpertBot class - it should be used by all expert bots as a parent class
 - Introduced a module for IntelMQ related datatypes `intelmq.lib.datatypes` which for now only contains an Enum listing the four bot types
 - Added a `bottype` attribute to CollectorBot, ParserBot, ExpertBot, OutputBot

--- a/docs/user/bots.rst
+++ b/docs/user/bots.rst
@@ -4006,7 +4006,7 @@ SQL
 * `lookup:` no
 * `public:` yes
 * `cache (redis db):` none
-* `description:` SQL is the bot responsible to send events to a PostgreSQL or SQLite Database, e.g. the IntelMQ :doc:`eventdb`
+* `description:` SQL is the bot responsible to send events to a PostgreSQL, SQLite, or MSSQL Database, e.g. the IntelMQ :doc:`eventdb`
 * `notes`: When activating autocommit, transactions are not used: http://initd.org/psycopg/docs/connection.html#connection.autocommit
 
 **Configuration Parameters**
@@ -4015,15 +4015,16 @@ The parameters marked with 'PostgreSQL' will be sent to libpq via psycopg2. Chec
 
 * `autocommit`: `psycopg's autocommit mode <http://initd.org/psycopg/docs/connection.html?#connection.autocommit>`_, optional, default True
 * `connect_timeout`: Database connect_timeout, optional, default 5 seconds
-* `engine`: 'postgresql' or 'sqlite'
-* `database`: PostgreSQL database or SQLite file
-* `host`: PostgreSQL host
+* `engine`: 'postgresql', 'sqlite', or 'mssql'
+* `database`: Database or SQLite file
+* `host`: Database host
 * `jsondict_as_string`: save JSONDict fields as JSON string, boolean. Default: true (like in versions before 1.1)
-* `port`: PostgreSQL port
-* `user`: PostgreSQL user
-* `password`: PostgreSQL password
-* `sslmode`: PostgreSQL sslmode, can be `'disable'`, `'allow'`, `'prefer'` (default), `'require'`, `'verify-ca'` or `'verify-full'`. See postgresql docs: https://www.postgresql.org/docs/current/static/libpq-connect.html#libpq-connect-sslmode
+* `port`: Database port
+* `user`: Database user
+* `password`: Database password
+* `sslmode`: Database sslmode, can be `'disable'`, `'allow'`, `'prefer'` (default), `'require'`, `'verify-ca'` or `'verify-full'`. See postgresql docs: https://www.postgresql.org/docs/current/static/libpq-connect.html#libpq-connect-sslmode
 * `table`: name of the database table into which events are to be inserted
+* `fields`: list of fields to read from the event. If None, read all fields
 
 **PostgreSQL**
 

--- a/docs/user/bots.rst
+++ b/docs/user/bots.rst
@@ -4101,6 +4101,10 @@ Then, set the `database` parameter to the `your-db.db` file path.
 
 .. _intelmq.bots.outputs.stomp.output:
 
+**MSSQL**
+
+For MSSQL support, the library `pymssql>=2.2` is required.
+
 STOMP
 ^^^^^
 

--- a/docs/user/bots.rst
+++ b/docs/user/bots.rst
@@ -4025,6 +4025,7 @@ The parameters marked with 'PostgreSQL' will be sent to libpq via psycopg2. Chec
 * `sslmode`: Database sslmode, can be `'disable'`, `'allow'`, `'prefer'` (default), `'require'`, `'verify-ca'` or `'verify-full'`. See postgresql docs: https://www.postgresql.org/docs/current/static/libpq-connect.html#libpq-connect-sslmode
 * `table`: name of the database table into which events are to be inserted
 * `fields`: list of fields to read from the event. If None, read all fields
+* `reconnect_delay`: number of seconds to wait before reconnecting in case of an error
 
 **PostgreSQL**
 

--- a/intelmq/bots/outputs/sql/REQUIREMENTS.txt
+++ b/intelmq/bots/outputs/sql/REQUIREMENTS.txt
@@ -2,3 +2,4 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
 psycopg2-binary>=2.5.5
+pymssql>=2.2

--- a/intelmq/bots/outputs/sql/output.py
+++ b/intelmq/bots/outputs/sql/output.py
@@ -17,6 +17,12 @@ from intelmq.lib.bot import OutputBot
 from intelmq.lib.mixins import SQLMixin
 
 
+def itemgetter_tuple(*items):
+    def g(obj):
+        return tuple(obj[item] for item in items)
+    return g
+
+
 class SQLOutputBot(OutputBot, SQLMixin):
     """Send events to a PostgreSQL or SQLite database"""
     autocommit = True
@@ -29,6 +35,7 @@ class SQLOutputBot(OutputBot, SQLMixin):
     sslmode = "require"
     table = 'events'
     user = "intelmq"
+    fields = None
 
     def init(self):
         super().init()
@@ -36,9 +43,13 @@ class SQLOutputBot(OutputBot, SQLMixin):
     def process(self):
         event = self.receive_message().to_dict(jsondict_as_string=self.jsondict_as_string)
 
-        keys = '", "'.join(event.keys())
-        values = list(event.values())
-        fvalues = len(values) * f'{self.format_char}, '
+        key_names = self.fields
+        if key_names is None:
+            key_names = event.keys()
+        valid_keys = [key for key in key_names if key in event]
+        keys = '", "'.join(valid_keys)
+        values = itemgetter_tuple(*valid_keys)(event)
+        fvalues = len(values) * '{0}, '.format(self.format_char)
         query = ('INSERT INTO {table} ("{keys}") VALUES ({values})'
                  ''.format(table=self.table, keys=keys, values=fvalues[:-2]))
 

--- a/intelmq/lib/mixins/sql.py
+++ b/intelmq/lib/mixins/sql.py
@@ -7,6 +7,8 @@ Based on the former SQLBot base class
 """
 from intelmq.lib import exceptions
 
+from time import sleep
+
 
 class SQLMixin:
     """
@@ -24,6 +26,7 @@ class SQLMixin:
     engine = None
     # overwrite the default value from the OutputBot
     message_jsondict_as_string = True
+    reconnect_delay = 0
 
     def __init__(self, *args, **kwargs):
         self._init_sql()
@@ -121,13 +124,19 @@ class SQLMixin:
                 except self._engine.OperationalError:
                     self.logger.exception('Executed rollback command '
                                           'after failed query execution.')
+                    if self.reconnect_delay > 0:
+                        sleep(self.reconnect_delay)
                     self._init_sql()
                 except Exception:
                     self.logger.exception('Cursor has been closed, connecting '
                                           'again.')
+                    if self.reconnect_delay > 0:
+                        sleep(self.reconnect_delay)
                     self._init_sql()
             else:
                 self.logger.exception('Database connection problem, connecting again.')
+                if self.reconnect_delay > 0:
+                    sleep(self.reconnect_delay)
                 self._init_sql()
         else:
             return True


### PR DESCRIPTION
This pull request enhances IntelMQ's SQL database support in three ways:
1. Add support for MSSQL servers in the `SQLMixin` class, requiring the package `pymssql`.
2. Add a parameter `fields` to `SQLOutputBot`, containing a list of which event fields to store in the database. If this is not specified, store all fields as before.
3. Add a parameter `reconnect_delay` to `SQLMixin`, making it wait that many seconds before attempting to reconnect after a connection error.
    * We found out the need for this the hard way, when the DB server rebooted and IntelMQ's tight reconnect loop filled the entire disk with error logs before the DB server came back.