### PR TITLE
bug: ctl: handle non-existing bot modules

### DIFF
--- a/intelmq/bin/intelmqctl.py
+++ b/intelmq/bin/intelmqctl.py
@@ -940,6 +940,12 @@ Get some debugging output on the settings and the environment (to be extended):
                     check_logger.error('SyntaxError in bot %r: %r', bot_id, exc)
                     retval = 1
                     continue
+                except AttributeError:
+                    # if module does not exist, utils.get_bot_module_name returns None. import_module then raises
+                    # AttributeError: 'NoneType' object has no attribute 'startswith'
+                    check_logger.error('Incomplete installation: Bot %r not importable.', bot_id,)
+                    retval = 1
+                    continue
                 bot = getattr(bot_module, 'BOT')
                 bot_parameters = copy.deepcopy(global_settings)
                 bot_parameters.update(bot_config.get('parameters', {}))  # the parameters field may not exist

--- a/intelmq/lib/utils.py
+++ b/intelmq/lib/utils.py
@@ -852,7 +852,10 @@ def _get_console_entry_points():
     return entries.get("console_scripts", [])  # it's a dict
 
 
-def get_bot_module_name(bot_name: str) -> str:
+def get_bot_module_name(bot_name: str) -> Optional[str]:
+    """
+    Returns None if the bot does not exist
+    """
     entries = entry_points()
     if hasattr(entries, "select"):
         entries = tuple(entries.select(name=bot_name, group="console_scripts"))


### PR DESCRIPTION
the new function utils.get_bot_module_name returns None if a bot module does not exist, and
importlib.import_module raises an exception when passed None

I added no changelog entry as the faulty code was never released.

previously:
```
Checking for bots.
Traceback (most recent call last):
  File "/usr/bin/intelmqctl", line 33, in <module>
    sys.exit(load_entry_point('intelmq==3.2.2a1', 'console_scripts', 'intelmqctl')())
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/intelmq/bin/intelmqctl.py", line 1295, in main
    return x.run()
           ^^^^^^^
  File "/usr/lib/python3.11/site-packages/intelmq/bin/intelmqctl.py", line 429, in run
    retval, results = args.func(**args_dict)
                      ^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/intelmq/bin/intelmqctl.py", line 934, in check
    bot_module = importlib.import_module(utils.get_bot_module_name(bot_config['module']))
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.11/importlib/__init__.py", line 117, in import_module
    if name.startswith('.'):
       ^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'startswith'
```

now:
```
Checking for bots.
Incomplete installation: Bot 'malc0de-parser' not importable.
```