### PR TITLE
Packaging fixes for Debian, clean deprecated buster from tests

### DIFF
--- a/.github/workflows/ansible-tests.yml
+++ b/.github/workflows/ansible-tests.yml
@@ -33,4 +33,4 @@ jobs:
         path: ./src/intelmq-vagrant
 
     - name: Run ansible tests
-      run: podman run -e CI=${CI} -v ${GITHUB_WORKSPACE}/src:/src docker.io/debian:buster-slim /src/intelmq/.github/workflows/scripts/ansible.sh
+      run: podman run -e CI=${CI} -v ${GITHUB_WORKSPACE}/src:/src docker.io/debian:bullseye-slim /src/intelmq/.github/workflows/scripts/ansible.sh

--- a/.github/workflows/debian-package.yml
+++ b/.github/workflows/debian-package.yml
@@ -23,7 +23,7 @@ jobs:
     name: Build Debian packages
     strategy:
       matrix:
-        codename: ['buster', 'bullseye']
+        codename: ['bullseye', 'bookworm']
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/scripts/debian-package.sh
+++ b/.github/workflows/scripts/debian-package.sh
@@ -10,7 +10,7 @@ set -x
 set -e
 
 # A list of known Debian releases
-knowncodenames=("stretch" "buster" "bullseye" "stable" "testing")
+knowncodenames=("bullseye" "bookworm" "stable" "testing")
 
 # We want exactly one argument: the name of the release
 if (( $# != 1 ))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,12 +142,6 @@ This is short list of the most important known issues. The full list can be retr
 - Corrupt dump files when interrupted during writing (#870).
 
 
-3.0.2 (2021-09-10)
-------------------
-
-### Core
-- `intelmq.lib.bot.CollectorBot`: Fixed an issue with within the `new_report` function, which re-loads the harmonization file after a new incoming dataset, which leads to CPU drain and decreased performance (PR#2106 by Sebastian Waldbauer, fixes #2098).
-
 3.1.0 (2023-02-10)
 ------------------
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+intelmq (3.2.2-1) UNRELEASED; urgency=medium
+
+  * 
+
+ -- Sebastian Wagner <sebix@sebix.at>  Tue, 05 Sep 2023 15:05:07 +0200
+
 intelmq (3.2.1-2) stable; urgency=medium
 
   * Fix build on Debian 12

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,8 +1,8 @@
-intelmq (3.2.2-1) UNRELEASED; urgency=medium
+intelmq (3.2.1-2) stable; urgency=medium
 
-  *
+  * Fix build on Debian 12
 
- -- Sebastian Wagner <sebix@sebix.at>  Mon, 28 Aug 2023 17:41:52 +0200
+ -- Sebastian Wagner <sebix@sebix.at>  Tue, 05 Sep 2023 15:04:36 +0200
 
 intelmq (3.2.1-1) stable; urgency=medium
 

--- a/debian/control
+++ b/debian/control
@@ -1,5 +1,5 @@
 Source: intelmq
-Maintainer: IntelMQ Team <intelmq-team@cert.at>
+Maintainer: Institute for Common Good Technology <packaging@commongoodtechnology.org>
 Section: python
 Priority: optional
 Build-Depends: debhelper (>= 4.1.16),
@@ -7,17 +7,17 @@ Build-Depends: debhelper (>= 4.1.16),
                lsb-release,
                python3-all,
                python3-cerberus,
-               python3-dateutil,
-               python3-dnspython,
-               python3-psutil,
-               python3-redis,
-               python3-requests,
+               python3-dateutil (>= 2.5),
+               python3-dnspython (>= 2.0.0),
+               python3-psutil (>= 1.2.1),
+               python3-redis (>= 2.10),
+               python3-requests (>= 2.2.0),
                python3-requests-mock,
                python3-ruamel.yaml,
                python3-setuptools,
                python3-sphinx,
                python3-sphinx-rtd-theme,
-               python3-termstyle,
+               python3-termstyle (>= 0.1.10),
                python3-tz,
                quilt,
                rsync,
@@ -37,7 +37,7 @@ Depends: bash-completion,
          python3-openssl,
          python3-psutil (>= 1.2.1),
          python3-redis (>= 2.10),
-         python3-requests (>= 2.2.1),
+         python3-requests (>= 2.2.0),
          python3-ruamel.yaml,
          python3-termstyle (>= 0.1.10),
          python3-tz,
@@ -48,9 +48,9 @@ Depends: bash-completion,
          ${python3:Depends}
 Suggests: python3-geoip2 (>= 2.2.0),
           python3-imbox (>= 0.8),
-          python3-psycopg2,
+          python3-psycopg2 (>= 2.5.5),
           python3-pyasn (>= 1.5.0),
-          python3-pymongo,
+          python3-pymongo (>= 2.7.1),
           python3-sleekxmpp (>= 1.3.1),
           python3-stomp.py (>= 4.1.9)
 Description: Solution for IT security teams for collecting and processing security feeds
@@ -61,3 +61,11 @@ Description: Solution for IT security teams for collecting and processing securi
  designed by European CERTs/CSIRTs during several InfoSec events. Its main goal
  is to give to incident responders an easy way to collect & process threat
  intelligence thus improving the incident handling processes of CERTs.
+ .
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.

--- a/debian/rules
+++ b/debian/rules
@@ -36,7 +36,7 @@ override_dh_auto_install: $(BOTDOCS)
 	rm intelmq/bin/rewrite_config_files.py
 	sed -i -e '/#!\/usr\/bin\//d' intelmq/bin/*.py
 	sed -i -f debian/sedfile intelmq/etc/* docs/user/intelmqctl.rst docs/user/bots.rst setup.py contrib/logrotate/intelmq contrib/logcheck/logcheck.logfiles
-	python3 setup.py install --root=debian/intelmq --prefix=/usr
+	dh_auto_install
 	# create directories
 	mkdir -p debian/intelmq/var/log/intelmq
 	mkdir -p debian/intelmq/var/lib/intelmq/bots/file-output

--- a/docs/user/installation.rst
+++ b/docs/user/installation.rst
@@ -30,7 +30,7 @@ The following instructions assume the following requirements. Python versions >=
 
 Supported and recommended operating systems are:
 
-* Debian 10 Buster, Debian 11 Bullseye, Debian 12 Bookworm
+* Debian Debian 11 Bullseye, Debian 12 Bookworm
 * openSUSE Tumbleweed, Leap 15.5
 * Ubuntu: 20.04 Focal, 22.04 Jammy
 * For the Docker-installation: Docker Engine: 18.x and higher

--- a/intelmq/bots/collectors/github_api/REQUIREMENTS.txt
+++ b/intelmq/bots/collectors/github_api/REQUIREMENTS.txt
@@ -1,4 +1,0 @@
-# SPDX-FileCopyrightText: 2019 Tomas Bellus
-# SPDX-License-Identifier: AGPL-3.0-or-later
-
-requests


### PR DESCRIPTION
Is already in home:sebix:intelmq:unstable and the Debian 12 build works.