### PR TITLE
Fix not connected error in STOMP output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,8 @@
     of necessary file(s)).
   - Add `stomp.py` version check (raise `MissingDependencyError` if not `>=4.1.12`).
   - Minor fixes/improvements and some refactoring (see also above: *Core*...).
+- `intelmq.bots.outputs.stomp.output` (PR#2423 by Kamil Mankowski):
+  - Try to reconnect on `NotConnectedException`.
 
 ### Documentation
 - Add a readthedocs configuration file to fix the build fail (PR#2403 by Sebastian Wagner).

--- a/intelmq/bots/outputs/stomp/output.py
+++ b/intelmq/bots/outputs/stomp/output.py
@@ -76,8 +76,12 @@ class StompOutputBot(OutputBot, StompMixin):
 
         body = self.export_event(event)
 
-        self._conn.send(body=body,
-                        destination=self.exchange)
+        try:
+            self._conn.send(body=body, destination=self.exchange)
+        except stomp.exception.NotConnectedException:
+            self.logger.warning("Detected connection error, trying to reestablish it.")
+            self.connect()
+            raise  # Fallback to default retry
         self.acknowledge_message()
 
     @classmethod


### PR DESCRIPTION
This PR depends on PR #2414 and handles connection errors in the output bot