### PR TITLE
bug: fix ctl process manager initialization non-interactive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,7 @@ CHANGELOG
 - CodeQL Github Actions `exponential backtracking on strings` fixed. (PR#2148 by Sebastian Waldbauer, fixes #2138)
 
 ### Tools
+- `intelmqctl`: fix process manager initialization if run non-interactively, as intelmqdump does it (PR#2189 by Sebastian Wagner, fixes 2188).
 
 ### Contrib
 - logrotate: Move compress and ownership rules to the IntelMQ-blocks to prevent that they apply to other files (PR#2111 by Sebastian Wagner, fixes #2110).

--- a/intelmq/bin/intelmqctl.py
+++ b/intelmq/bin/intelmqctl.py
@@ -15,7 +15,6 @@ import sys
 import textwrap
 import traceback
 import time
-from collections import OrderedDict
 
 import pkg_resources
 from ruamel.yaml import YAML
@@ -374,6 +373,14 @@ Get some debugging output on the settings and the environment (to be extended):
             parser_debug.set_defaults(func=self.debug)
 
             self.parser = parser
+        else:
+            self._processmanager = process_managers()[self._processmanagertype](
+                self._interactive,
+                self._runtime_configuration,
+                self._logger,
+                self._returntype,
+                self._quiet
+            )
 
     def load_defaults_configuration(self, silent=False):
         for option, value in utils.get_global_settings().items():


### PR DESCRIPTION
if the intelmq controller class is initiated non-interactively the
process manager instance was not initiated
this caused the intelmqdump tool to crash when retrieving the status of
a bot

fixes #2188 