### PR TITLE
Some Bugfixes

### DIFF
--- a/.github/workflows/ansible-tests.yml
+++ b/.github/workflows/ansible-tests.yml
@@ -15,9 +15,9 @@ on:
       - '.github/**'
 
 jobs:
-  build:
+  ansible:
     # temporary fix for https://github.com/actions/virtual-environments/issues/3080
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     name: Run ansible tests
 
     steps:

--- a/docs/user/bots.rst
+++ b/docs/user/bots.rst
@@ -1928,7 +1928,7 @@ RemoveAffix
 
 **Configuration Parameters**
 
-* `remove_prefix`: True - cut from start, False - cut from end
+* `remove_prefix`: True - cut from start, False - cut from end. Default: True
 * `affix`: example 'www.'
 * `field`: example field 'source.fqdn'
 

--- a/intelmq/bots/experts/domain_suffix/expert.py
+++ b/intelmq/bots/experts/domain_suffix/expert.py
@@ -36,7 +36,7 @@ class DomainSuffixExpertBot(ExpertBot):
 
     def init(self):
         if self.field not in ALLOWED_FIELDS:
-            raise InvalidArgument('key', got=self.field, expected=ALLOWED_FIELDS)
+            raise InvalidArgument('field', got=self.field, expected=ALLOWED_FIELDS)
         with codecs.open(self.suffix_file, encoding='UTF-8') as file_handle:
             self.psl = PublicSuffixList(source=file_handle, only_icann=True)
 

--- a/intelmq/bots/experts/jinja/expert.py
+++ b/intelmq/bots/experts/jinja/expert.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
-from intelmq.lib.bot import Bot
+from intelmq.lib.bot import ExpertBot
 from intelmq.lib.exceptions import MissingDependencyError
 
 import pathlib
@@ -15,7 +15,7 @@ except ImportError:
     Template = None
 
 
-class JinjaExpertBot(Bot):
+class JinjaExpertBot(ExpertBot):
     """
     Modify the message using the Jinja templating engine
     Example:

--- a/intelmq/bots/experts/remove_affix/expert.py
+++ b/intelmq/bots/experts/remove_affix/expert.py
@@ -4,10 +4,10 @@ Remove Affix
 SPDX-FileCopyrightText: 2021 Marius Karotkis <marius.karotkis@gmail.com>
 SPDX-License-Identifier: AGPL-3.0-or-later
 """
-from intelmq.lib.bot import Bot
+from intelmq.lib.bot import ExpertBot
 
 
-class RemoveAffixExpertBot(Bot):
+class RemoveAffixExpertBot(ExpertBot):
     remove_prefix: bool = True  # True - from start, False - from end
     affix: str = 'www.'
     field: str = 'source.fqdn'

--- a/intelmq/bots/outputs/amqptopic/output.py
+++ b/intelmq/bots/outputs/amqptopic/output.py
@@ -143,7 +143,11 @@ class AMQPTopicOutputBot(OutputBot):
 
     def shutdown(self):
         if self._connection:
-            self._connection.close()
+            try:
+                self._connection.close()
+            except pika.exceptions.ConnectionWrongStateError:
+                # pika.exceptions.ConnectionWrongStateError: BlockingConnection.close(200, 'Normal shutdown') called on closed connection.
+                pass
 
 
 BOT = AMQPTopicOutputBot

--- a/intelmq/lib/bot.py
+++ b/intelmq/lib/bot.py
@@ -52,6 +52,7 @@ class Bot:
     __message_counter_delay: timedelta = timedelta(seconds=2)
     __stats_cache: cache.Cache = None
 
+    logger = None
     # Bot is capable of SIGHUP delaying
     _sighup_delay: bool = True
     # From the runtime configuration

--- a/intelmq/lib/bot.py
+++ b/intelmq/lib/bot.py
@@ -49,8 +49,12 @@ IGNORED_SYSTEM_PARAMETERS = {'groupname', 'bot_id', 'parameters'}
 class Bot:
     """ Not to be reset when initialized again on reload. """
     __current_message: Optional[libmessage.Message] = None
