### PR TITLE
gitignore: add coverage file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ dist
 .vagrant/
 *~
 .coverage
+coverage.xml
 .idea/
 htmlcov/
 *.pem


### PR DESCRIPTION
add the file name coverage.xml to the gitignore patterns
the file is a result of a test coverage analysis, not to be committed to
the repository
