### PR TITLE
ENH: RTCollector: Exclude by subject and multiple values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,10 @@ CHANGELOG
 ### Bots
 
 #### Collectors
-- `intelmq.bots.collector.rt`: restrict `python-rt` to be below version 3.0 due to introduced breaking changes.
+- `intelmq.bots.collector.rt`:
+  - restrict `python-rt` to be below version 3.0 due to introduced breaking changes,
+  - added support for `Subject NOT LIKE` queries,
+  - added support for multiple values in ticket subject queries.
 
 #### Parsers
 - `intelmq.bots.parsers.shadowserver._config`:

--- a/docs/user/bots.rst
+++ b/docs/user/bots.rst
@@ -574,7 +574,8 @@ If none of the filename matches apply, the contents of the first (RT-) "history"
 * `search_queue`: queue of the ticket to search for (default: `Incident Reports`)
 * `search_requestor`: the e-mail address of the requestor
 * `search_status`: status of the ticket to search for (default: `new`)
-* `search_subject_like`: part of the subject of the ticket to search for (default: `Report`)
+* `search_subject_like`: part of the subject of the ticket to search for (default: `Report`); use list for multiple required values,
+* `search_subject_notlike`: exclude subject containing given value, use list for multiple excluding values,
 * `set_status`: status to set the ticket to after processing (default: `open`). `false` or `null` to not set a different status.
 * `take_ticket`: whether to take the ticket (default: `true`)
 * `url_regex`: regular expression of an URL to search for in the ticket

--- a/intelmq/bots/collectors/rt/collector_rt.py
+++ b/intelmq/bots/collectors/rt/collector_rt.py
@@ -98,7 +98,7 @@ class RTCollectorBot(CollectorBot, HttpMixin):
                     convert_to_raw = True
 
         if convert_to_raw:
-            kwargs = {'raw_query': self._convert_to_raw_query(kwargs)}
+            kwargs = self._convert_to_raw_query(kwargs)
 
         query = RT.search(order='Created', **kwargs)
         self.logger.info('%s results on search query.', len(query))
@@ -219,12 +219,15 @@ class RTCollectorBot(CollectorBot, HttpMixin):
     def _convert_to_raw_query(cls, kwargs: dict) -> str:
         parts = []
         for key, values in kwargs.items():
+            if key == 'Queue':
+                continue
             key_parts = key.split('__')
             field_name, op = key_parts[0], None if len(key_parts) == 1 else key_parts[-1]
             values = values if isinstance(values, list) else [values]
             for value in values:
                 parts.append(f"({field_name}{cls.RAW_QUERY_OP_MAPPING[op]}\'{value}\')")
-        return ' AND '.join(parts)
+
+        return {'Queue': kwargs.get('Queue'), 'raw_query': ' AND '.join(parts)}
 
 
 BOT = RTCollectorBot

--- a/intelmq/tests/bots/collectors/rt/test_collector.py
+++ b/intelmq/tests/bots/collectors/rt/test_collector.py
@@ -21,19 +21,19 @@ rt_attachment_ticket = os.getenv('INTELMQ_TEST_RT_ATTACHMENT_TICKET')
 rt_url_ticket = os.getenv('INTELMQ_TEST_RT_URL_TICKET')
 
 REPORT = {"__type": "Report",
-          "feed.name": "Example feed",
-          "feed.accuracy": 100.,
-          "raw": utils.base64_encode('bar text\n'),
-          "extra.file_name": "foobar",
-          "extra.email_subject": "Incoming IntelMQ Test Report",
-          "extra.ticket_subject": "Incoming IntelMQ Test Report",
-          "extra.ticket_requestors": "wagner@cert.at",
-          "extra.email_from": "wagner@cert.at",
-          "extra.ticket_queue": "Incident Reports",
-          "extra.ticket_status": "new",
-          "extra.ticket_owner": "intelmq",
-          "rtir_id": utils.lazy_int(0 if not rt_attachment_ticket else rt_attachment_ticket),
-          }
+              "feed.name": "Example feed",
+              "feed.accuracy": 100.,
+              "raw": utils.base64_encode('bar text\n'),
+              "extra.file_name": "foobar",
+              "extra.email_subject": "Incoming IntelMQ Test Report",
+              "extra.ticket_subject": "Incoming IntelMQ Test Report",
+              "extra.ticket_requestors": "wagner@cert.at",
+              "extra.email_from": "wagner@cert.at",
+              "extra.ticket_queue": "Incident Reports",
+              "extra.ticket_status": "new",
+              "extra.ticket_owner": "intelmq",
+              "rtir_id": utils.lazy_int(0 if not rt_attachment_ticket else rt_attachment_ticket),
+              }
 REPORT_URL1 = REPORT.copy()
 REPORT_URL1['rtir_id'] = utils.lazy_int(0 if not rt_url_ticket else rt_url_ticket)
 REPORT_URL1['extra.file_name'] = 'bar'
@@ -106,16 +106,17 @@ class TestRTRawQuery(unittest.TestCase):
             'Subject__like': 'Report',
             'Subject__notlike': 'except',
             'Created__gt': '2023-01-01',
+            'Queue': 'IR',
         }
 
         raw_query = RTCollectorBot._convert_to_raw_query(kwargs)
 
-        expected = ("(Status=\'active\')"
-                    " AND (Subject LIKE \'Report\')"
-                    " AND (Subject NOT LIKE \'except\')"
-                    " AND (Created>\'2023-01-01\')")
+        expected_query = ("(Status=\'active\')"
+                          " AND (Subject LIKE \'Report\')"
+                          " AND (Subject NOT LIKE \'except\')"
+                          " AND (Created>\'2023-01-01\')")
 
-        self.assertEqual(raw_query, expected)
+        self.assertEqual(raw_query, {"Queue": "IR", "raw_query": expected_query})
 
     def test_multiple_values(self):
         kwargs = {
@@ -123,18 +124,19 @@ class TestRTRawQuery(unittest.TestCase):
             'Subject__like': ['Report', 'Report 2'],
             'Subject__notlike': ['except', 'except2'],
             'Created__gt': '2023-01-01',
+            'Queue': 'IR',
         }
 
         raw_query = RTCollectorBot._convert_to_raw_query(kwargs)
 
-        expected = ("(Status=\'active\')"
-                    " AND (Subject LIKE \'Report\')"
-                    " AND (Subject LIKE \'Report 2\')"
-                    " AND (Subject NOT LIKE \'except\')"
-                    " AND (Subject NOT LIKE \'except2\')"
-                    " AND (Created>\'2023-01-01\')")
+        expected_query = ("(Status=\'active\')"
+                          " AND (Subject LIKE \'Report\')"
+                          " AND (Subject LIKE \'Report 2\')"
+                          " AND (Subject NOT LIKE \'except\')"
+                          " AND (Subject NOT LIKE \'except2\')"
+                          " AND (Created>\'2023-01-01\')")
 
-        self.assertEqual(raw_query, expected)
+        self.assertEqual(raw_query, {"Queue": "IR", "raw_query": expected_query})
 
 
 if __name__ == '__main__':  # pragma: no cover


### PR DESCRIPTION
Added support for filtering out tickets based on
given subject pattern. In addition, the subject
patterns can now contains multiple value. Because
this isn't currently supported by the python-rt library,
the query is converted to the RT-native format
if needed.