### PR TITLE
tst: fix threshold expert redis host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,7 @@ CHANGELOG
 - CodeQL Github Actions `exponential backtracking on strings` fixed. (PR#2148 by Sebastian Waldbauer, fixes #2138)
 - Reverse DNS expert tests: remove outdated failing test `test_invalid_ptr` (PR#2208 by Sebastian Wagner, fixes #2206).
 - Add test dependency `requests_mock` to the `development` extra requirements in `setup.py` (PR#2210 by Sebastian Wagner).
+- Threshold Expert tests: Use environment variable `INTELMQ_PIPELINE_HOST` as redis host, analogous to other tests (PR#2209 by Sebastian Wagner, fixes #2207).
 
 ### Tools
 - `intelmqctl`: fix process manager initialization if run non-interactively, as intelmqdump does it (PR#2189 by Sebastian Wagner, fixes 2188).

--- a/intelmq/tests/bots/experts/threshold/test_expert.py
+++ b/intelmq/tests/bots/experts/threshold/test_expert.py
@@ -4,8 +4,8 @@
 
 # -*- coding: utf-8 -*-
 
+import os
 import unittest
-import time
 
 import intelmq.lib.test as test
 from intelmq.lib import utils
@@ -35,7 +35,7 @@ PARAMETERS = {
     'filter_keys': ['source.ip'],
     'filter_type': 'whitelist',
     'redis_cache_db': 4,
-    'redis_cache_host': '127.0.0.1',
+    'redis_cache_host': os.getenv('INTELMQ_PIPELINE_HOST', 'localhost'),
     'redis_cache_password': None,
     'redis_cache_port': 6379,
     'timeout': 1,


### PR DESCRIPTION
Use environment variable `INTELMQ_PIPELINE_HOST` as redis host, analogous to other tests
fixes certtools/intelmq#2207