### PR TITLE
FIX: Flush statistics before rate limiting bot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ CHANGELOG
 
 ### Core
 - Fixed not resetting destination path statistics in the stats cache after restarting bot (Fixes [#2331](https://github.com/certtools/intelmq/issues/2331))
+- Force flushing statistics if bot will sleep longer than flushing delay (Fixes [#2336](https://github.com/certtools/intelmq/issues/2336))
 
 ### Development
 

--- a/intelmq/lib/bot.py
+++ b/intelmq/lib/bot.py
@@ -512,6 +512,9 @@ class Bot:
             if log:
                 self.logger.info("Idling for {:.1f}s ({}) now.".format(remaining,
                                                                        utils.seconds_to_human(remaining)))
+            if timedelta(seconds=remaining) > self.__message_counter_delay:
+                self.__stats(force=True)
+
             time.sleep(remaining)
             self.__handle_sighup()
             remaining = self.rate_limit - (time.time() - starttime)


### PR DESCRIPTION
Previously, statistics weren't flushed before applying rate limiting,
even if sleeping time was longer than statistics delay. This caused
significant delay in statistics. Now, statistics are flushed before
sleeping, if expected delay is longer than flushing delay.

Fixes #2336