### PR TITLE
doc: readthedocs: enable requirements

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -17,6 +17,6 @@ sphinx:
 # Optional but recommended, declare the Python requirements required
 # to build your documentation
 # See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
-# python:
-#    install:
-#    - requirements: docs/requirements.txt
+python:
+   install:
+   - requirements: docs/requirements.txt


### PR DESCRIPTION
Fixes just another readthedocs build failure

previously without the .readthedocs.yml file, the docs/requirements.txt file was used implicitly, now we need to specify it explicitly