### PR TITLE
Impelment time_format enhancement to use custom time formats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,9 @@ CHANGELOG
   - SMTP Data
   - Telnet Login
   - VNC/RFB Login
+- `intelmq.bots.parsers.generic.parser_csv`:
+  - Added enhancement to parameter `time_format`. It handles specific time formats given with different format codes. 
+  Usage e.g. `time_format: 'from_format|%d-%m-%Y %H:%M:%S'` (PR#2179 by Tamas Gutsohn, fixes #2105).
 - `intelmq.bots.parsers.microsoft.parser_ctip`:
   - New parameter `overwrite` (PR#2112 by Sebastian Wagner, fixes #2022).
   - Fix handling of field `Payload.domain` if it contains the same IP address as `Payload.serverIp` (PR#2144 by Mikk Margus Möll and Sebastian Wagner).

--- a/intelmq/bots/parsers/generic/parser_csv.py
+++ b/intelmq/bots/parsers/generic/parser_csv.py
@@ -27,12 +27,13 @@ from dateutil.parser import parse
 from intelmq.lib import utils
 from intelmq.lib.bot import ParserBot
 from intelmq.lib.exceptions import InvalidArgument, InvalidValue
-from intelmq.lib.harmonization import TIME_CONVERSIONS
+from intelmq.lib.harmonization import DateTime
 
-# TIME_CONVERSIONS = {'timestamp': DateTime.from_timestamp,
-#                     'windows_nt': DateTime.from_windows_nt,
-#                     'epoch_millis': DateTime.from_epoch_millis,
-#                     None: lambda value: parse(value, fuzzy=True).isoformat() + " UTC"}
+TIME_CONVERSIONS = {'timestamp': DateTime.from_timestamp,
+                    'windows_nt': DateTime.from_windows_nt,
+                    'epoch_millis': DateTime.from_epoch_millis,
+                    'from_format': DateTime.convert_from_format,
+                    None: lambda value: parse(value, fuzzy=True).isoformat() + " UTC"}
 
 DATA_CONVERSIONS = {'json': lambda data: json.loads(data)}
 DOCS = "https://intelmq.readthedocs.io/en/latest/guides/Bots.html#generic-csv-parser"
@@ -72,6 +73,7 @@ class GenericCsvParserBot(ParserBot):
         if not self.time_format:
             self.time_format = None
         if self.time_format not in TIME_CONVERSIONS.keys():
+        # if self.time_format.split('|')[0] not in TIME_CONVERSIONS.keys():
             raise InvalidArgument('time_format', got=self.time_format,
                                   expected=list(TIME_CONVERSIONS.keys()),
                                   docs=DOCS)
@@ -139,6 +141,7 @@ class GenericCsvParserBot(ParserBot):
                     value = DATA_CONVERSIONS[self.data_type[key]](value)
 
                 if key in ("time.source", "time.destination"):
+                        # value = DateTime.convert(value=value, format=self.time_format)
                     value = TIME_CONVERSIONS[self.time_format](value)
                 elif key.endswith('.url'):
                     if not value:

--- a/intelmq/bots/parsers/generic/parser_csv.py
+++ b/intelmq/bots/parsers/generic/parser_csv.py
@@ -27,12 +27,12 @@ from dateutil.parser import parse
 from intelmq.lib import utils
 from intelmq.lib.bot import ParserBot
 from intelmq.lib.exceptions import InvalidArgument, InvalidValue
-from intelmq.lib.harmonization import DateTime
+from intelmq.lib.harmonization import TIME_CONVERSIONS
 
-TIME_CONVERSIONS = {'timestamp': DateTime.from_timestamp,
-                    'windows_nt': DateTime.from_windows_nt,
-                    'epoch_millis': DateTime.from_epoch_millis,
-                    None: lambda value: parse(value, fuzzy=True).isoformat() + " UTC"}
+# TIME_CONVERSIONS = {'timestamp': DateTime.from_timestamp,
+#                     'windows_nt': DateTime.from_windows_nt,
+#                     'epoch_millis': DateTime.from_epoch_millis,
+#                     None: lambda value: parse(value, fuzzy=True).isoformat() + " UTC"}
 
 DATA_CONVERSIONS = {'json': lambda data: json.loads(data)}
 DOCS = "https://intelmq.readthedocs.io/en/latest/guides/Bots.html#generic-csv-parser"

--- a/intelmq/bots/parsers/generic/parser_csv.py
+++ b/intelmq/bots/parsers/generic/parser_csv.py
@@ -21,26 +21,25 @@ import io
 import json
 import re
 from typing import Optional, Union, Iterable
-
-from dateutil.parser import parse
-
 from intelmq.lib import utils
 from intelmq.lib.bot import ParserBot
 from intelmq.lib.exceptions import InvalidArgument, InvalidValue
 from intelmq.lib.harmonization import DateTime
 
-TIME_CONVERSIONS = {'timestamp': DateTime.from_timestamp,
-                    'windows_nt': DateTime.from_windows_nt,
-                    'epoch_millis': DateTime.from_epoch_millis,
-                    'from_format': DateTime.convert_from_format,
-                    None: lambda value: parse(value, fuzzy=True).isoformat() + " UTC"}
+TIME_CONVERSIONS = ['timestamp',
+                    'windows_nt',
+                    'epoch_millis',
+                    'from_format',
+                    'from_format_midnight',
+                    ]
 
 DATA_CONVERSIONS = {'json': lambda data: json.loads(data)}
 DOCS = "https://intelmq.readthedocs.io/en/latest/guides/Bots.html#generic-csv-parser"
 
 
 class GenericCsvParserBot(ParserBot):
-    """Parse generic CSV data. Ignoring lines starting with character #. URLs without protocol can be prefixed with a default value."""
+    """Parse generic CSV data. Ignoring lines starting with character #. URLs without protocol can be prefixed with a
+    default value."""
     column_regex_search: Optional[dict] = None
     columns: Union[str, Iterable] = None
     compose_fields: Optional[dict] = {}
@@ -72,11 +71,9 @@ class GenericCsvParserBot(ParserBot):
         # handle empty strings, false etc.
         if not self.time_format:
             self.time_format = None
-        if self.time_format not in TIME_CONVERSIONS.keys():
-        # if self.time_format.split('|')[0] not in TIME_CONVERSIONS.keys():
-            raise InvalidArgument('time_format', got=self.time_format,
-                                  expected=list(TIME_CONVERSIONS.keys()),
-                                  docs=DOCS)
+        if self.time_format is not None and self.time_format.split('|')[0] not in TIME_CONVERSIONS:
+            raise InvalidArgument('time_format', got=self.time_format, expected=TIME_CONVERSIONS, docs=DOCS)
+
         if self.filter_type and self.filter_type not in ('blacklist', 'whitelist'):
             raise InvalidArgument('filter_type', got=self.filter_type,
                                   expected=("blacklist", "whitelist"),
@@ -141,8 +138,7 @@ class GenericCsvParserBot(ParserBot):
                     value = DATA_CONVERSIONS[self.data_type[key]](value)
 
                 if key in ("time.source", "time.destination"):
-                        # value = DateTime.convert(value=value, format=self.time_format)
-                    value = TIME_CONVERSIONS[self.time_format](value)
+                    value = DateTime.convert(value=value, format=self.time_format)
                 elif key.endswith('.url'):
                     if not value:
                         continue

--- a/intelmq/lib/harmonization.py
+++ b/intelmq/lib/harmonization.py
@@ -428,7 +428,7 @@ class DateTime(String):
             return utils.decode(value)
 
         try:
-            value = dateutil.parser.parse(value, fuzzy=True, dayfirst=True)
+            value = dateutil.parser.parse(value, fuzzy=True)
             value = value.astimezone(pytz.utc)
             value = value.isoformat()
         except (ValueError, OverflowError):
@@ -537,7 +537,7 @@ class DateTime(String):
 
     @staticmethod
     def convert_fuzzy(value) -> str:
-        value = dateutil.parser.parse(value, fuzzy=True, dayfirst=True)
+        value = dateutil.parser.parse(value, fuzzy=True)
         if not value.tzinfo and sys.version_info <= (3, 6):
             value = pytz.utc.localize(value)  # pragma: no cover
         elif not value.tzinfo:
@@ -565,9 +565,9 @@ class DateTime(String):
         if format is None:
             format = 'fuzzy'
         if format.startswith('from_format|'):
-            return DateTime.convert_from_format(value, format=format[12:])
+            return DateTime.convert_from_format(value, format=format.split('|')[1])
         elif format.startswith('from_format_midnight|'):
-            return DateTime.convert_from_format_midnight(value, format=format[21:])
+            return DateTime.convert_from_format_midnight(value, format=format.split('|')[1])
         else:
             return DateTime.TIME_CONVERSIONS[format](value)
 

--- a/intelmq/lib/harmonization.py
+++ b/intelmq/lib/harmonization.py
@@ -428,7 +428,7 @@ class DateTime(String):
             return utils.decode(value)
 
         try:
-            value = dateutil.parser.parse(value, fuzzy=True)
+            value = dateutil.parser.parse(value, fuzzy=True, dayfirst=True)
             value = value.astimezone(pytz.utc)
             value = value.isoformat()
         except (ValueError, OverflowError):
@@ -537,7 +537,7 @@ class DateTime(String):
 
     @staticmethod
     def convert_fuzzy(value) -> str:
-        value = dateutil.parser.parse(value, fuzzy=True)
+        value = dateutil.parser.parse(value, fuzzy=True, dayfirst=True)
         if not value.tzinfo and sys.version_info <= (3, 6):
             value = pytz.utc.localize(value)  # pragma: no cover
         elif not value.tzinfo:

--- a/intelmq/tests/bots/parsers/generic/custom_date_format.csv
+++ b/intelmq/tests/bots/parsers/generic/custom_date_format.csv
@@ -1,0 +1,13 @@
+ # comment with space before
+	# comment with tab before
+	  # comment with mix of tabs and spaces before
+ # below line contains spaces only
+   
+ # below line contains tabs only
+			
+ # below line contains mix of tabs and spaces only
+ 	  	
+# nesmysl jak noha
+18-05-2022 06:19:00	Testing	Really bad actor site comment	Nothing	Unimportant	www.cennoworld.com/Payment_Confirmation/Payment_Confirmation.zip	198.105.221.5	mail5.bulls.unisonplatform.com	just another comment
+18-05-2022 06:19:00	Testing	Really bad actor site comment	Nothing	Unimportant	www.cennoworld.com/Payment_Confirmation/Payment_Confirmation.zip	198.105.221.161	mail5.bulls.unisonplatform.com	just another comment
+#dalsi nesmysl

--- a/intelmq/tests/bots/parsers/generic/custom_date_format.csv.license
+++ b/intelmq/tests/bots/parsers/generic/custom_date_format.csv.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2022 gutsohnCERT
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/intelmq/tests/bots/parsers/generic/test_parser_csv.py
+++ b/intelmq/tests/bots/parsers/generic/test_parser_csv.py
@@ -67,7 +67,7 @@ CUSTOM_DATE_REPORT = {"feed.name": "Sample CSV Feed",
 CUSTOM_DATE_EVENT = {"feed.name": "Sample CSV Feed",
                      "feed.url": "http://www.samplecsvthreatfeed.com/list",
                      "__type": "Event",
-                     "time.source": "2022-05-18T04:19:00+00:00",
+                     "time.source": "2022-05-18T06:19:00+00:00",
                      "source.url": "http://www.cennoworld.com/Payment_Confirmation/"
                                    "Payment_Confirmation.zip",
                      "source.ip": "198.105.221.5",

--- a/intelmq/tests/bots/parsers/generic/test_parser_csv.py
+++ b/intelmq/tests/bots/parsers/generic/test_parser_csv.py
@@ -62,7 +62,7 @@ CUSTOM_DATE_REPORT = {"feed.name": "Sample CSV Feed",
                       "feed.url": "http://www.samplecsvthreatfeed.com/list",
                       "raw": utils.base64_encode(CUSTOM_DATE_FILE),
                       "__type": "Report",
-                      "time.observation": "2022-05-18T04:19:00+00:00",
+                      "time.observation": "2022-05-18T06:19:00+00:00",
                       }
 CUSTOM_DATE_EVENT = {"feed.name": "Sample CSV Feed",
                      "feed.url": "http://www.samplecsvthreatfeed.com/list",
@@ -75,7 +75,7 @@ CUSTOM_DATE_EVENT = {"feed.name": "Sample CSV Feed",
                      "event_description.text": "Really bad actor site comment",
                      "classification.type": "malware-distribution",
                      "raw": utils.base64_encode(CUSTOM_DATE_SPLIT[10].replace('\t', ',')+'\r\n'),
-                     "time.observation": "2022-05-18T04:19:00+00:00",
+                     "time.observation": "2022-05-18T06:19:00+00:00",
                      }
 CUSTOM_DATE_EVENT_MIDNIGHT = CUSTOM_DATE_EVENT.copy()
 CUSTOM_DATE_EVENT_MIDNIGHT['time.source'] = "2022-05-18T00:00:00+00:00"

--- a/intelmq/tests/bots/parsers/generic/test_parser_csv.py
+++ b/intelmq/tests/bots/parsers/generic/test_parser_csv.py
@@ -17,6 +17,9 @@ SAMPLE_SPLIT = SAMPLE_FILE.splitlines()
 with open(os.path.join(os.path.dirname(__file__), 'compose_fields.csv')) as handle:
     COMPOSE_FILE = handle.read()
 COMPOSE_SPLIT = COMPOSE_FILE.splitlines()
+with open(os.path.join(os.path.dirname(__file__), 'custom_date_format.csv')) as handle:
+    CUSTOM_DATE_FILE = handle.read()
+CUSTOM_DATE_SPLIT = CUSTOM_DATE_FILE.splitlines()
 
 EXAMPLE_REPORT = {"feed.name": "Sample CSV Feed",
                   "feed.url": "http://www.samplecsvthreatfeed.com/list",
@@ -55,6 +58,27 @@ COMPOSE_EVENT = {"feed.name": "Sample CSV Feed",
                  "raw": utils.base64_encode(COMPOSE_SPLIT[1]+'\r\n'),
                  "time.observation": "2015-01-01T00:00:00+00:00",
                  }
+CUSTOM_DATE_REPORT = {"feed.name": "Sample CSV Feed",
+                      "feed.url": "http://www.samplecsvthreatfeed.com/list",
+                      "raw": utils.base64_encode(CUSTOM_DATE_FILE),
+                      "__type": "Report",
+                      "time.observation": "2022-05-18T04:19:00+00:00",
+                      }
+CUSTOM_DATE_EVENT = {"feed.name": "Sample CSV Feed",
+                     "feed.url": "http://www.samplecsvthreatfeed.com/list",
+                     "__type": "Event",
+                     "time.source": "2022-05-18T04:19:00+00:00",
+                     "source.url": "http://www.cennoworld.com/Payment_Confirmation/"
+                                   "Payment_Confirmation.zip",
+                     "source.ip": "198.105.221.5",
+                     "source.fqdn": "mail5.bulls.unisonplatform.com",
+                     "event_description.text": "Really bad actor site comment",
+                     "classification.type": "malware-distribution",
+                     "raw": utils.base64_encode(CUSTOM_DATE_SPLIT[10].replace('\t', ',')+'\r\n'),
+                     "time.observation": "2022-05-18T04:19:00+00:00",
+                     }
+CUSTOM_DATE_EVENT_MIDNIGHT = CUSTOM_DATE_EVENT.copy()
+CUSTOM_DATE_EVENT_MIDNIGHT['time.source'] = "2022-05-18T00:00:00+00:00"
 
 
 class TestGenericCsvParserBot(test.BotTestCase, unittest.TestCase):
@@ -104,6 +128,18 @@ class TestGenericCsvParserBot(test.BotTestCase, unittest.TestCase):
                                  'compose_fields': {"source.url": "http://{0}{1}"},
                                  'delimiter': ','})
         self.assertMessageEqual(0, COMPOSE_EVENT)
+
+    def test_custom_date_format(self):
+        """ Test if custom date value for parameter time_format is handled correctly. """
+        self.input_message = CUSTOM_DATE_REPORT
+        self.run_bot(parameters={'time_format': 'from_format|%d-%m-%Y %H:%M:%S'})
+        self.assertMessageEqual(0, CUSTOM_DATE_EVENT)
+
+    def test_custom_date_format_midnight(self):
+        """ Test if custom date value for parameter time_format is handled correctly. """
+        self.input_message = CUSTOM_DATE_REPORT
+        self.run_bot(parameters={'time_format': 'from_format_midnight|%d-%m-%Y %H:%M:%S'})
+        self.assertMessageEqual(0, CUSTOM_DATE_EVENT_MIDNIGHT)
 
 
 if __name__ == '__main__':  # pragma: no cover


### PR DESCRIPTION
Implementation and enhancement of time_format parameter to accept custom date formats (Fix #2105). Usage e.g.  'time_format': 'from_format|%d-%m-%Y %H:%M:%S'
