### PR TITLE
sql output: new parameter `fail_on_error`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,8 @@ CHANGELOG
   - Avoid extraneous search domain-based queries on NXDOMAIN result (PR#2352)
 
 #### Outputs
-- `intelmq.bots.output.cif3.output`: Added (PR#2244 by Michael Davis).
+- `intelmq.bots.outputs.cif3.output`: Added (PR#2244 by Michael Davis).
+- `intelmq.bots.outputs.sql.output`: New parameter `fail_on_errors` (PR#2362 by Sebastian Wagner).
 
 ### Documentation
 

--- a/docs/user/bots.rst
+++ b/docs/user/bots.rst
@@ -4116,6 +4116,7 @@ The parameters marked with 'PostgreSQL' will be sent to libpq via psycopg2. Chec
 * `table`: name of the database table into which events are to be inserted
 * `fields`: list of fields to read from the event. If None, read all fields
 * `reconnect_delay`: number of seconds to wait before reconnecting in case of an error
+* `fail_on_errors`: If any error should cause the bot to fail (raise an exception) or otherwise rollback. If false (default), the bot eventually waits and re-try (e.g. re-connect) etc. to solve the issue. If true, the bot raises an exception and - depending on the IntelMQ error handling configuration - stops.
 
 PostgreSQL
 ~~~~~~~~~~

--- a/intelmq/bots/outputs/sql/output.py
+++ b/intelmq/bots/outputs/sql/output.py
@@ -53,7 +53,7 @@ class SQLOutputBot(OutputBot, SQLMixin):
         query = ('INSERT INTO {table} ("{keys}") VALUES ({values})'
                  ''.format(table=self.table, keys=keys, values=fvalues[:-2]))
 
-        if self.execute(query, values, rollback=True):
+        if self.execute(query, values, rollback=not self.fail_on_errors):
             self.con.commit()
             self.acknowledge_message()
 

--- a/intelmq/lib/test.py
+++ b/intelmq/lib/test.py
@@ -303,7 +303,9 @@ class BotTestCase:
                 prepare=True, parameters={},
                 allowed_error_count=0,
                 allowed_warning_count=0,
-                stop_bot: bool = True):
+                stop_bot: bool = True,
+                expected_internal_queue_size: int = 0,
+                ):
         """
         Call this method for actually doing a test run for the specified bot.
 
@@ -339,10 +341,10 @@ class BotTestCase:
                          'iterations of `run_bot`.')
 
         internal_queue_size = len(self.get_input_internal_queue())
-        self.assertEqual(internal_queue_size, 0,
-                         'The internal input queue is not empty, but has '
+        self.assertEqual(internal_queue_size, expected_internal_queue_size,
+                         f'The internal input queue does not have expected size {expected_internal_queue_size}, but has '
                          f'{internal_queue_size} element(s). '
-                         'The bot did not acknowledge all messages.')
+                         'The bot did not acknowledge the expected number of messages.')
 
         """ Test if report has required fields. """
         if self.bot_type == 'collector':


### PR DESCRIPTION
Introduce a new parameter for the SQL Output bot to immediately fail on errors, not trying to fix the issue or waiting for some time.