### PR TITLE
Add extract_cve_from_tag to Shadowserver parser _config.py

### DIFF
--- a/intelmq/bots/parsers/shadowserver/_config.py
+++ b/intelmq/bots/parsers/shadowserver/_config.py
@@ -291,7 +291,7 @@ def category_or_detail(value: str, row: Dict[str, str]) -> str:
 
 
 def extract_cve_from_tag(tag: str) -> Optional[str]:
-    """ Returns a string with a sorted comma-separated list of CVEs or None if no CVE found in tag. """
+    """ Returns a string with a sorted semicolon-separated list of CVEs or None if no CVE found in tag. """
     cveset = set()
     tags = tag.split(";")
 
@@ -300,8 +300,8 @@ def extract_cve_from_tag(tag: str) -> Optional[str]:
             cveset.add(t)
 
     if not (len(cveset)):
-        return None;
-    return (','.join(str(c) for c in sorted(cveset)))
+        return None
+    return (';'.join(str(c) for c in sorted(cveset)))
 
 
 functions = {

--- a/intelmq/bots/parsers/shadowserver/_config.py
+++ b/intelmq/bots/parsers/shadowserver/_config.py
@@ -322,6 +322,7 @@ functions = {
     'scan_exchange_type': scan_exchange_type,
     'scan_exchange_identifier': scan_exchange_identifier,
     'category_or_detail': category_or_detail,
+    'extract_cve_from_tag': extract_cve_from_tag,
 }
 
 

--- a/intelmq/bots/parsers/shadowserver/_config.py
+++ b/intelmq/bots/parsers/shadowserver/_config.py
@@ -290,6 +290,20 @@ def category_or_detail(value: str, row: Dict[str, str]) -> str:
     return row.get('detail', '')
 
 
+def extract_cve_from_tag(tag: str) -> Optional[str]:
+    """ Returns a string with a sorted comma-separated list of CVEs or None if no CVE found in tag. """
+    cveset = set()
+    tags = tag.split(";")
+
+    for t in tags:
+        if re.match('^cve-[0-9]+-[0-9]+$', t):
+            cveset.add(t)
+
+    if not (len(cveset)):
+        return None;
+    return (','.join(str(c) for c in sorted(cveset)))
+
+
 functions = {
     'add_UTC_to_timestamp': add_UTC_to_timestamp,
     'convert_bool': convert_bool,


### PR DESCRIPTION
"extract_cve_from_tag" returns a sorted comma separated list of CVEs included with "tag" in the Vulnerable-HTTP report, e.g.

extract_cve_from_tag("affected-software;cve-2023-12345;cve-2024-56789;ssl;ssl-freak;vpn")
-> "cve-2023-12345,cve-2024-56789"

to be stored in "extra.cve" by adding

         [
            "extra.cve",
            "tag",
            "extract_cve_from_tag"
         ],

to the intelmq.json schema.
