### PR TITLE
doc: fix logo display in root repository

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@
 [![CII Badge](https://bestpractices.coreinfrastructure.org/projects/4186/badge)](https://bestpractices.coreinfrastructure.org/projects/4186/)
 -->
 
-![IntelMQ](static/images/Logo_Intel_MQ.svg)
+![IntelMQ](/docs/static/images/Logo_Intel_MQ.svg)
 
 # Introduction
 


### PR DESCRIPTION
* Use an absolute link from docs/index.md to make sure that the svg logo is displayed from the root repository as well as when viewing index.md directly.
