### PR TITLE
tst: skip tests which require an intelmq installation by default

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -75,4 +75,9 @@ jobs:
 
     - name: Run full testsuite
       if: ${{ matrix.type == 'full' }}
-      run: TZ=utc INTELMQ_TEST_DATABASES=1 INTELMQ_TEST_EXOTIC=1 pytest --cov intelmq/ --cov-report=xml --cov-branch intelmq/ contrib/
+      run: pytest --cov intelmq/ --cov-report=xml --cov-branch intelmq/ contrib/
+      env:
+        TZ: utz
+        INTELMQ_TEST_DATABASES: 1
+        INTELMQ_TEST_EXOTIC: 1
+        INTELMQ_TEST_INSTALLATION: 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ CHANGELOG
 ### Documentation
 
 ### Tests
+- New decorator `skip_installation` and environment variable `INTELMQ_TEST_INSTALLATION` to skip tests requiring an IntelMQ installation on the test host by default (PR#2370 by Sebastian Wagner, fixes #2369)
 
 ### Packaging
 

--- a/docs/dev/guide.rst
+++ b/docs/dev/guide.rst
@@ -238,12 +238,13 @@ There are a bunch of environment variables which switch on/off some tests:
 * `INTELMQ_TEST_EXOTIC`: some bots and tests require libraries which may not be available, those are skipped by default. To run them, set this to 1.
 * `INTELMQ_TEST_REDIS_PASSWORD`: Set this value to the password for the local redis database if needed.
 * `INTELMQ_LOOKYLOO_TEST`: Set this value to run the lookyloo tests. Public lookyloo instance will be used as default.
+* `INTELMQ_TEST_INSTALLATION`: Set this value to run tests which require a local IntelMQ installation, such as for testing the command lines tools relying on configuration files, dump files etc.
 
 For example, to run all tests you can use:
 
 .. code-block:: bash
 
-   INTELMQ_TEST_DATABASES=1 INTELMQ_TEST_EXOTIC=1 pytest intelmq/tests/
+   INTELMQ_TEST_DATABASES=1 INTELMQ_TEST_EXOTIC=1 INTELMQ_TEST_INSTALLATION=1 pytest intelmq/tests/
 
 Configuration test files
 ------------------------

--- a/intelmq/lib/test.py
+++ b/intelmq/lib/test.py
@@ -17,7 +17,6 @@ import re
 import unittest
 import unittest.mock as mock
 from itertools import chain
-from sys import version_info
 
 import pkg_resources
 import redis
@@ -109,6 +108,14 @@ def skip_ci():
 def skip_build_environment():
     # For test that regularly fail in build environments like local or public Open Build Service builds
     return unittest.skipIf(os.getenv('USER') == 'abuild', 'Test disabled in Build Service.')
+
+
+def skip_installation():
+    """
+    Skip a test that requires an IntelMQ installation on this host
+    """
+    return unittest.skipUnless(os.getenv('INTELMQ_TEST_INSTALLATION'),
+                               'Skipping tests requiring an IntelMQ installation.')
 
 
 class BotTestCase:

--- a/intelmq/tests/bin/test_intelmqctl.py
+++ b/intelmq/tests/bin/test_intelmqctl.py
@@ -12,6 +12,7 @@ from pkg_resources import resource_filename
 
 import intelmq.bin.intelmqctl as ctl
 import intelmq.lib.utils as utils
+from intelmq.lib.test import skip_installation
 
 
 class TestIntelMQProcessManager(unittest.TestCase):
@@ -100,16 +101,19 @@ class TestIntelMQController(unittest.TestCase):
         self.tmp_config_dir.cleanup()
         return super().tearDown()
 
+    @skip_installation()
     def test_check_passed_with_default_harmonization_and_empty_runtime(self):
         self._load_default_harmonization()
         self.assertEqual((0, 'success'), self.intelmqctl.check(no_connections=True, check_executables=False))
 
+    @skip_installation()
     def test_check_pass_with_default_runtime(self):
         with mock.patch.object(ctl.utils, "RUNTIME_CONF_FILE", self.tmp_runtime):
             self._load_default_harmonization()
             self._load_default_runtime()
             self.assertEqual((0, 'success'), self.intelmqctl.check(no_connections=True, check_executables=False))
 
+    @skip_installation()
     @mock.patch.object(ctl.importlib, "import_module", mock.Mock(side_effect=SyntaxError))
     def test_check_handles_syntaxerror_when_importing_bots(self):
         self._load_default_harmonization()

--- a/intelmq/tests/bin/test_intelmqdump.py
+++ b/intelmq/tests/bin/test_intelmqdump.py
@@ -14,6 +14,7 @@ from unittest import mock
 import termstyle
 
 from intelmq.bin import intelmqdump
+from intelmq.lib.test import skip_installation
 
 
 class TestCompleter(unittest.TestCase):
@@ -95,6 +96,7 @@ class TestIntelMQDump(unittest.TestCase):
                 intelmqdump.main(argv)
         return output.getvalue().split("\n")
 
+    @skip_installation()
     @mock.patch.object(intelmqdump, "input", return_value='q')
     def test_list_dumps_for_all_bots_from_default_log_path(self, _):
         self._prepare_empty_dump('test-1')
@@ -106,6 +108,7 @@ class TestIntelMQDump(unittest.TestCase):
         self.assertIn("0: test-1 empty file", output[1])
         self.assertIn("1: test-2 empty file", output[2])
 
+    @skip_installation()
     @mock.patch.object(intelmqdump, "input", return_value='q')
     def test_list_dumps_for_all_bots_from_custom_locations(self, _):
         self.global_config = {"logging_path": self.tmp_log_dir.name}
@@ -130,6 +133,7 @@ class TestIntelMQDump(unittest.TestCase):
         self.assertIn("0: test-1 empty file", output[1])
         self.assertIn("1: test-2 empty file", output[2])
 
+    @skip_installation()
     @mock.patch.object(intelmqdump, "input")
     def test_list_and_select_dump_from_global_location(self, input_mock):
         self._prepare_empty_dump('test-1')
@@ -145,6 +149,7 @@ class TestIntelMQDump(unittest.TestCase):
                 # Enough to check that the correct file path was used
                 self.assertIn("Processing test-1: empty file", output[2])
 
+    @skip_installation()
     @mock.patch.object(intelmqdump, "input")
     def test_list_and_select_dump_from_custom_location(self, input_mock):
         self.global_config = {"logging_path": self.tmp_log_dir.name}
@@ -166,6 +171,7 @@ class TestIntelMQDump(unittest.TestCase):
                 # Enough to check that the correct file path was used
                 self.assertIn("Processing test-1: empty file", output[2])
 
+    @skip_installation()
     @mock.patch.object(intelmqdump, "input")
     def test_selecting_dump_warns_when_filename_is_ambiguous(self, input_mock):
         """With different locations used, there could be a case of dumps with the same
@@ -197,6 +203,7 @@ class TestIntelMQDump(unittest.TestCase):
             output = self._run_main([])
             self.assertIn("Processing test-1: empty file", output[3])
 
+    @skip_installation()
     @mock.patch.object(intelmqdump, "input", return_value='q')
     def test_get_dump_for_one_bot(self, _):
         self._prepare_empty_dump("bot/bot-1")


### PR DESCRIPTION
fixes certtools/intelmq#2369