### PR TITLE
TST: bin/ctl.check: Skip executables check in tests

### DIFF
--- a/intelmq/bin/intelmqctl.py
+++ b/intelmq/bin/intelmqctl.py
@@ -822,7 +822,7 @@ Get some debugging output on the settings and the environment (to be extended):
         self.log_log_messages(messages[::-1])
         return 0, messages[::-1]
 
-    def check(self, no_connections=False):
+    def check(self, no_connections=False, check_executables=True):
         retval = 0
         if self._returntype is ReturnType.JSON:
             check_logger, list_handler = utils.setup_list_logging(name='check', logging_level=self._logging_level)
@@ -945,13 +945,14 @@ Get some debugging output on the settings and the environment (to be extended):
                 if bot_check:
                     for log_line in bot_check:
                         getattr(check_logger, log_line[0])(f"Bot {bot_id!r}: {log_line[1]}")
-        for group in utils.list_all_bots().values():
-            for bot_id, bot in group.items():
-                if subprocess.call(['which', bot['module']], stdout=subprocess.DEVNULL,
-                                   stderr=subprocess.DEVNULL):
-                    check_logger.error('Incomplete installation: Executable %r for %r not found in $PATH (%r).',
-                                       bot['module'], bot_id, os.getenv('PATH'))
-                    retval = 1
+        if check_executables:
+            for group in utils.list_all_bots().values():
+                for bot_id, bot in group.items():
+                    if subprocess.call(['which', bot['module']], stdout=subprocess.DEVNULL,
+                                       stderr=subprocess.DEVNULL):
+                        check_logger.error('Incomplete installation: Executable %r for %r not found in $PATH (%r).',
+                                           bot['module'], bot_id, os.getenv('PATH'))
+                        retval = 1
 
         if os.path.isfile(STATE_FILE_PATH):
             state = utils.load_configuration(STATE_FILE_PATH)

--- a/intelmq/tests/bin/test_intelmqctl.py
+++ b/intelmq/tests/bin/test_intelmqctl.py
@@ -102,13 +102,13 @@ class TestIntelMQController(unittest.TestCase):
 
     def test_check_passed_with_default_harmonization_and_empty_runtime(self):
         self._load_default_harmonization()
-        self.assertEqual((0, 'success'), self.intelmqctl.check(no_connections=True))
+        self.assertEqual((0, 'success'), self.intelmqctl.check(no_connections=True, check_executables=False))
 
     def test_check_pass_with_default_runtime(self):
         with mock.patch.object(ctl.utils, "RUNTIME_CONF_FILE", self.tmp_runtime):
             self._load_default_harmonization()
             self._load_default_runtime()
-            self.assertEqual((0, 'success'), self.intelmqctl.check(no_connections=True))
+            self.assertEqual((0, 'success'), self.intelmqctl.check(no_connections=True, check_executables=False))
 
     @mock.patch.object(ctl.importlib, "import_module", mock.Mock(side_effect=SyntaxError))
     def test_check_handles_syntaxerror_when_importing_bots(self):


### PR DESCRIPTION
in test environments, the executables don't exist necessarily add a parameter to check() to allow skipping these tests

fixes certtools/intelmq#2300