### PR TITLE
Fix to ensure self._mode does not get reset when reloading

### DIFF
--- a/intelmq/bots/parsers/shadowserver/parser.py
+++ b/intelmq/bots/parsers/shadowserver/parser.py
@@ -40,7 +40,7 @@ class ShadowserverParserBot(ParserBot):
     overwrite = False
 
     def init(self):
-        if self.feedname is not None:
+        if self.feedname is not None and self._mode is None:
             self._sparser_config = config.get_feed_by_feedname(self.feedname)
             if self._sparser_config:
                 self.logger.info('Using fixed feed name %r for parsing reports.' % self.feedname)


### PR DESCRIPTION
At startup, the Shadowserver Parser bot's init method sets self._mode to 'detect' since self.feedname is None. Next, when reports are parsed, self.feedname will contain the name of the last feed parsed. When the nightly logrotate run forces a reload of the bot, self._mode gets set to 'fixed' and the bot assumes erroneously that every report hereafter is of the type defined by self.feedname
