### PR TITLE
FIX: For Python 3.6, restrict the pymssql version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,7 @@ CHANGELOG
   - Lift restriction on requirement jinja2 < 3 (PR#2158 by Sebastian Wagner).
 - `intelmq.bots.outputs.sql`:
   - For PostgreSQL, escape Nullbytes in text to prevent "unsupported Unicode escape sequence" issues (PR#2223 by Sebastian Wagner, fixes #2203).
+  - For Python 3.6, restricted the required version of `pymssql` to be lower than 2.2.6 due to support dropped by the package (fixes #2262).  
 
 ### Documentation
 - Feeds: Add documentation for newly supported dataplane feeds, see above (PR#2102 by Mikk Margus Möll).

--- a/intelmq/bots/outputs/sql/REQUIREMENTS.txt
+++ b/intelmq/bots/outputs/sql/REQUIREMENTS.txt
@@ -3,3 +3,4 @@
 
 psycopg2-binary>=2.5.5
 pymssql>=2.2
+pymssql<2.2.6; python_version<="3.6"


### PR DESCRIPTION
Starting version 2.2.6 pymssql is not providing the wheels for Python 3.6 anymore. Building the package is not trivial, thus restricting version is currently the best option.

Closes: #2262

