### PR TITLE
docs: add readthedocs configuration file

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,22 @@
+# Read the Docs configuration file for Sphinx projects
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the OS, Python version and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
+# Build documentation in the "docs/" directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+
+# Optional but recommended, declare the Python requirements required
+# to build your documentation
+# See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+# python:
+#    install:
+#    - requirements: docs/requirements.txt

--- a/.readthedocs.yaml.license
+++ b/.readthedocs.yaml.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2023 Institute for Common Good Technology <sebix@commongoodtechnology.org>
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ CHANGELOG
 #### Outputs
 
 ### Documentation
+- Add a readthedocs configuration file to fix the build fail (PR#2403 by Sebastian Wagner).
 
 ### Packaging
 


### PR DESCRIPTION
readthedocs now requires the configuration key "build.os" to build the documentation.

used the template https://docs.readthedocs.io/en/stable/config-file/v2.html