### PR TITLE
TEST: Fix testing against dnspython v1

### DIFF
--- a/intelmq/tests/lib/test_utils.py
+++ b/intelmq/tests/lib/test_utils.py
@@ -376,7 +376,7 @@ class TestUtils(unittest.TestCase):
 
     @unittest.mock.patch.object(utils.dns.version, "MAJOR", 2)
     def test_resolve_dns_supports_dnspython_v2(self):
-        with unittest.mock.patch.object(utils.dns.resolver, "resolve") as resolve_mocks:
+        with unittest.mock.patch.object(utils.dns.resolver, "resolve", create=True) as resolve_mocks:
             utils.resolve_dns("example.com", "any", other="parameter")
 
         resolve_mocks.assert_called_once_with("example.com", "any", other="parameter", search=True)


### PR DESCRIPTION
The test case for dns compatibility layer on dnspython
version 2 needed to create mocked attribute when running
in the environement with older dnspython package.

Fix #2289