### PR TITLE
tst: fix reverse_dns test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,7 @@ CHANGELOG
 - Also test on Python 3.10 (PR#2140 by Sebastian Wagner).
 - Switch from nosetests to pytest, as the former does not support Python 3.10 (PR#2140 by Sebastian Wagner).
 - CodeQL Github Actions `exponential backtracking on strings` fixed. (PR#2148 by Sebastian Waldbauer, fixes #2138)
+- Reverse DNS expert tests: remove outdated failing test `test_invalid_ptr` (PR#2208 by Sebastian Wagner, fixes #2206).
 
 ### Tools
 - `intelmqctl`: fix process manager initialization if run non-interactively, as intelmqdump does it (PR#2189 by Sebastian Wagner, fixes 2188).

--- a/intelmq/tests/bots/experts/reverse_dns/test_expert.py
+++ b/intelmq/tests/bots/experts/reverse_dns/test_expert.py
@@ -33,14 +33,6 @@ EXAMPLE_OUTPUT6 = {"__type": "Event",
                    "source.reverse_dns": "iana.org",
                    "time.observation": "2015-01-01T00:00:00+00:00",
                    }
-INVALID_PTR_INP = {"__type": "Event",
-                   "source.ip": "31.210.115.39",  # PTR is '.'
-                   "time.observation": "2015-01-01T00:00:00+00:00",
-                   }
-INVALID_PTR_OUT = {"__type": "Event",
-                   "source.ip": "31.210.115.39",
-                   "time.observation": "2015-01-01T00:00:00+00:00",
-                   }
 INVALID_PTR_INP2 = {"__type": "Event",
                     "source.ip": "5.157.80.221",  # PTR is '5.157.80.221.' and 'aliancys.peopleinc.nl.'
                     "time.observation": "2015-01-01T00:00:00+00:00",
@@ -81,11 +73,6 @@ class TestReverseDnsExpertBot(test.BotTestCase, unittest.TestCase):
         self.input_message = EXAMPLE_INPUT6
         self.run_bot()
         self.assertMessageEqual(0, EXAMPLE_OUTPUT6)
-
-    def test_invalid_ptr(self):
-        self.input_message = INVALID_PTR_INP
-        self.run_bot()
-        self.assertMessageEqual(0, INVALID_PTR_OUT)
 
     def test_invalid_ptr2(self):
         self.input_message = INVALID_PTR_INP2


### PR DESCRIPTION
remove test_invalid_ptr as the IP address used no longer returns the
expected result

fixes certtools/intelmq#2206