### PR TITLE
FIX: Save current line when processing Cymru data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@
 - `intelmq.bots.parsers.sucuri.parser`: Removed as the feed is discontinued. (#2442 by Filip Pokorný)
 - `intelmq.bots.parsers.shadowserver._config`:
   - Switch to dynamic configuration to decouple report schema changes from IntelMQ releases by regularly downloading them from the Shadowserver server (PR#2372 by elsif2).
+- `intelmq.bots.parsers.cymru`: Save current line. (PR by Kamil Mankowski)
 
 #### Experts
 - `intelmq.bots.experts.jinja` (PR#2417 by Mikk Margus Möll):

--- a/intelmq/bots/parsers/cymru/parser_cap_program.py
+++ b/intelmq/bots/parsers/cymru/parser_cap_program.py
@@ -64,6 +64,7 @@ class CymruCAPProgramParserBot(ParserBot):
                 elif 'Data file written at' in line:
                     self.parse_line = self.parse_line_old
             else:
+                self._current_line = line
                 yield line
 
     def parse_bot_old(self, comment_split, report_type, event):


### PR DESCRIPTION
Bot wasn't saving the current line resulting in harder
debugging on errors.