### PR TITLE
Fix Shadowserver parser fixed report type.

### DIFF
--- a/intelmq/bots/parsers/shadowserver/_config.py
+++ b/intelmq/bots/parsers/shadowserver/_config.py
@@ -126,7 +126,7 @@ def enable_auto_update(enable):
     __config.auto_update = enable
 
 
-def get_feed_by_feedname(given_feedname: str) -> Optional[Dict[str, Any]]:
+def get_feed_by_feedname(given_feedname: str) -> Optional[Tuple[str, Dict[str, Any]]]:
     return __config.feedname_mapping.get(given_feedname, None)
 
 

--- a/intelmq/bots/parsers/shadowserver/parser.py
+++ b/intelmq/bots/parsers/shadowserver/parser.py
@@ -63,6 +63,7 @@ class ShadowserverParserBot(ParserBot):
         if self.feedname is not None:
             self._sparser_config = config.get_feed_by_feedname(self.feedname)
             if self._sparser_config:
+                self._sparser_config = self._sparser_config[1]
                 self.logger.info('Using fixed feed name %r for parsing reports.' % self.feedname)
                 self._mode = 'fixed'
             else:


### PR DESCRIPTION
Fixes following error when using Fixed Report Type:

```
File "/opt/venv/lib/python3.9/site-packages/intelmq/bots/parsers/shadowserver/parser.py", line 129, in parse_line
    for item in conf.get('required_fields'):
AttributeError: 'tuple' object has no attribute 'get'
```