### PR TITLE
FIX: Swap the logging creation and the privileges drop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,7 +133,9 @@ CHANGELOG
 - Threshold Expert tests: Use environment variable `INTELMQ_PIPELINE_HOST` as redis host, analogous to other tests (PR#2209 by Sebastian Wagner, fixes #2207).
 
 ### Tools
-- `intelmqctl`: fix process manager initialization if run non-interactively, as intelmqdump does it (PR#2189 by Sebastian Wagner, fixes 2188).
+- `intelmqctl`:
+  - fix process manager initialization if run non-interactively, as intelmqdump does it (PR#2189 by Sebastian Wagner, fixes 2188).
+  - Privilege drop before logfile creation (PR#2277 by Sebastian Waldbauer, fixes 2176)
 - `intelmqsetup`: Revised installation of manager by building the static files at setup, not build time, making it behave more meaningful. Requires intelmq-manager >= 3.1.0 (PR#2198 by Sebastian Wagner, fixes #2197).
 
 ### Contrib

--- a/intelmq/bin/intelmqctl.py
+++ b/intelmq/bin/intelmqctl.py
@@ -99,6 +99,9 @@ class IntelMQController():
         # otherwise the output on stdout/stderr is less than the user expects
         logging_level_stream = self._logging_level if self._logging_level == 'DEBUG' else 'INFO'
 
+        if drop_privileges and not utils.drop_privileges():
+            self.abort('IntelMQ must not run as root. Dropping privileges did not work.')
+
         try:
             if no_file_logging:
                 raise FileNotFoundError('Logging to file disabled.')
@@ -115,9 +118,6 @@ class IntelMQController():
                 self._logger.error('Not logging to file: %s', exc)
         if defaults_loading_exc:
             self._logger.exception('Loading the defaults configuration failed!', exc_info=defaults_loading_exc)
-
-        if drop_privileges and not utils.drop_privileges():
-            self.abort('IntelMQ must not run as root. Dropping privileges did not work.')
 
         APPNAME = "intelmqctl"
         try:


### PR DESCRIPTION
Before creating the logging file, we drop the permissions so the file owner will be intelmq.

fixes #2176

