### PR TITLE
STOMP-and-n6-related updates, fixes and enhancements, especially adding login-based authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,22 @@ CHANGELOG
 ------------------
 
 ### Configuration
+- Add new optional configuration parameters for `intelmq.bots.collectors.stomp.collector`
+  and `intelmq.bots.outputs.stomp.output` (PR#2408 by Jan Kaliszewski):
+  - `auth_by_ssl_client_certificate` (Boolean, default: *true*; if *false* then
+    `ssl_client_certificate` and `ssl_client_certificate_key` will be ignored);
+  - `username` (STOMP authentication login, default: "guest"; to be used only
+    if `auth_by_ssl_client_certificate` is *false*);
+  - `password` (STOMP authentication passcode, default: "guest"; to be used only
+    if `auth_by_ssl_client_certificate` is *false*).
 
 ### Core
 - `intelmq.lib.message`: For invalid message keys, add a hint on the failure to the exception: not allowed by configuration or not matching regular expression (PR#2398 by Sebastian Wagner).
 - `intelmq.lib.exceptions.InvalidKey`: Add optional parameter `additional_text` (PR#2398 by Sebastian Wagner).
+- `intelmq.lib.mixins`: Add a new class, `StompMixin` (defined in a new submodule: `stomp`),
+  which provides certain common STOMP-bot-specific operations, factored out from
+  `intelmq.bots.collectors.stomp.collector` and `intelmq.bots.outputs.stomp.output`
+  (PR#2408 by Jan Kaliszewski).
 
 ### Development
 
@@ -22,15 +34,42 @@ CHANGELOG
 
 ### Bots
 #### Collectors
+- `intelmq.bots.collectors.stomp.collector` (PR#2408 by Jan Kaliszewski):
+  - Add support for authentication based on STOMP login and passcode,
+    introducing 3 new configuration parameters (see above: *Configuration*).
+  - Update the code to support new versions of `stomp.py`, including the latest (`8.1.0`);
+    fixes [#2342](https://github.com/certtools/intelmq/issues/2342).
+  - Fix the reconnection behavior: do not attempt to reconnect after `shutdown`. Also,
+    never attempt to reconnect if the version of `stomp.py` is older than `4.1.21` (it
+    did not work properly anyway).
+  - Add coercion of the `port` config parameter to `int`.
+  - Add implementation of the `check` hook (verifying, in particular, accessibility
+    of necessary file(s)).
+  - Remove undocumented and unused attributes of `StompCollectorBot` instances:
+    `ssl_ca_cert`, `ssl_cl_cert`, `ssl_cl_cert_key`.
+  - Minor fixes/improvements and some refactoring (see also above: *Core*...).
 
 #### Parsers
 
 #### Experts
 
 #### Outputs
+- `intelmq.bots.outputs.stomp.output` (PR#2408 by Jan Kaliszewski):
+  - Add support for authentication based on STOMP login and passcode,
+    introducing 3 new configuration parameters (see above: *Configuration*).
+  - Update the code to support new versions of `stomp.py`, including the latest (`8.1.0`).
+  - Fix `AttributeError` caused by attempts to get unset attributes of `StompOutputBot`
+    (`ssl_ca_cert` et consortes).
+  - Add coercion of the `port` config parameter to `int`.
+  - Add implementation of the `check` hook (verifying, in particular, accessibility
+    of necessary file(s)).
+  - Add `stomp.py` version check (raise `MissingDependencyError` if not `>=4.1.8`).
+  - Minor fixes/improvements and some refactoring (see also above: *Core*...).
 
 ### Documentation
 - Add a readthedocs configuration file to fix the build fail (PR#2403 by Sebastian Wagner).
+- Update/fix/improve the stuff related to the STOMP bots and integration with the *n6*'s
+  Stream API (PR#2408 by Jan Kaliszewski).
 
 ### Packaging
 

--- a/docs/user/bots.rst
+++ b/docs/user/bots.rst
@@ -945,12 +945,15 @@ Install the `stomp.py` library from PyPI:
 **Configuration Parameters**
 
 * **Feed parameters** (see above)
-* `exchange`: exchange point
+* `exchange`: STOMP *destination* to subscribe to, e.g. "/exchange/my.org/*.*.*.*"
 * `port`: 61614
-* `server`: hostname e.g. "n6stream.cert.pl"
+* `server`: hostname, e.g. "n6stream.cert.pl"
 * `ssl_ca_certificate`: path to CA file
-* `ssl_client_certificate`: path to client cert file
-* `ssl_client_certificate_key`: path to client cert key file
+* `auth_by_ssl_client_certificate`: Boolean, default: true (note: set to false for new *n6* auth)
+* `ssl_client_certificate`: path to client cert file, used only if `auth_by_ssl_client_certificate` is true
+* `ssl_client_certificate_key`: path to client cert key file, used only if `auth_by_ssl_client_certificate` is true
+* `username`: STOMP *login* (e.g., *n6* user login), used only if `auth_by_ssl_client_certificate` is false
+* `password`: STOMP *passcode* (e.g., *n6* user API key), used only if `auth_by_ssl_client_certificate` is false
 
 
 .. _intelmq.bots.collectors.twitter.collector_twitter:
@@ -4305,7 +4308,7 @@ Also you will need a so called "exchange point".
 
 **Configuration Parameters**
 
-* `exchange`: The exchange to push at
+* `exchange`: STOMP *destination* to push at, e.g. "/exchange/_push"
 * `heartbeat`: default: 60000
 * `message_hierarchical_output`: Boolean, default: false
 * `message_jsondict_as_string`: Boolean, default: false
@@ -4314,8 +4317,11 @@ Also you will need a so called "exchange point".
 * `server`: Host or IP address of the STOMP server
 * `single_key`: Boolean or string (field name), default: false
 * `ssl_ca_certificate`: path to CA file
-* `ssl_client_certificate`: path to client cert file
-* `ssl_client_certificate_key`: path to client cert key file
+* `auth_by_ssl_client_certificate`: Boolean, default: true (note: set to false for new *n6* auth)
+* `ssl_client_certificate`: path to client cert file, used only if `auth_by_ssl_client_certificate` is true
+* `ssl_client_certificate_key`: path to client cert key file, used only if `auth_by_ssl_client_certificate` is true
+* `username`: STOMP *login* (e.g., *n6* user login), used only if `auth_by_ssl_client_certificate` is false
+* `password`: STOMP *passcode* (e.g., *n6* user API key), used only if `auth_by_ssl_client_certificate` is false
 
 
 .. _intelmq.bots.outputs.tcp.output:

--- a/docs/user/n6-integrations.rst
+++ b/docs/user/n6-integrations.rst
@@ -11,10 +11,9 @@ n6 is maintained and developed by `CERT.pl <https://www.cert.pl/>`_.
 
 Information about n6 can be found here:
 
-- Website: `n6.cert.pl <https://n6.cert.pl/en/>`_
+- Website: `cert.pl/en/n6 <https://cert.pl/en/n6/>`_
 - Source Code: `github.com/CERT-Polska/n6 <https://github.com/CERT-Polska/n6/>`_
 - n6 documentation: `n6.readthedocs.io <https://n6.readthedocs.io/>`_
-- n6sdk developer documentation: `n6sdk.readthedocs.io <https://n6sdk.readthedocs.io/>`_
 
 .. image:: /_static/n6/n6-schemat2.png
    :alt: n6 schema

--- a/intelmq/bots/collectors/stomp/collector.py
+++ b/intelmq/bots/collectors/stomp/collector.py
@@ -77,6 +77,9 @@ class StompCollectorBot(CollectorBot, StompMixin):
     exchange: str = ''
     port: int = 61614
     server: str = "n6stream.cert.pl"
+    auth_by_ssl_client_certificate: bool = True
+    username: str = 'guest'  # ignored if `auth_by_ssl_client_certificate` is true
+    password: str = 'guest'  # ignored if `auth_by_ssl_client_certificate` is true
     ssl_ca_certificate: str = 'ca.pem'  # TODO pathlib.Path
     ssl_client_certificate: str = 'client.pem'  # TODO pathlib.Path
     ssl_client_certificate_key: str = 'client.key'  # TODO pathlib.Path

--- a/intelmq/bots/outputs/stomp/output.py
+++ b/intelmq/bots/outputs/stomp/output.py
@@ -26,6 +26,9 @@ class StompOutputBot(OutputBot, StompMixin):
     port: int = 61614
     server: str = "127.0.0.1"  # TODO: could be ip address
     single_key: bool = False
+    auth_by_ssl_client_certificate: bool = True
+    username: str = 'guest'  # ignored if `auth_by_ssl_client_certificate` is true
+    password: str = 'guest'  # ignored if `auth_by_ssl_client_certificate` is true
     ssl_ca_certificate: str = 'ca.pem'  # TODO: could be pathlib.Path
     ssl_client_certificate: str = 'client.pem'  # TODO: pathlib.Path
     ssl_client_certificate_key: str = 'client.key'  # TODO: patlib.Path

--- a/intelmq/etc/feeds.yaml
+++ b/intelmq/etc/feeds.yaml
@@ -1158,20 +1158,19 @@ providers:
           module: intelmq.bots.collectors.stomp.collector
           parameters:
             exchange: "{insert your exchange point as given by CERT.pl}"
-            ssl_client_certificate_key: "{insert path to client cert key file for
-              CERT.pl's n6}"
             ssl_ca_certificate: "{insert path to CA file for CERT.pl's n6}"
+            auth_by_ssl_client_certificate: false
+            username: "{insert n6 user's login}"
+            password: "{insert n6 user's API key}"
             port: '61614'
-            ssl_client_certificate: "{insert path to client cert file for CERTpl's
-              n6}"
             server: n6stream.cert.pl
             name: __FEED__
             provider: __PROVIDER__
         parser:
           module: intelmq.bots.parsers.n6.parser_n6stomp
           parameters:
-      revision: 2018-01-20
-      documentation: https://n6.cert.pl/en/
+      revision: 2023-09-23
+      documentation: https://n6.readthedocs.io/usage/streamapi/
       public: false
   AlienVault:
     OTX:

--- a/intelmq/lib/mixins/__init__.py
+++ b/intelmq/lib/mixins/__init__.py
@@ -5,5 +5,6 @@
 from intelmq.lib.mixins.http import HttpMixin
 from intelmq.lib.mixins.cache import CacheMixin
 from intelmq.lib.mixins.sql import SQLMixin
+from intelmq.lib.mixins.stomp import StompMixin
 
-__all__ = ['HttpMixin', 'CacheMixin', 'SQLMixin']
+__all__ = ['HttpMixin', 'CacheMixin', 'SQLMixin', 'StompMixin']

--- a/intelmq/lib/mixins/stomp.py
+++ b/intelmq/lib/mixins/stomp.py
@@ -1,0 +1,145 @@
+""" StompMixin for IntelMQ
+
+SPDX-FileCopyrightText: 2017 Sebastian Wagner, 2023 NASK
+SPDX-License-Identifier: AGPL-3.0-or-later
+"""
+
+from typing import (
+    Any,
+    Callable,
+    List,
+    NoReturn,
+    Tuple,
+)
+
+try:
+    import stomp
+except ImportError:
+    stomp = None
+
+from intelmq.lib.exceptions import MissingDependencyError
+
+
+class StompMixin:
+
+    """A mixin that provides certain common methods for STOMP bots."""
+
+    #
+    # STOMP bot attributes relevant to this mixin
+
+    server: str
+    port: int
+    heartbeat: int
+
+    ssl_ca_certificate: str  # TODO: could be pathlib.Path
+    ssl_client_certificate: str  # TODO: could be pathlib.Path
+    ssl_client_certificate_key: str  # TODO: could be patlib.Path
+
+    #
+    # Helper methods intended to be used in subclasses
+
+    @classmethod
+    def stomp_bot_parameters_check(cls, parameters: dict) -> List[List[str]]:
+        """Intended to be used in bots' `check()` static/class method."""
+        logs = []
+        cls.__verify_parameters(
+            get_param=parameters.get,
+            on_error=lambda msg: logs.append(['error', msg]),
+        )
+        return logs
+
+    def stomp_bot_runtime_initial_check(self) -> None:
+        """Intended to be used in bots' `init()` instance method."""
+        self.__verify_dependency()
+        self.__verify_parameters(
+            get_param=self.__get_own_attribute,
+            on_error=self.__raise_value_error,
+        )
+
+    def prepare_stomp_connection(self) -> Tuple['stomp.Connection', dict]:
+        """
+        Get a `(<STOMP connection>, <STOMP connect arguments>)` pair.
+
+        * `<STOMP connection>` is a new instance of `stomp.Connection`,
+           with the SSL stuff *already configured*, but *without* any
+           invocations of `connect()` made yet;
+
+        * `<STOMP connect arguments>` is a dict of arguments -- ready
+          to be passed to the `connect()` method of the aforementioned
+          `<STOMP connection>` object.
+        """
+        ssl_kwargs, connect_kwargs = self.__get_ssl_and_connect_kwargs()
+        host_and_ports = [(self.server, int(self.port))]
+        stomp_connection = stomp.Connection(host_and_ports=host_and_ports,
+                                            heartbeats=(self.heartbeat,
+                                                        self.heartbeat))
+        stomp_connection.set_ssl(host_and_ports, **ssl_kwargs)
+        return stomp_connection, connect_kwargs
+
+    #
+    # Implementation details
+
+    _DEPENDENCY_NAME_REMARK = (
+        "Note that the actual name of the pip-installable "
+        "distribution package is 'stomp.py', not 'stomp'.")
+
+    @classmethod
+    def __verify_dependency(cls) -> None:
+        # Note: the pip-installable package's name is 'stomp.py', but
+        # e.g. the apt-installable package's name is 'python3-stomp' (or
+        # similar) -- that's why we pass to the `MissingDependencyError`
+        # constructor the name 'stomp', but also pass the value of the
+        # `_DEPENDENCY_NAME_REMARK` constant as `additional_text`...
+        if stomp is None:
+            raise MissingDependencyError('stomp',
+                                         additional_text=cls._DEPENDENCY_NAME_REMARK)
+        if stomp.__version__ < (4, 1, 8):
+            raise MissingDependencyError('stomp', version="4.1.8",
+                                         installed=stomp.__version__,
+                                         additional_text=cls._DEPENDENCY_NAME_REMARK)
+
+    @classmethod
+    def __verify_parameters(cls,
+                            get_param: Callable[[str], Any],
+                            on_error: Callable[[str], None]) -> None:
+        for param_name in [
+            'ssl_ca_certificate',
+            'ssl_client_certificate',
+            'ssl_client_certificate_key',
+        ]:
+            cls.__verify_file_param(param_name, get_param, on_error)
+
+    @classmethod
+    def __verify_file_param(cls,
+                            param_name: str,
+                            get_param: Callable[[str], Any],
+                            on_error: Callable[[str], None]) -> None:
+        path = get_param(param_name)
+        if path is None:
+            on_error(f"Parameter {param_name!r} is not given "
+                     f"(or is set to None).")
+            return
+        try:
+            open(path, 'rb').close()
+        except OSError as exc:
+            # (note: the filename is mentioned in the included exc message)
+            on_error(f"Cannot open file specified as parameter "
+                     f"{param_name!r} ({str(exc)!r}).")
+
+    def __get_own_attribute(self, param_name: str) -> Any:
+        return getattr(self, param_name, None)
+
+    def __raise_value_error(self, msg: str) -> NoReturn:
+        raise ValueError(msg)
+
+    def __get_ssl_and_connect_kwargs(self) -> Tuple[dict, dict]:
+        # Note: the `ca_certs` argument to `set_ssl()` must always be
+        # provided, otherwise the `stomp.py`'s machinery would *not*
+        # perform any certificate verification!
+        ssl_kwargs = dict(
+            ca_certs=self.ssl_ca_certificate,
+            cert_file=self.ssl_client_certificate,
+            key_file=self.ssl_client_certificate_key,
+        )
+        connect_kwargs = dict(wait=True)
+        return ssl_kwargs, connect_kwargs


### PR DESCRIPTION
This is a bunch of updates, fixes and enhancements related to integration with STOMP-based services, especially with the [*n6*](https://github.com/CERT-Polska/n6)'s one.

The most important change is related to the **upcoming switch of authentication to the *n6 Stream API*: from *client certificate-based* to *login-and-passcode-based*.** Other changes focus on compatibility with newer versions of the `stomp.py` library as well as on minor fixes/cleanups/improvements (mostly consistency-related).

***

The key changes concern the *STOMP collector bot* and the *STOMP output bot*:

* Each of those two bots obtained three new config parameters -- necessary to accommodate to the incoming changes regarding the *n6 Stream API*'s authentication mechanism, i.e., switching from the legacy *client-certificate-based* one to a new *STOMP-login-and-passcode-based* one. The new config parameters are:
  * `auth_by_ssl_client_certificate`: if true (the default), the legacy *certificate-based* authentication will be attempted (so `ssl_client_certificate` and `ssl_client_certificate_key` need to be specified); if false, the new *login-based* authentication will be attempted (so the config parameters described below need to be specified);
  * ~~`stomp_login`~~ `username`: a *STOMP login* (in the case of *n6* it is just the user's login, the same which you use to log in to *n6 Portal*);
  * ~~`stomp_passcode`~~ `password`: a *STOMP passcode* (in the case of *n6* it is the user's API key which can be obtained via *n6 Portal*).
* From now on, newer versions of the `stomp.py` library are supported, including the latest (8.1.0).

See also: the commit messages.