### PR TITLE
bug: fix reverse_dns expert caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ CHANGELOG
 #### Parsers
 
 #### Experts
+- `intelmq.bots.experts.reverse_dns.expert`:
+  - Fix the cache key to not cache results for /24 (IPv4) and /128 (IPv6) networks but for single IP-Adresses (PR#2395 by Sebastian Wagner, fixes #2394).
 
 #### Outputs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,39 @@
 CHANGELOG
 ==========
 
+3.2.1 (unreleased)
+------------------
+
+### Configuration
+
+### Core
+
+### Development
+
+### Data Format
+
+### Bots
+#### Collectors
+
+#### Parsers
+
+#### Experts
+
+#### Outputs
+
+### Documentation
+
+### Packaging
+
+### Tests
+
+### Tools
+
+### Contrib
+
+### Known issues
+
+
 3.2.0 (2023-07-18)
 ------------------
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,13 @@ Please refer to the change log for a full list of changes.
 3.2.1 Bugfix release (unreleased)
 ---------------------------------
 
+### Reverse DNS Expert
+Until IntelMQ version 3.2.0, the bot incorrectly cached and re-used results for /24 networks instead of single IP addresses.
+If the bot retrieved the PTR for `192.0.43.7`, it was cached for `192.0.43.0/24` and used for all IP addresses in this range, for example for `192.0.43.8`.
+IntelMQ version 3.2.1 fixes this issue.
+
+The bugfix will correctly increase the cache sizes and decrease the performance, as less (incorrect) data is re-used.
+
 ### Requirements
 
 ### Tools

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,22 @@ This file lists all changes which have an affect on the administration of IntelM
 Please refer to the change log for a full list of changes.
 
 
+3.2.1 Bugfix release (unreleased)
+---------------------------------
+
+### Requirements
+
+### Tools
+
+### Data Format
+
+### Configuration
+
+### Libraries
+
+### Postgres databases
+
+
 3.2.0 Feature release (2023-07-18)
 ----------------------------------
 

--- a/intelmq/bots/experts/reverse_dns/expert.py
+++ b/intelmq/bots/experts/reverse_dns/expert.py
@@ -15,8 +15,6 @@ from intelmq.lib.harmonization import IPAddress
 from intelmq.lib.mixins import CacheMixin
 from intelmq.lib.utils import resolve_dns
 
-MINIMUM_BGP_PREFIX_IPV4 = 24
-MINIMUM_BGP_PREFIX_IPV6 = 128
 DNS_EXCEPTION_VALUE = "__dns-exception"
 
 
@@ -48,16 +46,9 @@ class ReverseDnsExpertBot(ExpertBot, CacheMixin):
                 continue
 
             ip = event.get(ip_key)
-            ip_version = IPAddress.version(ip)
             ip_integer = IPAddress.to_int(ip)
 
-            if ip_version == 4:
-                minimum = MINIMUM_BGP_PREFIX_IPV4
-
-            elif ip_version == 6:
-                minimum = MINIMUM_BGP_PREFIX_IPV6
-
-            cache_key = bin(ip_integer)[2: minimum + 2]
+            cache_key = bin(ip_integer)[2:]
             cachevalue = self.cache_get(cache_key)
 
             result = None

--- a/intelmq/tests/bots/experts/reverse_dns/test_expert.py
+++ b/intelmq/tests/bots/experts/reverse_dns/test_expert.py
@@ -17,20 +17,20 @@ EXAMPLE_INPUT = {"__type": "Event",
 EXAMPLE_OUTPUT = {"__type": "Event",
                   "source.ip": "192.0.43.7",
                   "source.reverse_dns": "icann.org",
-                  "destination.ip": "192.0.43.8",
-                  "destination.reverse_dns": "icann.org",
-                  # manual verification shows another result:
-                  # "destination.reverse_dns": "43-8.any.icann.org.",       # pretty weird!
+                  "destination.ip": "192.0.43.8",  # in the same /24 as source.ip, certtools/intelmq#2394
+                  "destination.reverse_dns": "43-8.any.icann.org",
                   "time.observation": "2015-01-01T00:00:00+00:00",
                   }
 EXAMPLE_INPUT6 = {"__type": "Event",
                   "source.ip": "2001:500:88:200::8",  # iana.org
                   "source.reverse_dns": "example.com",
                   "time.observation": "2015-01-01T00:00:00+00:00",
+                  "destination.ip": "2001:500:88:200::7",  # has no reverse record, certtools/intelmq#2394
                   }
 EXAMPLE_OUTPUT6 = {"__type": "Event",
                    "source.ip": "2001:500:88:200::8",
                    "source.reverse_dns": "iana.org",
+                   "destination.ip": "2001:500:88:200::7",
                    "time.observation": "2015-01-01T00:00:00+00:00",
                    }
 INVALID_PTR_INP2 = {"__type": "Event",

--- a/intelmq/version.py
+++ b/intelmq/version.py
@@ -2,5 +2,5 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
-__version_info__ = (3, 2, 0)
+__version_info__ = (3, 2, 1, 'a1')
 __version__ = '.'.join(map(str, __version_info__))


### PR DESCRIPTION
fixes https://github.com/certtools/intelmq/issues/2394

the bot incorrectly cached PTR records for /24 or /128 networks
now the cache operates on single IP addresses