### PR TITLE
FIX: Pin codespell version

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -26,6 +26,6 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v2
     - name: Install codespell
-      run: pip install codespell
+      run: pip install "codespell==2.2.4"
     - name: Run codespell
       run: /home/runner/.local/bin/codespell

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ CHANGELOG
 - `intelmq.lib.harmonization`: Changes signature and names of `DateTime` conversion functions for consistency, backwards compatible (PR#2329 by Filip Pokorný).
 
 ### Development
+- CI: pin the Codespell version to omit troubles caused by its new releases (PR #2379).
 
 ### Bots
 


### PR DESCRIPTION
Without pinning the version, codespell is regulary
failing after releasing their new version with
new dictionary.