### PR TITLE
Fix reconnection in SQL Mixin

### DIFF
--- a/intelmq/lib/mixins/sql.py
+++ b/intelmq/lib/mixins/sql.py
@@ -1,6 +1,6 @@
 """ SQLMixin for IntelMQ
 
-SPDX-FileCopyrightText: 2021 Birger Schacht
+SPDX-FileCopyrightText: 2021 Birger Schacht, 2022 Intevation GmbH
 SPDX-License-Identifier: AGPL-3.0-or-later
 
 Based on the former SQLBot base class
@@ -25,6 +25,11 @@ class SQLMixin:
     message_jsondict_as_string = True
 
     def __init__(self, *args, **kwargs):
+        self._init_sql()
+
+        super().__init__(*args, **kwargs)
+
+    def _init_sql(self):
         self.logger.debug("Running SQL Mixin initialization.")
         self._engine_name = getattr(self, 'engine', self._default_engine).lower()
         engines = {SQLMixin.POSTGRESQL: (self._init_postgresql, "%s"),
@@ -97,14 +102,14 @@ class SQLMixin:
                 except self._engine.OperationalError:
                     self.logger.exception('Executed rollback command '
                                           'after failed query execution.')
-                    self.init()
+                    self._init_sql()
                 except Exception:
                     self.logger.exception('Cursor has been closed, connecting '
                                           'again.')
-                    self.init()
+                    self._init_sql()
             else:
                 self.logger.exception('Database connection problem, connecting again.')
-                self.init()
+                self._init_sql()
         else:
             return True
         return False

--- a/intelmq/lib/mixins/sql.py
+++ b/intelmq/lib/mixins/sql.py
@@ -5,6 +5,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 Based on the former SQLBot base class
 """
+from intelmq.lib import exceptions
 
 
 class SQLMixin:


### PR DESCRIPTION
Fixes #2200:
- bug: sql mixin: add missing import of `exception`
- sql mixin: properly separate parameters from internal variables
parameters show not be changed during runtime, this prevents reloading
the bot and other re-initializations (self.engine was made a class
instance)
- bug: sql mixin: reconnect on connection issues
separate the sql mixin initialization from the `__init__` to be able to
call it from inside the bot for re-connecting.
calling `self.__init__` would require at least the bot-id
calling `self._connect` would require preparing all the arguments
