### PR TITLE
ENH: message: show reason for InvalidKey exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ CHANGELOG
 ### Configuration
 
 ### Core
+- `intelmq.lib.message`: For invalid message keys, add a hint on the failure to the exception: not allowed by configuration or not matching regular expression (PR#2398 by Sebastian Wagner).
+- `intelmq.lib.exceptions.InvalidKey`: Add optional parameter `additional_text` (PR#2398 by Sebastian Wagner).
 
 ### Development
 

--- a/intelmq/lib/exceptions.py
+++ b/intelmq/lib/exceptions.py
@@ -88,8 +88,8 @@ class InvalidValue(IntelMQHarmonizationException):
 
 class InvalidKey(IntelMQHarmonizationException, KeyError):
 
-    def __init__(self, key: str):
-        message = "invalid key %s" % repr(key)
+    def __init__(self, key: str, additional_text: Optional[str] = None):
+        message = f"invalid key {key!r} {additional_text or ''}".strip()  # remove trailing whitespace if additional_text is not given
         super().__init__(message)
 
 

--- a/intelmq/tests/lib/test_exceptions.py
+++ b/intelmq/tests/lib/test_exceptions.py
@@ -64,6 +64,13 @@ class TestUtils(unittest.TestCase):
         self.assertIn(repr(depname), exc)
         self.assertTrue(exc.endswith(" %s" % additional))
 
+    def test_invalid_key(self):
+        """
+        Check intelmq.lib.exceptions.InvalidKey
+        """
+        exc = excs.InvalidKey('test_key', additional_text='TEST').args[0]
+        self.assertTrue(exc.endswith(' TEST'))
+
 
 if __name__ == '__main__':  # pragma: no cover
     unittest.main()

--- a/intelmq/tests/lib/test_message.py
+++ b/intelmq/tests/lib/test_message.py
@@ -168,8 +168,10 @@ class TestMessageFactory(unittest.TestCase):
     def test_report_invalid_key(self):
         """ Test if report raises InvalidKey for invalid key in add(). """
         report = self.new_report()
-        with self.assertRaises(exceptions.InvalidKey):
+        with self.assertRaises(exceptions.InvalidKey) as cm:
             report.add('invalid', 0)
+        self.assertIn('not allowed', cm.exception.args[0])
+
 
     def test_report_add_raw(self):
         """ Test if report can add raw value. """
@@ -764,10 +766,11 @@ class TestMessageFactory(unittest.TestCase):
             message.Event(harmonization={'event': {'foo.bar.': {}}})
 
     def test_invalid_extra_key_name(self):
-        """ Test if error is raised if an extra field name is invalid. """
+        """ Test if error is raised when an extra field name is invalid and error message is included in exception. """
         event = message.Event(harmonization=HARM)
-        with self.assertRaises(exceptions.InvalidKey):
+        with self.assertRaises(exceptions.InvalidKey) as cm:
             event.add('extra.foo-', 'bar')
+        self.assertIn('Does not match regular expression', cm.exception.args[0])
 
 
 class TestReport(unittest.TestCase):


### PR DESCRIPTION
if the user wants to add a field with an invalid key, the reason was not clear
now the error message says that either
- the key is not allowed in the harmonization configuration or
- the key does not match the regular expression (for extra keys), e.g. is not lower case etc.