### PR TITLE
FIX: intelmqsetup - never take ownership of /

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ CHANGELOG
 
 ### Tools
 - `intelmqsetup`:
-  - SECURITY: fixed a low-risk bug causing the tool to change owner of `/` path if running with the `INTELMQ_PATHS_NO_OPT` environment variable set to `True`. This affects only the PIP package as the DEB package doesn't contain this tool. (PR#2355 by Kamil Mańkowski)
+  - SECURITY: fixed a low-risk bug causing the tool to change owner of `/` if run with the `INTELMQ_PATHS_NO_OPT` environment variable set. This affects only the PIP package as the DEB/RPM packages don't contain this tool. (PR#2355 by Kamil Mańkowski, fixes #2354)
 
 ### Known Errors
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ CHANGELOG
 ### Packaging
 
 ### Tools
+- `intelmqsetup`:
+  - SECURITY: fixed a low-risk bug causing the tool to change owner of `/` path if running with the `INTELMQ_PATHS_NO_OPT` environment variable set to `True`. This affects only the PIP package as the DEB package doesn't contain this tool. (PR#2355 by Kamil Mańkowski)
 
 ### Known Errors
 

--- a/intelmq/bin/intelmqsetup.py
+++ b/intelmq/bin/intelmqsetup.py
@@ -95,6 +95,9 @@ def create_directory(directory: str, octal_mode: int):
 
 
 def change_owner(file: str, owner: Optional[str] = None, group: Optional[str] = None, log: bool = True):
+    if Path(file).as_posix() in ['/', '//']:
+        # Skip taking ownership over system root path
+        return
     if owner and Path(file).owner() != owner:
         if log:
             print(f'Fixing owner of {file!s}.')

--- a/intelmq/tests/bin/test_intelmqsetup.py
+++ b/intelmq/tests/bin/test_intelmqsetup.py
@@ -1,0 +1,35 @@
+"""Tests for the intelmqsetup
+
+SPDX-FileCopyrightText: 2023 CERT.at GmbH <https://cert.at/>
+SPDX-License-Identifier: AGPL-3.0-or-later
+"""
+
+import unittest
+from unittest import mock
+
+from intelmq.bin import intelmqsetup
+
+
+class TestOwnership(unittest.TestCase):
+    @mock.patch("shutil.chown")
+    def test_skip_changing_root_path_ownership(self, chown_mock):
+        with mock.patch.object(intelmqsetup.Path, 'owner') as owner_mock:
+            with mock.patch.object(intelmqsetup.Path, 'group') as group_mock:
+                owner_mock.return_value = 'root'
+                group_mock.return_value = 'root'
+                intelmqsetup.change_owner('/', 'intelmq', 'intelmq')
+                intelmqsetup.change_owner('//', 'intelmq', 'intelmq')
+                intelmqsetup.change_owner('///', 'intelmq', 'intelmq')
+
+        chown_mock.assert_not_called()
+
+    @mock.patch("shutil.chown")
+    def test_change_file_ownership(self, chown_mock):
+        with mock.patch.object(intelmqsetup.Path, 'owner') as owner_mock:
+            with mock.patch.object(intelmqsetup.Path, 'group') as group_mock:
+                owner_mock.return_value = 'root'
+                group_mock.return_value = 'root'
+                intelmqsetup.change_owner('/the/path', 'intelmq', 'intelmq')
+
+        chown_mock.assert_any_call('/the/path', user='intelmq')
+        chown_mock.assert_any_call('/the/path', group='intelmq')


### PR DESCRIPTION
The tool intelmqsetup wants to change the owner ROOT_DIR path.
If instructed to install IntelMQ in LSB-style paths, it's set
to the '/' resulting in changing the owner of system root to
intelmq.

This case is rare to happen (requires explixitly set INTELMQ_PATHS_NO_OPT
variable and using PIP package or directly the source code,
as the native package doesn't contain intelmqsetup), but it's
still potentially dangerous and can cause the system degradation
(e.g. prevents systemd-tmpfiles from working correctly).

Fixes: #2354
