### PR TITLE
FIX: Keep standalone flag after reloading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ CHANGELOG
 ### Configuration
 
 ### Core
+- Fixed issue preventing bots from stopping after reloading (PR by Kamil Mankowski).
 
 ### Development
 

--- a/intelmq/lib/bot.py
+++ b/intelmq/lib/bot.py
@@ -183,7 +183,7 @@ class Bot:
 
         try:
             self.logger.info('Bot is starting.')
-            self.logger.debug("Standalone mode: %s", self._standalone)
+            self.logger.debug("Standalone mode: %s.", self._standalone)
 
             broker = self.source_pipeline_broker.title()
             if broker != 'Amqp':

--- a/intelmq/lib/bot.py
+++ b/intelmq/lib/bot.py
@@ -183,6 +183,7 @@ class Bot:
 
         try:
             self.logger.info('Bot is starting.')
+            self.logger.debug("Standalone mode: %s", self._standalone)
 
             broker = self.source_pipeline_broker.title()
             if broker != 'Amqp':
@@ -310,7 +311,7 @@ class Bot:
             self.logger.exception('Error during shutdown of bot.')
         self.logger.handlers = []  # remove all existing handlers
         self.__sighup.clear()
-        self.__init__(self.__bot_id_full, sighup_event=self.__sighup)
+        self.__init__(self.__bot_id_full, sighup_event=self.__sighup, standalone=self._standalone)
 
     def init(self):
         pass

--- a/intelmq/lib/bot.py
+++ b/intelmq/lib/bot.py
@@ -159,7 +159,7 @@ class Bot:
             version_info = sys.version.splitlines()[0].strip()
             self.__log('info',
                        f'{self.__class__.__name__} initialized with id {bot_id} and intelmq {__version__}'
-                       f' and python {version_info} as process {os.getpid()}.')
+                       f' and python {version_info} as process {os.getpid()}. Standalone mode: {self._standalone}.')
             self.__log('debug', f'Library path: {__file__!r}.')
 
             # in standalone mode, drop privileges
@@ -183,7 +183,6 @@ class Bot:
 
         try:
             self.logger.info('Bot is starting.')
-            self.logger.debug("Standalone mode: %s.", self._standalone)
 
             broker = self.source_pipeline_broker.title()
             if broker != 'Amqp':


### PR DESCRIPTION
Library mode introduced 'standalone' flag for
bots running as a process. This flag instruct
the bot to handle signals, including SIGTERM.
 Unfortuneatly, this flag weren't preserved
when reloading the bot, what caused not being
able to gracefully stop reloaded bots.

Reloading is used when logrotate with recommended
configuration is enabled, what means that
this bug affects all 3.2.0 installations
from native packages after first logrotate.
