### PR TITLE
ParserBot: Fix line recovery and message dumping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ CHANGELOG
 - `intelmq.bots.parsers.shadowserver._config`:
   - Added support for `Accessible AMQP`, `Device Identification Report` (IPv4 and IPv6) (PR#2134 by Mateo Durante).
   - Added file name mapping for `SSL-POODLE-Vulnerable-Servers IPv6` (file name `scan6_ssl_poodle`) (PR#2134 by Mateo Durante).
+- `intelmq.bots.parsers.generic.parser_csv`: Use RewindableFileHandle to use the original current line for line recovery (PR#2192 by Sebastian Wagner).
 
 #### Experts
 - `intelmq.bots.experts.domain_valid`: New bot for checking domain's validity (PR#1966 by Marius Karotkis).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ CHANGELOG
   The `LogLevel` and `ReturnType` Enums were added to `intelmq.lib.datatypes`.
 - `intelmq.lib.bot`:
   - Enhance behaviour if an unconfigured bot is started (PR#2054 by Sebastian Wagner).
+  - Fix line recovery and message dumping of the `ParserBot` (PR#2192 by Sebastian Wagner).
+    - Previously the dumped message was always the last message of a report if the report contained muliple lines leading to data-loss.
 
 ### Development
 

--- a/intelmq/bots/parsers/abusech/parser_ip.py
+++ b/intelmq/bots/parsers/abusech/parser_ip.py
@@ -69,7 +69,7 @@ class AbusechIPParserBot(ParserBot):
         for line in data_lines:
             yield line.strip()
 
-    def parse_line(self, line, report):
+    def parse_line(self, line: str, report):
         event = self.new_event(report)
         self.__process_defaults(event, line, report['feed.url'])
         self.__process_fields(event, line, report['feed.url'])
@@ -114,7 +114,7 @@ class AbusechIPParserBot(ParserBot):
     def __sanitize_csv_lines(s: str):
         return s.replace('"', '')
 
-    def recover_line(self, line):
+    def recover_line(self, line: str):
         return '\n'.join(self.comments + [self.header_line, line])
 
 

--- a/intelmq/bots/parsers/cymru/parser_full_bogons.py
+++ b/intelmq/bots/parsers/cymru/parser_full_bogons.py
@@ -26,7 +26,7 @@ class CymruFullBogonsParserBot(ParserBot):
         for row in raw_report.splitlines():
             yield row.strip()
 
-    def parse_line(self, val, report):
+    def parse_line(self, val: str, report):
         if not len(val) or val.startswith('#') or val.startswith('//'):
             return
 

--- a/intelmq/bots/parsers/generic/parser_csv.py
+++ b/intelmq/bots/parsers/generic/parser_csv.py
@@ -28,6 +28,7 @@ from intelmq.lib import utils
 from intelmq.lib.bot import ParserBot
 from intelmq.lib.exceptions import InvalidArgument, InvalidValue
 from intelmq.lib.harmonization import DateTime
+from intelmq.lib.utils import RewindableFileHandle
 
 TIME_CONVERSIONS = {'timestamp': DateTime.from_timestamp,
                     'windows_nt': DateTime.from_windows_nt,
@@ -101,8 +102,10 @@ class GenericCsvParserBot(ParserBot):
         if self.skip_header:
             self.tempdata.append(raw_report[:raw_report.find('\n')])
             raw_report = raw_report[raw_report.find('\n') + 1:]
-        for row in csv.reader(io.StringIO(raw_report),
+        self._handle = RewindableFileHandle(io.StringIO(raw_report))
+        for row in csv.reader(self._handle,
                               delimiter=str(self.delimiter)):
+            self._current_line = self._handle.current_line
 
             if self.filter_text and self.filter_type:
                 text_in_row = self.filter_text in self.delimiter.join(row)

--- a/intelmq/bots/parsers/generic/parser_csv.py
+++ b/intelmq/bots/parsers/generic/parser_csv.py
@@ -115,7 +115,7 @@ class GenericCsvParserBot(ParserBot):
             else:
                 yield row
 
-    def parse_line(self, row, report):
+    def parse_line(self, row: list, report):
         event = self.new_event(report)
 
         for keygroup, value, required in zip(self.columns, row, self.columns_required):

--- a/intelmq/bots/parsers/microsoft/parser_ctip.py
+++ b/intelmq/bots/parsers/microsoft/parser_ctip.py
@@ -210,11 +210,15 @@ class MicrosoftCTIPParserBot(ParserBot):
     def parse(self, report):
         raw_report = utils.base64_decode(report.get("raw"))
         if raw_report.startswith('['):
+            # Interflow
             self.recover_line = self.recover_line_json
             yield from self.parse_json(report)
         elif raw_report.startswith('{'):
+            # Azure
             self.recover_line = self.recover_line_json_stream
             yield from self.parse_json_stream(report)
+        else:
+            raise ValueError("Can't parse the received message. It is neither a JSON list nor a JSON dictionary. Please report this bug.")
 
     def parse_line(self, line, report):
         if line.get('version', None) == 1.5:

--- a/intelmq/bots/parsers/microsoft/parser_ctip.py
+++ b/intelmq/bots/parsers/microsoft/parser_ctip.py
@@ -257,7 +257,7 @@ class MicrosoftCTIPParserBot(ParserBot):
         yield event
 
     def parse_azure(self, line, report):
-        raw = self.recover_line(line)
+        raw = self.recover_line()
 
         event = self.new_event(report)
 

--- a/intelmq/bots/parsers/microsoft/parser_ctip.py
+++ b/intelmq/bots/parsers/microsoft/parser_ctip.py
@@ -222,7 +222,7 @@ class MicrosoftCTIPParserBot(ParserBot):
         else:
             yield from self.parse_azure(line, report)
 
-    def parse_interflow(self, line, report):
+    def parse_interflow(self, line: dict, report):
         raw = self.recover_line(line)
         if line['indicatorthreattype'] != 'Botnet':
             raise ValueError('Unknown indicatorthreattype %r, only Botnet is supported.' % line['indicatorthreattype'])

--- a/intelmq/bots/parsers/shadowserver/parser.py
+++ b/intelmq/bots/parsers/shadowserver/parser.py
@@ -197,7 +197,7 @@ class ShadowserverParserBot(ParserBot):
         # Now add additional constant fields.
         event.update(conf.get('constant_fields', {}))
 
-        event.add('raw', self.recover_line(row))
+        event.add('raw', self.recover_line())
 
         # Add everything which could not be resolved to extra.
         for f in fields:

--- a/intelmq/lib/bot.py
+++ b/intelmq/lib/bot.py
@@ -1024,6 +1024,7 @@ class ParserBot(Bot):
         for line in utils.base64_decode(report.get("raw")).splitlines():
             line = line.strip()
             if not any([line.startswith(prefix) for prefix in self._ignore_lines_starting]):
+                self._current_line = line
                 yield line
 
     def parse_line(self, line: Any, report: libmessage.Report):
@@ -1063,14 +1064,14 @@ class ParserBot(Bot):
                     events: list[libmessage.Event] = [value]
             except Exception:
                 self.logger.exception('Failed to parse line.')
-                self.__failed.append((traceback.format_exc(), line))
+                self.__failed.append((traceback.format_exc(), self._current_line))
             else:
                 events_count += len(events)
                 self.send_message(*events)
 
-        for exc, line in self.__failed:
+        for exc, original_line in self.__failed:
             report_dump: libmessage.Message = report.copy()
-            report_dump.change('raw', self.recover_line(line))
+            report_dump.change('raw', self.recover_line(original_line))
             if self.error_dump_message:
                 self._dump_message(exc, report_dump)
             if self.destination_queues and '_on_error' in self.destination_queues:
@@ -1115,21 +1116,34 @@ class ParserBot(Bot):
         line = line if line else self._current_line
         return '\n'.join(tempdata + [line])
 
-    def recover_line_csv(self, line: str) -> str:
-        out = io.StringIO()
-        writer = csv.writer(out, **self._csv_params)
-        writer.writerow(line)
+    def recover_line_csv(self, line: Optional[list]) -> str:
+        """
+        Parameter:
+            line: Optional line as list. If absent, the current line is used as string.
+        """
+        if line:
+            out = io.StringIO()
+            writer = csv.writer(out, **self._csv_params)
+            writer.writerow(line)
+            result = out.getvalue()
+        else:
+            result = self._current_line
         tempdata = '\r\n'.join(self.tempdata) + '\r\n' if self.tempdata else ''
-        return tempdata + out.getvalue()
+        return tempdata + result
 
-    def recover_line_csv_dict(self, line: str) -> str:
+    def recover_line_csv_dict(self, line: Union[dict, str, None] = None) -> str:
         """
         Converts dictionaries to csv. self.csv_fieldnames must be list of fields.
         """
         out = io.StringIO()
         writer = csv.DictWriter(out, self.csv_fieldnames, **self._csv_params)
         writer.writeheader()
-        out.write(self._current_line)
+        if isinstance(line, dict):
+            writer.writerow(line)
+        elif isinstance(line, str):
+            out.write(line)
+        else:
+            out.write(self._current_line)
 
         return out.getvalue().strip()
 
@@ -1138,20 +1152,29 @@ class ParserBot(Bot):
         Reverse of parse for JSON pulses.
 
         Recovers a fully functional report with only the problematic pulse.
+        Using a string as input here is not possible, as the input may span over multiple lines.
+        Output is not identical to the input, but has the same content.
+
+        Parameters:
+            The line as dict.
+
+        Returns:
+            str: The JSON-encoded line as string.
         """
         return json.dumps([line])
 
-    def recover_line_json_stream(self, line=None) -> str:
+    def recover_line_json_stream(self, line: Optional[str] = None) -> str:
         """
-        recover_line for json streams, just returns the current line, unparsed.
+        recover_line for JSON streams (one JSON element per line, no outer structure),
+        just returns the current line, unparsed.
 
         Parameters:
-            line: None, not required, only for compatibility with other recover_line methods
+            line: The line itself as dict, if available, falls back to original current line
 
         Returns:
             str: unparsed JSON line.
         """
-        return self._current_line
+        return line if line else self._current_line
 
 
 class CollectorBot(Bot):

--- a/intelmq/lib/bot.py
+++ b/intelmq/lib/bot.py
@@ -30,8 +30,6 @@ from collections import defaultdict
 from datetime import datetime, timedelta
 from typing import Any, List, Optional, Union
 
-import psutil
-
 import intelmq.lib.message as libmessage
 from intelmq import (DEFAULT_LOGGING_PATH,
                      HARMONIZATION_CONF_FILE,
@@ -942,7 +940,7 @@ class ParserBot(Bot):
     _csv_params = {}
     _ignore_lines_starting = []
     _handle = None
-    _current_line = None
+    _current_line: Optional[str] = None
 
     def __init__(self, bot_id: str, start: bool = False, sighup_event=None,
                  disable_multithreading: bool = None):
@@ -956,6 +954,7 @@ class ParserBot(Bot):
     def parse_csv(self, report: libmessage.Report):
         """
         A basic CSV parser.
+        The resulting lines are lists.
         """
         raw_report: str = utils.base64_decode(report.get("raw")).strip()
         raw_report = raw_report.translate({0: None})
@@ -971,6 +970,7 @@ class ParserBot(Bot):
     def parse_csv_dict(self, report: libmessage.Report):
         """
         A basic CSV Dictionary parser.
+        The resulting lines are dictionaries with the column names as keys.
         """
         raw_report: str = utils.base64_decode(report.get("raw")).strip()
         raw_report: str = raw_report.translate({0: None})

--- a/intelmq/lib/pipeline.py
+++ b/intelmq/lib/pipeline.py
@@ -29,7 +29,7 @@ except ImportError:
 class PipelineFactory:
 
     @staticmethod
-    def create(logger, broker=None, direction=None, queues=None, pipeline_args=None, load_balance=False, is_multithreaded=False):
+    def create(logger, broker=None, direction=None, queues=None, pipeline_args: Optional[dict] = None, load_balance=False, is_multithreaded=False):
         """
         direction: "source" or "destination", optional, needed for queues
         queues: needs direction to be set, calls set_queues


### PR DESCRIPTION
- BUG: Fix line recovery and message dumping in ParserBot
  ParserBot.process first iterates over all message in a parsed report and
  catches the errors, saves the erroneous message and at the end dumps all
  of them in one row.
  The recover_line methods were not consistent in their use of the line
  given as parameter and the use of the _current_line class member.
  This lead to parsers always dumping the last message (_current_line
  which was active at the time of the dumping) leading to data loss for
  dumped messages for `recover_line_csv_dict` and
  `recover_line_json_stream`.
- DOC: type annotations and inline documentation
  mainly for ParserBot's recover_line methods and related
- ENH: generic csv parser: use current_line
  Use RewindableFileHandle to use the orignal current line for line recovery
- BUG: ctip parser and shadowserver parser: use current line for raw
  use the unparsed current line as string instead of the parsed line
- ENH: ctip parser: better error message for bogous reports
  reports must not be dropped silently if their format is unknown (can
  also happen because of misconfiguration)
- TST: add and update tests for correct line recovery