### PR TITLE
FIX: Ensure rejecting URLs starting with space

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -26,6 +26,6 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v2
     - name: Install codespell
-      run: pip install codespell
+      run: pip install "codespell==2.2.4"
     - name: Run codespell
       run: /home/runner/.local/bin/codespell

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,9 @@ CHANGELOG
 - `intelmq.lib.upgrages`: Fix a bug in the upgrade function for version 3.1.0 which caused an exception if a generic csv parser instance had no parameter `type` (PR#2319 by Filip Pokorný).
 - `intelmq.lib.datatypes`: Adds `TimeFormat` class to be used for the `time_format` bot parameter (PR#2329 by Filip Pokorný).
 - `intelmq.lib.exceptions`: Fixes a bug in `InvalidArgument` exception (PR#2329 by Filip Pokorný).
-- `intelmq.lib.harmonization`: Changes signature and names of `DateTime` conversion functions for consistency, backwards compatible (PR#2329 by Filip Pokorný).
+- `intelmq.lib.harmonization`:
+  - Changes signature and names of `DateTime` conversion functions for consistency, backwards compatible (PR#2329 by Filip Pokorný).
+  - Ensure rejecting URLs with leading whitespaces after changes in CPython (fixes [#2377](https://github.com/certtools/intelmq/issues/2377))
 
 ### Development
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ CHANGELOG
   - Ensure rejecting URLs with leading whitespaces after changes in CPython (fixes [#2377](https://github.com/certtools/intelmq/issues/2377))
 
 ### Development
+- CI: pin the Codespell version to omit troubles caused by its new releases (PR #2379).
 
 ### Bots
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ CHANGELOG
 - `intelmq.bots.parsers.html_table.parser`: Changes `time_format` parameter to use new `TimeFormat` class (PR#2329 by Filip Pokorný).
 - `intelmq.bots.parsers.turris.parser.py` Updated to the latest data format (issue #2167). (PR#2373 by Filip Pokorný).
 
+
 #### Experts
 - `intelmq.bots.experts.sieve`:
   - Allow empty lists in sieve rule files (PR#2341 by Mikk Margus Möll).
@@ -66,6 +67,7 @@ CHANGELOG
   - SECURITY: fixed a low-risk bug causing the tool to change owner of `/` if run with the `INTELMQ_PATHS_NO_OPT` environment variable set. This affects only the PIP package as the DEB/RPM packages don't contain this tool. (PR#2355 by Kamil Mańkowski, fixes #2354)
 
 ### Known Errors
+- `intelmq.parsers.html_table` may not process invalid URLs in patched Python version due to changes in `urllib`. See #2382
 
 3.1.0 (2023-02-10)
 ------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,6 @@ CHANGELOG
 - `intelmq.bots.parsers.html_table.parser`: Changes `time_format` parameter to use new `TimeFormat` class (PR#2329 by Filip Pokorný).
 - `intelmq.bots.parsers.turris.parser.py` Updated to the latest data format (issue #2167). (PR#2373 by Filip Pokorný).
 
-
 #### Experts
 - `intelmq.bots.experts.sieve`:
   - Allow empty lists in sieve rule files (PR#2341 by Mikk Margus Möll).

--- a/intelmq/lib/harmonization.py
+++ b/intelmq/lib/harmonization.py
@@ -34,6 +34,7 @@ import ipaddress
 import json
 import re
 import socket
+import string
 import warnings
 import urllib.parse as parse
 from typing import Optional, Union
@@ -1088,6 +1089,9 @@ class URL(String):
             value = URL.sanitize(value)
 
         if not GenericType.is_valid(value):
+            return False
+
+        if value[0] in string.whitespace:
             return False
 
         result = parse.urlsplit(value)

--- a/intelmq/tests/bots/parsers/html_table/test_parser_column_split.py
+++ b/intelmq/tests/bots/parsers/html_table/test_parser_column_split.py
@@ -70,6 +70,7 @@ class TestHTMLTableParserBot(test.BotTestCase, unittest.TestCase):
         self.run_bot()
         self.assertMessageEqual(0, EXAMPLE_EVENT)
 
+    @unittest.skip("Change in urllib prevent invalid URLs to be processed, see #2377")
     def test_event_without_split(self):
         self.sysconfig = {"columns": ["time.source", "source.url", "malware.hash.md5",
                                       "source.ip", "__IGNORE__"],


### PR DESCRIPTION
The gh-102153 change in CPython modified how
urllib.pare handles URLs with the leading
spaces. To ensure previous behaviour, additional
check was added.

Closes: #2377