### PR TITLE
FIX: intelmqdump: respected logging_path settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -716,6 +716,7 @@ IntelMQ no longer supports Python 3.5 (and thus Debian 9 and Ubuntu 16.04), the 
 ### Tools
 - `intelmqdump`:
     - Check if given queue is configured upon recovery (#1433, PR#1587 by Mladen Markovic).
+    - Respected global and per-bot custom settings of `logging_path` (fix #1605).
 - `intelmqctl`:
   - `intelmq list queues`: `--sum`, `--count`, `-s` flag for showing total count of messages (#1408, PR#1581 by Mladen Markovic).
   - `intelmq check`: Added a possibility to ignore queues from the orphaned queues check (by Sebastian Wagner).
@@ -737,7 +738,6 @@ IntelMQ no longer supports Python 3.5 (and thus Debian 9 and Ubuntu 16.04), the 
 - Bots started with IntelMQ-API/Manager stop when the webserver is restarted (#952).
 - Corrupt dump files when interrupted during writing (#870).
 - CSV line recovery forces Windows line endings (#1597).
-- intelmqdump: Honor logging_path variable (#1605).
 - Timeout error in mail URL fetcher (#1621).
 - AMQP pipeline: get_queues needs to check vhost of response (#1746).
 

--- a/intelmq/tests/bin/test_intelmqdump.py
+++ b/intelmq/tests/bin/test_intelmqdump.py
@@ -102,6 +102,7 @@ class TestIntelMQDump(unittest.TestCase):
 
     @mock.patch.object(intelmqdump, "input", return_value='q')
     def test_list_dumps_for_all_bots_from_custom_locations(self, _):
+        self.global_config = {"logging_path": self.tmp_log_dir.name}
         self._prepare_empty_dump('bot-1/test-1')
         self._prepare_empty_dump('bot-2/test-2')
 
@@ -140,6 +141,7 @@ class TestIntelMQDump(unittest.TestCase):
 
     @mock.patch.object(intelmqdump, "input")
     def test_list_and_select_dump_from_custom_location(self, input_mock):
+        self.global_config = {"logging_path": self.tmp_log_dir.name}
         self._prepare_empty_dump('/bot-1/test-1')
 
         self.runtime_config = {
@@ -191,8 +193,9 @@ class TestIntelMQDump(unittest.TestCase):
 
     @mock.patch.object(intelmqdump, "input", return_value='q')
     def test_get_dump_for_one_bot(self, _):
-        self._prepare_empty_dump("bot-1")
-        self.bot_configs = {"bot-1": {"parameters": {"logging_path": self.tmp_log_dir.name}}}
+        self._prepare_empty_dump("bot/bot-1")
+        self.global_config = {"logging_path": self.tmp_log_dir.name}
+        self.bot_configs = {"bot-1": {"parameters": {"logging_path": f"{self.tmp_log_dir.name}/bot"}}}
 
         output = self._run_main(["bot-1"])
         self.assertIn("Processing bot-1: empty file", output[0])

--- a/intelmq/tests/bin/test_intelmqdump.py
+++ b/intelmq/tests/bin/test_intelmqdump.py
@@ -3,9 +3,17 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
 # -*- coding: utf-8 -*-
-import unittest
 
-import intelmq.bin.intelmqdump
+import contextlib
+import io
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import termstyle
+
+from intelmq.bin import intelmqdump
 
 
 class TestCompleter(unittest.TestCase):
@@ -14,7 +22,7 @@ class TestCompleter(unittest.TestCase):
     """
 
     def test_simple(self):
-        comp = intelmq.bin.intelmqdump.Completer(['foo', 'foobar', 'else'])
+        comp = intelmqdump.Completer(['foo', 'foobar', 'else'])
         self.assertEqual(comp.complete('', 0), 'else')
         self.assertEqual(comp.complete('', 2), 'foobar')
         self.assertEqual(comp.complete('f', 0), 'foo')
@@ -22,8 +30,8 @@ class TestCompleter(unittest.TestCase):
         self.assertEqual(comp.complete('a', 0), None)
 
     def test_queues(self):
-        comp = intelmq.bin.intelmqdump.Completer(['r ', 'a '],
-                                                 queues={'some-parser-queue', 'some-expert-queue'})
+        comp = intelmqdump.Completer(['r ', 'a '],
+                                     queues={'some-parser-queue', 'some-expert-queue'})
         self.assertEqual(comp.complete('r ', 0), 'r ')
         self.assertEqual(comp.complete('r 1 ', 0), 'r 1 some-expert-queue')
         self.assertEqual(comp.complete('r 1 ', 1), 'r 1 some-parser-queue')
@@ -33,6 +41,161 @@ class TestCompleter(unittest.TestCase):
         self.assertEqual(comp.complete('a  ', 2), None)
         self.assertEqual(comp.complete('r  34 some-p', 0), 'r  34 some-parser-queue')
         self.assertEqual(comp.complete('a some-e', 0), 'a some-expert-queue')
+
+
+class TestIntelMQDump(unittest.TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.tmp_log_dir = tempfile.TemporaryDirectory()
+        self.global_config = {}
+        self.runtime_config = {}
+        self.bot_configs = {}
+
+        self.config_patcher = mock.patch.multiple(
+            intelmqdump.utils,
+            get_global_settings=mock.Mock(side_effect=self._mocked_global_config),
+            get_runtime=mock.Mock(side_effect=self._mocked_runtime_config),
+            get_bots_settings=mock.Mock(side_effect=self._mocked_bots_config))
+        self.config_patcher.start()
+
+        # Coloring output makes asserts unnecessary complicated
+        termstyle.disable()
+
+    def _mocked_global_config(self):
+        return self.global_config
+
+    def _mocked_runtime_config(self, *args):
+        return {"global": self.global_config, **self.runtime_config}
+
+    def _mocked_bots_config(self, bot_id):
+        return self.bot_configs[bot_id]
+
+    def _prepare_empty_dump(self, filename: str):
+        path = Path(f"{self.tmp_log_dir.name}/{filename}.dump")
+        path.parent.mkdir(parents=True, exist_ok=True)
+        Path(path).touch()
+
+    def tearDown(self) -> None:
+        self.config_patcher.stop()
+        self.tmp_log_dir.cleanup()
+        termstyle.auto()
+        return super().tearDown()
+
+    def _run_main(self, argv: list) -> str:
+        """Helper for running intelmqdump.main and capturing output"""
+        output = io.StringIO()
+        with contextlib.redirect_stdout(output):
+            with contextlib.suppress(SystemExit):
+                intelmqdump.main(argv)
+        return output.getvalue().split("\n")
+
+    @mock.patch.object(intelmqdump, "input", return_value='q')
+    def test_list_dumps_for_all_bots_from_default_log_path(self, _):
+        self._prepare_empty_dump('test-1')
+        self._prepare_empty_dump('test-2')
+
+        with mock.patch.object(intelmqdump, "DEFAULT_LOGGING_PATH", self.tmp_log_dir.name):
+            output = self._run_main([])
+
+        self.assertIn("0: test-1 empty file", output[1])
+        self.assertIn("1: test-2 empty file", output[2])
+
+    @mock.patch.object(intelmqdump, "input", return_value='q')
+    def test_list_dumps_for_all_bots_from_custom_locations(self, _):
+        self._prepare_empty_dump('bot-1/test-1')
+        self._prepare_empty_dump('bot-2/test-2')
+
+        self.runtime_config = {
+            "bot-1": {
+                "parameters": {
+                    "logging_path": f"{self.tmp_log_dir.name}/bot-1"
+                }
+            },
+            "bot-2": {
+                "parameters": {
+                    "logging_path": f"{self.tmp_log_dir.name}/bot-2"
+                }
+            }
+        }
+
+        output = self._run_main([])
+
+        self.assertIn("0: test-1 empty file", output[1])
+        self.assertIn("1: test-2 empty file", output[2])
+
+    @mock.patch.object(intelmqdump, "input")
+    def test_list_and_select_dump_from_global_location(self, input_mock):
+        self._prepare_empty_dump('test-1')
+
+        self.global_config = {"logging_path": self.tmp_log_dir.name}
+
+        for selector in ['0', 'test-1']:
+            with self.subTest(selector):
+                input_mock.side_effect = [selector, 'q']
+                output = self._run_main([])
+
+                self.assertIn("0: test-1 empty file", output[1])
+                # Enough to check that the correct file path was used
+                self.assertIn("Processing test-1: empty file", output[2])
+
+    @mock.patch.object(intelmqdump, "input")
+    def test_list_and_select_dump_from_custom_location(self, input_mock):
+        self._prepare_empty_dump('/bot-1/test-1')
+
+        self.runtime_config = {
+            "bot-1": {
+                "parameters": {
+                    "logging_path": f"{self.tmp_log_dir.name}/bot-1"
+                }
+            },
+        }
+        for selector in ['0', 'test-1']:
+            with self.subTest(selector):
+                input_mock.side_effect = [selector, 'q']
+                output = self._run_main([])
+
+                self.assertIn("0: test-1 empty file", output[1])
+                # Enough to check that the correct file path was used
+                self.assertIn("Processing test-1: empty file", output[2])
+
+    @mock.patch.object(intelmqdump, "input")
+    def test_selecting_dump_warns_when_filename_is_ambiguous(self, input_mock):
+        """With different locations used, there could be a case of dumps with the same
+            filename. Then, if user tried to select using filename, warn and exit.
+            Selecting using numbers should be supported"""
+
+        self._prepare_empty_dump('test-1')
+        self._prepare_empty_dump('bot-1/test-1')
+
+        self.global_config = {"logging_path": self.tmp_log_dir.name}
+        self.runtime_config = {
+            "bot-1": {
+                "parameters": {
+                    "logging_path": f"{self.tmp_log_dir.name}/bot-1"
+                }
+            },
+        }
+
+        with self.subTest("warn on ambiguous filename"):
+            input_mock.side_effect = ['test-1']
+            output = self._run_main([])
+
+            self.assertIn("0: test-1 empty file", output[1])
+            self.assertIn("1: test-1 empty file", output[2])
+            self.assertIn("Given filename is not unique, please use number", output[3])
+
+        with self.subTest("allow selecting using number"):
+            input_mock.side_effect = ['1', 'q']
+            output = self._run_main([])
+            self.assertIn("Processing test-1: empty file", output[3])
+
+    @mock.patch.object(intelmqdump, "input", return_value='q')
+    def test_get_dump_for_one_bot(self, _):
+        self._prepare_empty_dump("bot-1")
+        self.bot_configs = {"bot-1": {"parameters": {"logging_path": self.tmp_log_dir.name}}}
+
+        output = self._run_main(["bot-1"])
+        self.assertIn("Processing bot-1: empty file", output[0])
 
 
 if __name__ == '__main__':  # pragma: no cover

--- a/intelmq/tests/bin/test_intelmqdump.py
+++ b/intelmq/tests/bin/test_intelmqdump.py
@@ -58,6 +58,11 @@ class TestIntelMQDump(unittest.TestCase):
             get_bots_settings=mock.Mock(side_effect=self._mocked_bots_config))
         self.config_patcher.start()
 
+        self.ctl_config_patcher = mock.patch.multiple(
+            intelmqdump.intelmqctl.utils,
+            load_configuration=mock.Mock(side_effect=self._mocked_runtime_config))
+        self.ctl_config_patcher.start()
+
         # Coloring output makes asserts unnecessary complicated
         termstyle.disable()
 
@@ -76,6 +81,7 @@ class TestIntelMQDump(unittest.TestCase):
         Path(path).touch()
 
     def tearDown(self) -> None:
+        self.ctl_config_patcher.stop()
         self.config_patcher.stop()
         self.tmp_log_dir.cleanup()
         termstyle.auto()


### PR DESCRIPTION
'intelmqdup' supports now configuration of logging_path,
both global and custom per-both. It can find and restore
dumps from all possibly configured locations. For readibility
reasons, the behaviour of showing just the filename in the
dumps list is left unchanged. If there is more than one
dump listed with the same filename, selecting them using
filename will throw an error, and the number should be used.

Unit testes for the command are introduced. For the purpose
of the change, just checking an empty dump file is enough.

closes: #1605