### PR TITLE
FIX: Restrict python-rt version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ CHANGELOG
 ### Bots
 
 #### Collectors
+- `intelmq.bots.collector.rt`: restrict `python-rt` to be below version 3.0 due to introduced breaking changes.
 
 #### Parsers
 - `intelmq.bots.parsers.shadowserver._config`:

--- a/docs/user/bots.rst
+++ b/docs/user/bots.rst
@@ -554,7 +554,7 @@ You need the rt-library >= 1.9 and < 3.0 from nic.cz, available via `pypi <https
 
 .. warning::
 
-   Actually the bot supports the python-rt library in the version older than 3.0.
+   At the moment, the bot only supports `python-rt` versions below 3.0.
 
 This rt bot will connect to RT and inspect the given `search_queue` for tickets matching all criteria in `search_*`,
 Any matches will be inspected. For each match, all (RT-) attachments of the matching RT tickets are iterated over and within this loop, the first matching filename in the attachment is processed.

--- a/docs/user/bots.rst
+++ b/docs/user/bots.rst
@@ -550,7 +550,7 @@ Request Tracker
 * `cache (redis db):` none
 * `description:` Request Tracker Collector fetches attachments from an RTIR instance.
 
-You need the rt-library >= 1.9 and < 3.0 from nic.cz, available via `pypi <https://pypi.org/project/rt/>`_: `pip3 install rt`
+You need the rt-library >= 1.9 and < 3.0 from nic.cz, available via `pypi <https://pypi.org/project/rt/>`_: `pip3 install 'rt<3'`
 
 .. warning::
 

--- a/docs/user/bots.rst
+++ b/docs/user/bots.rst
@@ -550,7 +550,11 @@ Request Tracker
 * `cache (redis db):` none
 * `description:` Request Tracker Collector fetches attachments from an RTIR instance.
 
-You need the rt-library >= 1.9 from nic.cz, available via `pypi <https://pypi.org/project/rt/>`_: `pip3 install rt`
+You need the rt-library >= 1.9 and < 3.0 from nic.cz, available via `pypi <https://pypi.org/project/rt/>`_: `pip3 install rt`
+
+.. warning::
+
+   Actually the bot supports the python-rt library in the version older than 3.0.
 
 This rt bot will connect to RT and inspect the given `search_queue` for tickets matching all criteria in `search_*`,
 Any matches will be inspected. For each match, all (RT-) attachments of the matching RT tickets are iterated over and within this loop, the first matching filename in the attachment is processed.

--- a/intelmq/bots/collectors/rt/REQUIREMENTS.txt
+++ b/intelmq/bots/collectors/rt/REQUIREMENTS.txt
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2016 Sebastian Wagner
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
-rt>=1.0.9
+rt<3.0.0,>=1.0.9


### PR DESCRIPTION
The `python-rt` in version 3 introduced some small backward incompatible changes. 

Related changes are tracked in #2367