### PR TITLE
FIX Very slow dataplane parser due to loading the config for every event

### DIFF
--- a/intelmq/bots/parsers/dataplane/parser.py
+++ b/intelmq/bots/parsers/dataplane/parser.py
@@ -6,7 +6,6 @@
 """ IntelMQ Dataplane Parser """
 
 from intelmq.lib.bot import ParserBot
-from intelmq.lib.message import Event
 
 
 class DataplaneParserBot(ParserBot):
@@ -64,7 +63,7 @@ class DataplaneParserBot(ParserBot):
         if line.startswith('#') or len(line) == 0:
             self.tempdata.append(line)
         else:
-            event = Event(report)
+            event = self.new_event(report)
 
             line_contents = line.split('|')
             if len(line_contents) != len(self.FILE_FORMAT) + 1:


### PR DESCRIPTION
The Dataplane parser creates a new event for every data line. The harmonization config is not passed to this constructor.
This causes the code to load the harmonization config for every data line.

For feeds like http://dataplane.org/sshclient.txt, this will load the harmonization config almost 40,000 times. Hence it can take hours to parse all the feeds.
This fix reuses the harmonization config that is already loaded in the bot. This reduces the parse time to minutes (if not seconds).