### PR TITLE
Only load the config once on intelmqctl init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
   (PR#2408 and PR#2414 by Jan Kaliszewski).
 - `intelmq.lib.upgrades`: Replace deprecated instances of `url2fqdn` experts by the new `url` expert in runtime configuration (PR#2432 by Sebastian Wagner).
 - `intelmq.lib.bot`: Ensure closing log files on reloading (PR#2435 by Kamil Mankowski).
+- Only load the config once when starting intelmqctl (which makes IntelMQ API calls take less time) (PR#2444 by DigitalTrustCenter).
 
 ### Development
 - Makefile: Add codespell and test commands (PR#2425 by Sebastian Wagner).


### PR DESCRIPTION
Every time intelmqctl is started, the runtime yaml config is loaded twice in the __init__ method.
1. The global settings are loaded. This is done by loading the whole runtime config and taking the global section.
2. The runtime config is loaded and stored in the _runtime_configuration variable.

This fix changes intelmqctl init so that it only loads (and parses) the runtime config once. The global settings are taken from the config that is already loaded.

This looks like a small optimization, but the current (pure python) YAML parser is quite slow. The IntelMQ manager calls the IntelMQ API. The IntelMQ API calls intelmqctl. Hence on a quite large runtime config, the manager feels sluggish. 

In our test, we reduced the time it took for a single API call by 0.4 seconds with this fix.