### PR TITLE
BUG: mail collectors: fix IMAP abort handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,9 @@ CHANGELOG
 - Set the parent class of all bots to the correct bot class
 
 #### Collectors
-- `intelmq.bots.collectors.mail._lib`: Add support for unverified SSL/STARTTLS connections (PR#2055 by Sebastian Wagner).
+- `intelmq.bots.collectors.mail._lib`:
+  - Add support for unverified SSL/STARTTLS connections (PR#2055 by Sebastian Wagner).
+  - Fix exception handling for aborted IMAP connections (PR#2187 by Sebastian Wagner).
 - `intelmq.bots.collectors.blueliv`: Fix Blueliv collector requirements (PR#2161 by Gethvi).
 
 #### Parsers

--- a/intelmq/bots/collectors/mail/_lib.py
+++ b/intelmq/bots/collectors/mail/_lib.py
@@ -76,7 +76,7 @@ class MailCollectorBot(CollectorBot):
                 if self.process_message(uid, message):
                     try:
                         mailbox.mark_seen(uid)
-                    except imaplib.abort:
+                    except imaplib.IMAP4.abort:
                         # Disconnect, see https://github.com/certtools/intelmq/issues/852
                         mailbox = self.connect_mailbox()
                         mailbox.mark_seen(uid)


### PR DESCRIPTION
the try-except block to handle aborted IMAP connections (timeout after a
long processing of the message in IntelMQ) used the wrong class
imaplib.abort does not exist, but the class is named imaplib.IMAP4.abort