+    __message_counter: dict = {"since": None}
     __message_counter_delay: timedelta = timedelta(seconds=2)
     __stats_cache: cache.Cache = None
+    __source_pipeline = None
+    __destination_pipeline = None
+    __log_buffer: List[tuple] = []
 
     logger = None
     # Bot is capable of SIGHUP delaying

--- a/intelmq/lib/bot.py
+++ b/intelmq/lib/bot.py
@@ -32,6 +32,7 @@ from typing import Any, List, Optional, Union
 
 import intelmq.lib.message as libmessage
 from intelmq import (DEFAULT_LOGGING_PATH,
+                     DEFAULT_LOGGING_LEVEL,
                      HARMONIZATION_CONF_FILE,
                      RUNTIME_CONF_FILE, __version__)
 from intelmq.lib import cache, exceptions, utils
@@ -85,8 +86,8 @@ class Bot:
     log_processed_messages_count: int = 500
     log_processed_messages_seconds: int = 900
     logging_handler: str = "file"
-    logging_level: str = "INFO"
-    logging_path: str = "/opt/intelmq/var/log/"
+    logging_level: str = DEFAULT_LOGGING_LEVEL
+    logging_path: str = DEFAULT_LOGGING_PATH
     logging_syslog: str = "/dev/log"
     process_manager: str = "intelmq"
     rate_limit: int = 0

--- a/intelmq/lib/bot.py
+++ b/intelmq/lib/bot.py
@@ -38,7 +38,7 @@ from intelmq import (DEFAULT_LOGGING_PATH,
 from intelmq.lib import cache, exceptions, utils
 from intelmq.lib.pipeline import PipelineFactory, Pipeline
 from intelmq.lib.utils import RewindableFileHandle, base64_decode
-from intelmq.lib.datatypes import *
+from intelmq.lib.datatypes import BotType
 
 __all__ = ['Bot', 'CollectorBot', 'ParserBot', 'OutputBot', 'ExpertBot']
 ALLOWED_SYSTEM_PARAMETERS = {'enabled', 'run_mode', 'group', 'description', 'module', 'name'}

--- a/intelmq/lib/bot.py
+++ b/intelmq/lib/bot.py
@@ -961,9 +961,8 @@ class ParserBot(Bot):
 
     default_fields: Optional[dict] = {}
 
-    def __init__(self, bot_id: str, start: bool = False, sighup_event=None,
-                 disable_multithreading: bool = None):
-        super().__init__(bot_id, start, sighup_event, disable_multithreading)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         if self.__class__.__name__ == 'ParserBot':
             self.logger.error('ParserBot can\'t be started itself. '
                               'Possible Misconfiguration.')
@@ -1257,9 +1256,8 @@ class CollectorBot(Bot):
     provider: Optional[str] = None
     documentation: Optional[str] = None
 
-    def __init__(self, bot_id: str, start: bool = False, sighup_event=None,
-                 disable_multithreading: bool = None):
-        super().__init__(bot_id, start, sighup_event, disable_multithreading)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         if self.__class__.__name__ == 'CollectorBot':
             self.logger.error('CollectorBot can\'t be started itself. '
                               'Possible Misconfiguration.')
@@ -1317,9 +1315,8 @@ class ExpertBot(Bot):
     """
     bottype = BotType.EXPERT
 
-    def __init__(self, bot_id: str, start: bool = False, sighup_event=None,
-                 disable_multithreading: bool = None):
-        super().__init__(bot_id, start, sighup_event, disable_multithreading)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
 
 class OutputBot(Bot):
@@ -1328,9 +1325,8 @@ class OutputBot(Bot):
     """
     bottype = BotType.OUTPUT
 
-    def __init__(self, bot_id: str, start: bool = False, sighup_event=None,
-                 disable_multithreading: bool = None):
-        super().__init__(bot_id, start, sighup_event, disable_multithreading)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         if self.__class__.__name__ == 'OutputBot':
             self.logger.error('OutputBot can\'t be started itself. '
                               'Possible Misconfiguration.')

--- a/intelmq/lib/bot.py
+++ b/intelmq/lib/bot.py
@@ -28,7 +28,7 @@ import types
 import warnings
 from collections import defaultdict
 from datetime import datetime, timedelta
-from typing import Any, List, Optional, Union
+from typing import Any, List, Optional, Union, Tuple
 
 import intelmq.lib.message as libmessage
 from intelmq import (DEFAULT_LOGGING_PATH,
@@ -563,7 +563,7 @@ class Bot:
                 print(level.upper(), '-', message)
         self.__log_buffer = []
 
-    def __check_bot_id(self, name: str):
+    def __check_bot_id(self, name: str) -> Tuple[str, str, str]:
         res = re.fullmatch(r'([0-9a-zA-Z\-]+)(\.[0-9]+)?', name)
         if res:
             if not (res.group(2) and threading.current_thread() == threading.main_thread()):
@@ -572,6 +572,7 @@ class Bot:
                                   "Invalid bot id, must match '"
                                   r"[^0-9a-zA-Z\-]+'."))
         self.stop()
