### PR TITLE
FIX: RIPE expert: handle unknown response for non-ASN types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,8 @@
 - `intelmq.bots.experts.jinja` (PR#2417 by Mikk Margus Möll):
   - Add optional `socket_perms` and `socket_group` parameters to change
     file permissions on socket file, if it is in use.
+- `intelmq.bots.experts.ripe` (PR#2461 by Mikk Margus Möll):
+  - Handle "No abuse contact found for" messages for non-ASN resources
 
 #### Outputs
 - `intelmq.bots.outputs.stomp.output` (PR#2408 and PR#2414 by Jan Kaliszewski):

--- a/intelmq/bots/experts/ripe/expert.py
+++ b/intelmq/bots/experts/ripe/expert.py
@@ -138,7 +138,7 @@ class RIPEExpertBot(ExpertBot, CacheMixin):
                                              data="", timeout=self.http_timeout_sec)
 
             if response.status_code != 200:
-                if type == 'db_asn' and response.status_code == 404:
+                if response.status_code == 404:
                     """ If no abuse contact could be found, a 404 is given. """
                     try:
                         if response.json()['message'].startswith('No abuse contact found for '):

--- a/intelmq/tests/bots/experts/ripe/test_expert.py
+++ b/intelmq/tests/bots/experts/ripe/test_expert.py
@@ -75,6 +75,9 @@ INDEX_ERROR = {"__type": "Event",
                "source.ip": "228.66.141.189",
                }
 
+ARIN_IP_EVENT = {"__type": "Event",
+                 "source.ip": "2001:500:110:201::47"}
+
 @test.skip_internet()
 class TestRIPEExpertBot(test.BotTestCase, unittest.TestCase):
     """
@@ -262,6 +265,12 @@ class TestRIPEExpertBot(test.BotTestCase, unittest.TestCase):
         self.input_message = INDEX_ERROR
         self.run_bot()
         self.assertMessageEqual(0, INDEX_ERROR)
+
+    def test_arin_ip(self):
+        self.input_message = ARIN_IP_EVENT
+        self.run_bot()
+        self.assertMessageEqual(0, ARIN_IP_EVENT)
+
 
 if __name__ == '__main__':  # pragma: no cover
     unittest.main()


### PR DESCRIPTION
Currently, the RIPE bot successfully handles "No abuse contact found for" messages in response to ASNs, but not for IPs. An example of this would be the address `2001:470:1:c84::12e`, which is from a range assigned by ARIN.
This PR removes the filter on only checking for these types of messages on ASNs, allowing for IPs to not cause errors in the bot.