### PR TITLE
FIX: Fixes a bug in default_fields upgrade function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ CHANGELOG
 ### Core
 - Fixed not resetting destination path statistics in the stats cache after restarting bot (Fixes [#2331](https://github.com/certtools/intelmq/issues/2331))
 - Force flushing statistics if bot will sleep longer than flushing delay (Fixes [#2336](https://github.com/certtools/intelmq/issues/2336))
+- `intelmq.lib.upgrages`: Fix a bug in the upgrade function for version 3.1.0 which caused an exception if a generic csv parser instance had no parameter `type` (PR#2319 by Filip Pokorný).
 
 ### Development
 

--- a/intelmq/lib/upgrades.py
+++ b/intelmq/lib/upgrades.py
@@ -808,10 +808,11 @@ def v310_feed_changes(configuration, harmonization, dry_run, **kwargs):
                 bot["module"] == "intelmq.bots.parsers.abusech.parser_domain"):
             found_abusech_removed_parsers.append(bot_id)
         if bot["module"] == "intelmq.bots.parsers.generic.parser_csv":
-            bot["parameters"]["default_fields"] = {
-                "classification.type": bot["parameters"]["type"]
-            }
-            del bot["parameters"]["type"]
+            if bot.get("parameters") and bot["parameters"].get("type"):
+                bot["parameters"]["default_fields"] = {
+                    "classification.type": bot["parameters"]["type"]
+                }
+                del bot["parameters"]["type"]
         if bot["module"] == "intelmq.bots.parsers.taichung.parser":
             found_taichung.append(bot_id)
 


### PR DESCRIPTION
Not all CSV parsers have `type` key unfortunately... :cry: 