+        return False, False, False
 
     def __connect_pipelines(self):
         pipeline_args = {key: getattr(self, key) for key in dir(self) if not inspect.ismethod(getattr(self, key)) and (key.startswith('source_pipeline_') or key.startswith('destination_pipeline'))}

--- a/intelmq/lib/bot.py
+++ b/intelmq/lib/bot.py
@@ -227,7 +227,7 @@ class Bot:
 
                 @atexit.register
                 def catch_shutdown():
-                    self.stop()
+                    self.stop(exitcode=0)
         except Exception as exc:
             if self.error_log_exception:
                 self.logger.exception('Bot initialization failed.')

--- a/intelmq/lib/mixins/cache.py
+++ b/intelmq/lib/mixins/cache.py
@@ -44,8 +44,6 @@ class CacheMixin:
         return retval
 
     def cache_set(self, key: str, value: Any, ttl: Optional[int] = None):
-        if self.redis_cache_ttl is None:
-            ttl = self.redis_cache_ttl
         if isinstance(value, str):
             value = utils.encode(value)
         # backward compatibility (Redis v2.2)

--- a/intelmq/lib/pipeline.py
+++ b/intelmq/lib/pipeline.py
@@ -3,6 +3,16 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
 # -*- coding: utf-8 -*-
+
+"""
+Algorithm
+---------
+[Receive]     B RPOP LPUSH   source_queue ->  internal_queue
+[Send]        LPUSH          message      ->  destination_queue
+[Acknowledge] RPOP           message      <-  internal_queue
+"""
+
+
 import time
 from itertools import chain
 from typing import Dict, Optional
@@ -326,18 +336,13 @@ class Redis(Pipeline):
         Rejecting is a no-op as the message is in the internal queue anyway.
         """
 
-# Algorithm
-# ---------
-# [Receive]     B RPOP LPUSH   source_queue ->  internal_queue
-# [Send]        LPUSH          message      ->  destination_queue
-# [Acknowledge] RPOP           message      <-  internal_queue
-
 
 class Pythonlist(Pipeline):
     """
     This pipeline uses simple lists and is only for testing purpose.
 
     It behaves in most ways like a normal pipeline would do,
+    including all encoding and decoding steps,
     but works entirely without external modules and programs.
     Data is saved as it comes (no conversion) and it is not blocking.
     """

--- a/intelmq/lib/utils.py
+++ b/intelmq/lib/utils.py
@@ -311,7 +311,12 @@ class StreamHandler(logging.StreamHandler):
                 stream = sys.stderr
                 stream.write(red(msg))
             stream.write(self.terminator)
-            self.flush()
+            try:
+                self.flush()
+            except ValueError:
+                # I/O operation on closed file.
+                # stdout/stderr is already close (during shutdown), there's nothing we can do about it
+                pass
         except Exception:
             self.handleError(record)
 


### PR DESCRIPTION
* doc: lib/pipeline: move arch docs to module docstring
* cache mixin: remove unused operation
* bugfix: domain suffix: fix parameter error message
* lib/bot: use *args, **kwargs for derived classes' constructors
  avoids errors when parameters of Bot change
  now all derived classes are always compatible
* lib/bot: load logging defaults from constants