### PR TITLE
DOC: Remove unused custom_template config

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -47,7 +47,6 @@ plugins:
 
   - mkdocstrings:
       enabled: false
-      custom_templates: templates
       default_handler: python
       handlers:
         python:


### PR DESCRIPTION
This configuration was recently updated to check if the target
exists [1]. As we do not acutally use custom plugins, removing
the setting fixes CI.

[1]: https://github.com/mkdocstrings/mkdocstrings/commit/370a61d12b33f3fb61f6bddb3939eb8ff6018620