### PR TITLE
Increased the performance of the intelmqctl script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,8 @@ CHANGELOG
 - `contrib.eventdb.separate-raws-table.sql`: Added the missing commas to complete the sql syntax. (PR#2386, fixes #2125 by Sebastian Kufner)
 - `intelmq_psql_initdb`:
   - Added parameter `-o` to set the output file destination. (by Sebastian Kufner)
+- `intelmqctl`:
+  - Increased the performance through removing unnecessary reads. (by Sebastian Kufner)
 
 ### Known Errors
 - `intelmq.parsers.html_table` may not process invalid URLs in patched Python version due to changes in `urllib`. See #2382

--- a/intelmq/bin/intelmqctl.py
+++ b/intelmq/bin/intelmqctl.py
@@ -4,6 +4,7 @@
 
 # -*- coding: utf-8 -*-
 import argparse
+import copy
 import datetime
 import importlib
 import json
@@ -925,6 +926,7 @@ Get some debugging output on the settings and the environment (to be extended):
                                  "intelmqctl upgrade-config.")
 
         check_logger.info('Checking for bots.')
+        global_settings = files[RUNTIME_CONF_FILE]
         for bot_id, bot_config in files[RUNTIME_CONF_FILE].items():
             if bot_id != 'global':
                 # importable module
@@ -939,7 +941,7 @@ Get some debugging output on the settings and the environment (to be extended):
                     retval = 1
                     continue
                 bot = getattr(bot_module, 'BOT')
-                bot_parameters = utils.get_global_settings()
+                bot_parameters = copy.deepcopy(global_settings)
                 bot_parameters.update(bot_config.get('parameters', {}))  # the parameters field may not exist
                 bot_check = bot.check(bot_parameters)
                 if bot_check:

--- a/intelmq/bin/intelmqctl.py
+++ b/intelmq/bin/intelmqctl.py
@@ -926,7 +926,7 @@ Get some debugging output on the settings and the environment (to be extended):
                                  "intelmqctl upgrade-config.")
 
         check_logger.info('Checking for bots.')
-        global_settings = files[RUNTIME_CONF_FILE]
+        global_settings = files[RUNTIME_CONF_FILE].get('global', {})
         for bot_id, bot_config in files[RUNTIME_CONF_FILE].items():
             if bot_id != 'global':
                 # importable module


### PR DESCRIPTION
It should improve the performance of the check method of the intelmqctl script. 
The global settings were read from a file with each loop pass, now the settings are read only once and then only copied.
