### PR TITLE
BUG: lib/pipeline: use blmove only if redis-py supports it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ CHANGELOG
   - Fix line recovery and message dumping of the `ParserBot` (PR#2192 by Sebastian Wagner).
     - Previously the dumped message was always the last message of a report if the report contained multiple lines leading to data-loss.
 - `intelmq.lib.pipeline`:
-  - Changed `BRPOPLPUSH` to `BLMOVE`, because `BRPOPLPUSH` has been marked as deprecated by redis in favor of `BLMOVE` (PR#2149 by Sebastian Waldbauer, fixes #1827)
+  - Changed `BRPOPLPUSH` to `BLMOVE`, because `BRPOPLPUSH` has been marked as deprecated by redis in favor of `BLMOVE` (PR#2149 and PR#2240 by Sebastian Waldbauer and Sebastian Wagner, fixes #1827, #2233).
 - `intelmq.lib.utils`:
   - Added wrapper `resolve_dns` for querying DNS, with the support for recommended methods from `dnspython` package in versions 1 and 2.
   - Moved line filtering inside `RewindableFileHandle` for easier handling and limiting number of temporary objects.


### PR DESCRIPTION
BRLPOPLPUSH is deprecated, but BLMOVE can only be used if the redis
python client does support it, ie. >= 4.1.2

fixes certtools/intelmq#2233