### PR TITLE
FIX: Disabled Feodotracker bots in default config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ CHANGELOG
 - Upgraded syntax to Python 3.6 (mostly Format-Strings) using pyuprade (PR#2136 by Sebastian Wagner).
 
 ### Configuration
+- Disabled the Feodo bots in the default configuration as they required additional dependencies to run (fixes [#1499](https://github.com/certtools/intelmq/issues/1499)).
 
 ### Core
 - `intelmq.lib.upgrades`:

--- a/intelmq/etc/runtime.yaml
+++ b/intelmq/etc/runtime.yaml
@@ -40,7 +40,7 @@ deduplicator-expert:
 feodo-tracker-browse-collector:
   description: Generic URL Fetcher is the bot responsible to get the report from an
     URL.
-  enabled: true
+  enabled: false
   group: Collector
   module: intelmq.bots.collectors.http.collector_http
   name: URL Fetcher
@@ -60,7 +60,7 @@ feodo-tracker-browse-collector:
 feodo-tracker-browse-parser:
   description: HTML Table Parser is a bot configurable to parse different html table
     data.
-  enabled: true
+  enabled: false
   group: Parser
   module: intelmq.bots.parsers.html_table.parser
   name: HTML Table


### PR DESCRIPTION
Feodotracker bots requires additional, heavy dependencies
(beautifulsoup4) to start. Disabling them in the default
conf allows us to ship the working config with the package
without increase the dependencies required to install
at the beginning.

Fix: #1499
