### PR TITLE
bots/collectors/api: make socket file permissions configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,9 @@
 #### Parsers
 
 #### Experts
+- `intelmq.bots.experts.jinja` (PR#2417 by Mikk Margus Möll):
+  - Add optional `socket_perms` and `socket_group` parameters to change
+    file permissions on socket file, if it is in use.
 
 #### Outputs
 - `intelmq.bots.outputs.stomp.output` (PR#2408 by Jan Kaliszewski):

--- a/docs/user/bots.md
+++ b/docs/user/bots.md
@@ -259,6 +259,14 @@ used. Requires the [tornado](https://pypi.org/project/tornado/) library.
 
 (optional, string) Location of the socket. Defaults to `/tmp/imq_api_default_socket`.
 
+**`socket_perms`**
+
+(optional, octal integer) Unix permissions to grant to the socket file. Default: `600`
+
+**`socket_group`**
+
+(optional, string) Name of group to change group ownership of socket file to.
+
 ---
 
 ### Generic URL Fetcher <div id="intelmq.bots.collectors.http.collector_http" />


### PR DESCRIPTION
By default, `tornado.netutil.bind_unix_socket` creates socket files with `600` permissions and which have the owner and group of the creating user (intelmq). This does not work well in the common case of the process at the other end of the socket not being a process running as the intelmq user.
This commit adds `socket_perms` and `socket_group` configuration parameters to the bot to allow for the file's permissions to be changed.