### PR TITLE
FIX: Correctly configure SSL context for AMQP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
   (PR#2408 and PR#2414 by Jan Kaliszewski).
 - `intelmq.lib.upgrades`: Replace deprecated instances of `url2fqdn` experts by the new `url` expert in runtime configuration (PR#2432 by Sebastian Wagner).
 - `intelmq.lib.bot`: Ensure closing log files on reloading (PR#2435 by Kamil Mankowski).
+- AMQP Pipeline: fix SSL context to pointing to create a client-side connection that verifies the server (PR by Kamil Mankowski).
 
 ### Development
 - Makefile: Add codespell and test commands (PR#2425 by Sebastian Wagner).
@@ -61,6 +62,7 @@
   - Remove undocumented and unused attributes of `StompCollectorBot` instances:
     `ssl_ca_cert`, `ssl_cl_cert`, `ssl_cl_cert_key`.
   - Minor fixes/improvements and some refactoring (see also above: *Core*...).
+- `intelmq.bots.collectors.amqp`: fix SSL context to pointing to create a client-side connection that verifies the server (PR by Kamil Mankowski).
 
 #### Parsers
   - `intelmq.bots.parsers.netlab_360.parser`: Removed as the feed is discontinued. (#2442 by Filip Pokorný)
@@ -93,6 +95,7 @@
   - Try to reconnect on `NotConnectedException`.
 - `intelmq.bots.outputs.smtp_batch.output` (PR #2439 by Edvard Rejthar):
   - Fix ability to send with the default `bcc`
+- `intelmq.bots.outputs.amqp`: fix SSL context to pointing to create a client-side connection that verifies the server (PR by Kamil Mankowski).
 
 ### Documentation
 - Add a readthedocs configuration file to fix the build fail (PR#2403 by Sebastian Wagner).
@@ -165,7 +168,7 @@
 #### Parsers
 - `intelmq.bots.parsers.shadowserver._config`:
   - Reset detected `feedname` at shutdown to re-detect the feedname on reloads (PR#2361 by @elsif2, fixes #2360).
-  - Switch to dynamic configuration to decouple report schema changes from IntelMQ releases. 
+  - Switch to dynamic configuration to decouple report schema changes from IntelMQ releases.
   - Added 'IPv6-Vulnerable-Exchange' alias and 'Accessible-WS-Discovery-Service' report. (PR#2338)
   - Removed unused `p0f_genre` and `p0f_detail` from the 'DNS-Open-Resolvers' report. (PR#2338)
   - Added 'Accessible-SIP' report. (PR#2348)

--- a/intelmq/bots/collectors/amqp/collector_amqp.py
+++ b/intelmq/bots/collectors/amqp/collector_amqp.py
@@ -55,7 +55,7 @@ class AMQPCollectorBot(AMQPTopicOutputBot, CollectorBot):
                                                                self.password)
 
         if self.use_ssl:
-            self.kwargs['ssl_options'] = pika.SSLOptions(context=ssl.create_default_context(ssl.Purpose.CLIENT_AUTH))
+            self.kwargs['ssl_options'] = pika.SSLOptions(context=ssl.create_default_context(ssl.Purpose.SERVER_AUTH))
 
         self.connection_parameters = pika.ConnectionParameters(
             host=self.connection_host,

--- a/intelmq/bots/outputs/amqptopic/output.py
+++ b/intelmq/bots/outputs/amqptopic/output.py
@@ -64,7 +64,7 @@ class AMQPTopicOutputBot(OutputBot):
                                                                self.password)
 
         if self.use_ssl:
-            self.kwargs['ssl_options'] = pika.SSLOptions(context=ssl.create_default_context(ssl.Purpose.CLIENT_AUTH))
+            self.kwargs['ssl_options'] = pika.SSLOptions(context=ssl.create_default_context(ssl.Purpose.SERVER_AUTH))
 
         self.connection_parameters = pika.ConnectionParameters(
             host=self.connection_host,

--- a/intelmq/lib/pipeline.py
+++ b/intelmq/lib/pipeline.py
@@ -530,7 +530,7 @@ class Amqp(Pipeline):
         if self.username and self.password:
             self.kwargs['credentials'] = pika.PlainCredentials(self.username, self.password)
         if self.ssl:
-            self.kwargs['ssl_options'] = pika.SSLOptions(context=ssl.create_default_context(ssl.Purpose.CLIENT_AUTH))
+            self.kwargs['ssl_options'] = pika.SSLOptions(context=ssl.create_default_context(ssl.Purpose.SERVER_AUTH))
         pika_version = tuple(int(x) for x in pika.__version__.split('.'))
         if pika_version < (0, 11):
             self.kwargs['heartbeat_interval'] = 10


### PR DESCRIPTION
According to the Python documentation, in order to establish
a client-side connection the purpose of SERVER_AUTH is appropriate.
It instructs the SSL libraries to verify the authenticity
of the server. As of Python 3.10 [2], the internal configuration
used has been changed from the generic PROTOCOL_TLS to a specific
variant for client or server. Therefore, when using Python 3.10
or higher, the incorrect configuration of ssl.Purpose results
in an inability to establish a connection.

[1] https://docs.python.org/3/library/ssl.html#ssl.Purpose.SERVER_AUTH
[2] https://docs.python.org/3/library/ssl.html#ssl.PROTOCOL_TLS
