### PR TITLE
postgresql output: escape all null bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,8 @@ CHANGELOG
 - `intelmq.bots.outputs.templated_smtp.output`:
   - Add new function `from_json()` (which just calls `json.loads()` in the standard Python environment), meaning the Templated SMTP output bot can take strings containing JSON documents and do the formatting itself (PR#2120 by Karl-Johan Karlsson).
   - Lift restriction on requirement jinja2 < 3 (PR#2158 by Sebastian Wagner).
+- `intelmq.bots.outputs.sql`:
+  - For PostgreSQL, escape Nullbytes in text to prevent "unsupported Unicode escape sequence" issues (PR#2223 by Sebastian Wagner, fixes #2203).
 
 ### Documentation
 - Feeds: Add documentation for newly supported dataplane feeds, see above (PR#2102 by Mikk Margus Möll).

--- a/docs/user/bots.rst
+++ b/docs/user/bots.rst
@@ -4026,7 +4026,8 @@ The parameters marked with 'PostgreSQL' will be sent to libpq via psycopg2. Chec
 * `fields`: list of fields to read from the event. If None, read all fields
 * `reconnect_delay`: number of seconds to wait before reconnecting in case of an error
 
-**PostgreSQL**
+PostgreSQL
+~~~~~~~~~~
 
 You have two basic choices to run PostgreSQL:
 
@@ -4081,7 +4082,13 @@ if the user `intelmq` can authenticate):
 
    psql -h localhost intelmq-events intelmq </tmp/initdb.sql
 
-**SQLite**
+**PostgreSQL and null characters**
+
+While null characters (`\0`, not SQL "NULL") in TEXT and JSON/JSONB fields are valid, data containing null characters can cause troubles in some combinations of clients, servers and each settings.
+To prevent unhandled errors and data which can't be inserted into the database, all null characters are escaped (`\\u0000`) before insertion.
+
+SQLite
+~~~~~~
 
 Similarly to PostgreSQL, you can use `intelmq_psql_initdb` to create initial SQL statements
 from `harmonization.conf`. The script will create the required table layout

--- a/intelmq/bots/outputs/sql/output.py
+++ b/intelmq/bots/outputs/sql/output.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2019 Edvard Rejthar
+# SPDX-FileCopyrightText: 2019 Edvard Rejthar, 2022 Intevation GmbH
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
@@ -48,14 +48,23 @@ class SQLOutputBot(OutputBot, SQLMixin):
             key_names = event.keys()
         valid_keys = [key for key in key_names if key in event]
         keys = '", "'.join(valid_keys)
-        values = itemgetter_tuple(*valid_keys)(event)
-        fvalues = len(values) * '{0}, '.format(self.format_char)
+        values = self.prepare_values(itemgetter_tuple(*valid_keys)(event))
+        fvalues = len(values) * f'{self.format_char}, '
         query = ('INSERT INTO {table} ("{keys}") VALUES ({values})'
                  ''.format(table=self.table, keys=keys, values=fvalues[:-2]))
 
         if self.execute(query, values, rollback=True):
             self.con.commit()
             self.acknowledge_message()
+
+    def prepare_values(self, values):
+        if self._engine_name == self.POSTGRESQL:
+            # escape JSON-encoded NULL characters. JSON escapes them once, but we need to escape them twice,
+            # so that Postgres does not encounter a NULL char while decoding it
+            # https://github.com/certtools/intelmq/issues/2203
+            return [value.replace('\\u0000', '\\\\u0000') if isinstance(value, str) else value for value in values]
+        else:
+            return list(values)
 
 
 BOT = SQLOutputBot

--- a/intelmq/lib/test.py
+++ b/intelmq/lib/test.py
@@ -188,7 +188,7 @@ class BotTestCase:
             return logger
         return log
 
-    def prepare_bot(self, parameters={}, destination_queues=None):
+    def prepare_bot(self, parameters={}, destination_queues=None, prepare_source_queue: bool = True):
         """
         Reconfigures the bot with the changed attributes.
 
@@ -238,7 +238,8 @@ class BotTestCase:
         self.pipe.set_queues(parameters.source_queue, "source")
         self.pipe.set_queues(parameters.destination_queues, "destination")
 
-        self.prepare_source_queue()
+        if prepare_source_queue:
+            self.prepare_source_queue()
 
     def prepare_source_queue(self):
         if self.input_message is not None:


### PR DESCRIPTION
while null bytes (`\0`, not SQL "NULL") in TEXT and JSON/JSONB fields are valid, data containing null bytes can cause troubles in some combinations of clients, servers and each settings.
To prevent unhandled errors, and data which can't be inserted into the database, all null bytes are escaped

fixes certtools/intelmq#2203