### PR TITLE
Multithreading causes bot to crash or not start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ CHANGELOG
   - Enhance behaviour if an unconfigured bot is started (PR#2054 by Sebastian Wagner).
   - Fix line recovery and message dumping of the `ParserBot` (PR#2192 by Sebastian Wagner).
     - Previously the dumped message was always the last message of a report if the report contained multiple lines leading to data-loss.
+  - Fix crashing at start in multithreaded bots (PR#2236 by DigitalTrustCenter).
 - `intelmq.lib.pipeline`:
   - Changed `BRPOPLPUSH` to `BLMOVE`, because `BRPOPLPUSH` has been marked as deprecated by redis in favor of `BLMOVE` (PR#2149 by Sebastian Waldbauer, fixes #1827)
 - `intelmq.lib.utils`:

--- a/intelmq/lib/bot.py
+++ b/intelmq/lib/bot.py
@@ -945,7 +945,7 @@ class ParserBot(Bot):
 
     def __init__(self, bot_id: str, start: bool = False, sighup_event=None,
                  disable_multithreading: bool = None):
-        super().__init__(bot_id=bot_id)
+        super().__init__(bot_id, start, sighup_event, disable_multithreading)
         if self.__class__.__name__ == 'ParserBot':
             self.logger.error('ParserBot can\'t be started itself. '
                               'Possible Misconfiguration.')
@@ -1216,7 +1216,7 @@ class CollectorBot(Bot):
 
     def __init__(self, bot_id: str, start: bool = False, sighup_event=None,
                  disable_multithreading: bool = None):
-        super().__init__(bot_id=bot_id)
+        super().__init__(bot_id, start, sighup_event, disable_multithreading)
         if self.__class__.__name__ == 'CollectorBot':
             self.logger.error('CollectorBot can\'t be started itself. '
                               'Possible Misconfiguration.')
@@ -1276,7 +1276,7 @@ class ExpertBot(Bot):
 
     def __init__(self, bot_id: str, start: bool = False, sighup_event=None,
                  disable_multithreading: bool = None):
-        super().__init__(bot_id=bot_id)
+        super().__init__(bot_id, start, sighup_event, disable_multithreading)
 
 
 class OutputBot(Bot):
@@ -1287,7 +1287,7 @@ class OutputBot(Bot):
 
     def __init__(self, bot_id: str, start: bool = False, sighup_event=None,
                  disable_multithreading: bool = None):
-        super().__init__(bot_id=bot_id)
+        super().__init__(bot_id, start, sighup_event, disable_multithreading)
         if self.__class__.__name__ == 'OutputBot':
             self.logger.error('OutputBot can\'t be started itself. '
                               'Possible Misconfiguration.')

--- a/intelmq/lib/utils.py
+++ b/intelmq/lib/utils.py
@@ -52,8 +52,6 @@ import intelmq
 from intelmq import RUNTIME_CONF_FILE
 from intelmq.lib.exceptions import DecodingError
 
-yaml = YAML(typ="unsafe", pure=True)
-
 __all__ = ['base64_decode', 'base64_encode', 'decode', 'encode',
            'load_configuration', 'load_parameters', 'log', 'parse_logline',
            'reverse_readline', 'error_message_from_exc', 'parse_relative',
@@ -216,7 +214,7 @@ def load_configuration(configuration_filepath: str) -> dict:
     if os.path.exists(configuration_filepath):
         with open(configuration_filepath) as fpconfig:
             try:
-                config = yaml.load(fpconfig)
+                config = YAML(typ="unsafe", pure=True).load(fpconfig)
             except ScannerError as exc:
                 if "found character '\\t' that cannot start any token" in exc.problem:
                     fpconfig.seek(0)
@@ -257,7 +255,7 @@ def write_configuration(configuration_filepath: str,
         pathlib.Path(configuration_filepath + '.bak').write_text(config.read_text())
     with open(configuration_filepath, 'w') as handle:
         if useyaml:
-            yaml.dump(content, handle)
+            YAML(typ="unsafe", pure=True).dump(content, handle)
         else:
             json.dump(content, fp=handle, indent=4,
                       sort_keys=True,


### PR DESCRIPTION
We are testing the mulithreading capabilities of IntelMQ in combination with RabbitMQ. We have found two (regression) issues that completely break mulithreaded bots:

1. The new YAML configuration format uses a global YAML object in lib/utils.py to read/write configuration. When mulithreading is enabled for a bot, each thread calls \__init__ on the bot class. Since the init function loads the configuration of the bot, this means that each thread tries to load the configuration at the same time. This causes a race condition on the YAML loader, and usually crashes the threads, and thus the bot fails to start.

2. When starting new threads for a bot, the parameter start=True is passed to the \__init__ method of the Bot class. This causes the bot at the end of the \__init__ method to call the start function, and thus start processing messages.
The problem lies in the fact that the subclasses for Bot (CollectorBot, ParserBot, ExpertBot, OutputBot) do not pass the start parameter to the (super) Bot class. This defaults the start parameter to False, hence the threads never start, and quit without doing anything.

