### PR TITLE
FIX: Fixes DateTime handling of naive time string. Removes pytz dependency.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,11 @@ CHANGELOG
   - Changed `BRPOPLPUSH` to `BLMOVE`, because `BRPOPLPUSH` has been marked as deprecated by redis in favor of `BLMOVE` (PR#2149 by Sebastian Waldbauer, fixes #1827)
 - `intelmq.lib.utils`:
   - Added wrapper `resolve_dns` for querying DNS, with the support for recommended methods from `dnspython` package in versions 1 and 2.
+- `intelmq.lib.harmonization`:
+  - Fixed DateTime handling of naive time strings (previously assumed local timezone, now assumes UTC) (PR#2279 by Filip Pokorný, fixes #2278)
+  - Removes `tzone` argument from `DateTime.from_timestamp` and `DateTime.from_epoch_millis`
+  - `DateTime.from_timstamp` now also allows string argument
+- Removes `pytz` global dependency
 
 ### Development
 - Removed Python 3.6 from CI.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -7,7 +7,6 @@ dnspython>=1.11.1
 psutil>=1.2.1
 python-dateutil>=2.5
 python-termstyle>=0.1.10
-pytz>=2012c
 redis>=2.10
 requests>=2.2.0
 ruamel.yaml

--- a/docs/user/installation.rst
+++ b/docs/user/installation.rst
@@ -119,7 +119,7 @@ CentOS 7 / RHEL 7:
 .. code-block:: bash
 
    yum install epel-release
-   yum install python36 python36-dns python36-pytz python36-requests python3-setuptools redis bash-completion jq
+   yum install python36 python36-dns python36-requests python3-setuptools redis bash-completion jq
    yum install gcc gcc-c++ python36-devel
    # optional dependencies
    yum install python3-psycopg2
@@ -129,7 +129,7 @@ CentOS 8:
 .. code-block:: bash
 
     dnf install epel-release
-    dnf install python3-dateutil python3-dns python3-pip python3-psutil python3-pytz python3-redis python3-requests redis bash-completion jq
+    dnf install python3-dateutil python3-dns python3-pip python3-psutil python3-redis python3-requests redis bash-completion jq
     # optional dependencies
     dnf install python3-psycopg2 python3-pymongo
 
@@ -137,7 +137,7 @@ openSUSE:
 
 .. code-block:: bash
 
-   zypper install python3-dateutil python3-dnspython python3-psutil python3-pytz python3-redis python3-requests python3-python-termstyle redis bash-completion jq
+   zypper install python3-dateutil python3-dnspython python3-psutil python3-redis python3-requests python3-python-termstyle redis bash-completion jq
    # optional dependencies
    zypper in python3-psycopg2 python3-pymongo
 

--- a/intelmq/bots/collectors/microsoft/collector_interflow.py
+++ b/intelmq/bots/collectors/microsoft/collector_interflow.py
@@ -34,9 +34,8 @@ import gzip
 import io
 import re
 import sys
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
-import pytz
 from dateutil import parser
 
 from intelmq.lib.bot import CollectorBot
@@ -68,7 +67,7 @@ class MicrosoftInterflowCollectorBot(CollectorBot, HttpMixin, CacheMixin):
         over.
         """
         if isinstance(self.time_match, datetime):  # absolute
-            now = datetime.now(tz=pytz.timezone('UTC'))
+            now = datetime.now(tz=timezone.utc)
             if now - timedelta(seconds=self.redis_cache_ttl) > self.time_match:
                 raise ValueError("The cache's TTL must be higher than 'not_older_than', "
                                  "otherwise the bot is processing the same data over and over again.")
@@ -84,7 +83,7 @@ class MicrosoftInterflowCollectorBot(CollectorBot, HttpMixin, CacheMixin):
             try:
                 self.time_match = timedelta(minutes=parse_relative(self.not_older_than))
             except ValueError:
-                self.time_match = parser.parse(self.not_older_than).astimezone(pytz.utc)
+                self.time_match = parser.parse(self.not_older_than).astimezone(timezone.utc)
                 self.logger.info("Filtering files absolute %r.", self.time_match)
                 self.check_ttl_time()
             else:
@@ -113,7 +112,7 @@ class MicrosoftInterflowCollectorBot(CollectorBot, HttpMixin, CacheMixin):
                 self.logger.debug('File %r does not match absolute time filter.', file['Name'])
                 continue
             else:
-                now = datetime.now(tz=pytz.timezone('UTC'))
+                now = datetime.now(tz=timezone.utc)
                 if isinstance(self.time_match, timedelta) and filetime < (now - self.time_match):
                     self.logger.debug('File %r does not match relative time filter.', file['Name'])
                     continue

--- a/intelmq/bots/experts/filter/expert.py
+++ b/intelmq/bots/experts/filter/expert.py
@@ -5,9 +5,8 @@
 # -*- coding: utf-8 -*-
 
 import re
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
-import pytz
 from dateutil import parser
 
 from intelmq.lib.bot import ExpertBot
@@ -79,7 +78,7 @@ class FilterExpertBot(ExpertBot):
         # time based filtering
         if self.time_filter and 'time.source' in event:
             try:
-                event_time = parser.parse(str(event.get('time.source'))).replace(tzinfo=pytz.timezone('UTC'))
+                event_time = parser.parse(str(event.get('time.source'))).replace(tzinfo=timezone.utc)
             except ValueError:
                 self.logger.error("Could not parse time.source %s.", event.get('time.source'))
             else:
@@ -92,7 +91,7 @@ class FilterExpertBot(ExpertBot):
                     self.logger.debug("Filtered out event with time.source %r.", event.get('time.source'))
                     return
 
-                now = datetime.now(tz=pytz.timezone('UTC'))
+                now = datetime.now(tz=timezone.utc)
                 if type(self.not_after) is timedelta and event_time > (now - self.not_after):
                     self.acknowledge_message()
                     self.logger.debug("Filtered out event with time.source %r.", event.get('time.source'))

--- a/intelmq/tests/lib/test_harmonization.py
+++ b/intelmq/tests/lib/test_harmonization.py
@@ -13,7 +13,6 @@ import unittest
 
 import intelmq.lib.harmonization as harmonization
 import intelmq.lib.test as test
-import pytz
 
 
 class TestHarmonization(unittest.TestCase):
@@ -210,25 +209,13 @@ class TestHarmonization(unittest.TestCase):
                          harmonization.DateTime.from_epoch_millis(1441008970))
         self.assertEqual('2015-08-31T08:16:10+00:00',
                          harmonization.DateTime.from_epoch_millis("1441008970"))
-        self.assertEqual('2015-08-31T07:16:10-01:00',
-                         harmonization.DateTime.from_epoch_millis(144100897000,
-                                                                 'Etc/GMT+1'))
-        self.assertEqual('2015-08-31T04:16:10-04:00',
-                         harmonization.DateTime.from_epoch_millis(1441008970000,
-                                                                     'America/'
-                                                                     'Guyana'))
 
     def test_datetime_from_timestamp(self):
         """ Test DateTime.from_timestamp method. """
         self.assertEqual('2015-08-31T08:16:10+00:00',
                          harmonization.DateTime.from_timestamp(1441008970))
-        self.assertEqual('2015-08-31T07:16:10-01:00',
-                         harmonization.DateTime.from_timestamp(1441008970,
-                                                               'Etc/GMT+1'))
-        self.assertEqual('2015-08-31T04:16:10-04:00',
-                         harmonization.DateTime.from_timestamp(1441008970,
-                                                               'America/'
-                                                               'Guyana'))
+        self.assertEqual('2015-08-31T08:16:10+00:00',
+                         harmonization.DateTime.from_timestamp("1441008970"))
 
     def test_datetime_from_windows_nt(self):
         """ Test DateTime.from_ldap method. """
@@ -244,12 +231,6 @@ class TestHarmonization(unittest.TestCase):
                          harmonization.DateTime.sanitize(
                          '2016-07-19 13:08:38 UTC'))
 
-    def test_datetime_from_timestamp_invalid(self):
-        """ Test DateTime.from_timestamp method with invalid inputs. """
-        with self.assertRaises(TypeError):
-            harmonization.DateTime.from_timestamp('1441008970')
-
-    @unittest.skipIf(time.timezone != 0, 'Test only works with UTC')
     def test_datetime_convert(self):
         self.assertEqual('2019-07-01T15:15:15+00:00',
                          harmonization.DateTime.convert('15 15 15 07 01 2019',
@@ -267,7 +248,7 @@ class TestHarmonization(unittest.TestCase):
                          harmonization.DateTime.parse_utc_isoformat('2020-12-31T12:00:00+00:00'))
         self.assertEqual('2020-12-31T12:00:00.001+00:00',
                          harmonization.DateTime.parse_utc_isoformat('2020-12-31T12:00:00.001+00:00'))
-        self.assertEqual(datetime.datetime(year=2020, month=12, day=31, hour=12, tzinfo=pytz.utc),
+        self.assertEqual(datetime.datetime(year=2020, month=12, day=31, hour=12, tzinfo=datetime.timezone.utc),
                          harmonization.DateTime.parse_utc_isoformat('2020-12-31T12:00:00+00:00',
                                                                     return_datetime=True))
 

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,6 @@ REQUIRES = [
     'psutil>=1.2.1',
     'python-dateutil>=2.5',
     'python-termstyle>=0.1.10',
-    'pytz>=2012c',
     'redis>=2.10',
     'requests>=2.2.0',
     'ruamel.yaml',


### PR DESCRIPTION
Fixes #2278. Globally removes pytz dependency.

It removes a very small functionality that is not used at all: when making DateTime object from timestamp it is now not possible to also set the timezone of the resulting time. This is also contradictory with the documentation on DateTime which says that UTC is the only allowed timezone.

~~Also fixes following deprecation warning:~~
~~`intelmq/intelmq/lib/harmonization.py:718: DeprecationWarning: please use dns.resolver.resolve() instead`~~