### PR TITLE
FIX: Fixed typos found by new codespell

### DIFF
--- a/.github/workflows/codespell.excludelines
+++ b/.github/workflows/codespell.excludelines
@@ -34,3 +34,6 @@ Destination                 destination.local_hostname          :ref:`string`   
 
 # ./docs/dev/harmonization-fields.rst:28: compromized ==> compromised
 Destination                 destination.local_ip                :ref:`ipaddress`              Some sources report a internal (NATed) IP address related a compromized system. N.B. RFC1918 IPs are OK here.
+
+# ./intelmq/tests/bots/parsers/shodan/test_parser.py:36: ALLO ==> ALLOW
+                         '   ALLO   MLST   MLSD   SITE   P@SW   STRU   CLNT   MFMT\n'

--- a/intelmq/bots/parsers/cymru/parser_cap_program.py
+++ b/intelmq/bots/parsers/cymru/parser_cap_program.py
@@ -251,7 +251,7 @@ class CymruCAPProgramParserBot(ParserBot):
         """
         category, ip, asn, timestamp, notes, asninfo = line.split('|')
 
-        # to detect bogous lines like 'hostname: sub.example.comport: 80'
+        # to detect bogus lines like 'hostname: sub.example.comport: 80'
         bogus = BOGUS_HOSTNAME_PORT.search(notes)
         if bogus:
             span = bogus.span()

--- a/intelmq/lib/utils.py
+++ b/intelmq/lib/utils.py
@@ -687,7 +687,7 @@ def drop_privileges() -> bool:
         except (OSError, KeyError):
             # KeyError: User or group 'intelmq' does not exist
             return False
-    if os.geteuid() != 0:  # For the unprobably possibility that intelmq is root
+    if os.geteuid() != 0:  # For the improbably possibility that intelmq is root
         return True
     return False
 


### PR DESCRIPTION
New codespell release updated dictionary, and found a few
new typos.

This unblocks other PRs.