### PR TITLE
Fix dataplane parser failing to parse AS names with pipe characters

### DIFF
--- a/intelmq/bots/parsers/dataplane/parser.py
+++ b/intelmq/bots/parsers/dataplane/parser.py
@@ -143,7 +143,10 @@ class DataplaneParserBot(ParserBot):
         else:
             event = self.new_event(report)
 
-            line_contents = line.split('|')
+            # As mentioned in the feed header: Each field is separated
+            # by a pipe symbol ('|') and at least two whitespace
+            # characters on either side.
+            line_contents = line.split('  |  ')
             feed_name = line_contents[-1].strip()
             file_format = FILE_FORMATS.get(feed_name) or FILE_FORMATS['_default']
 

--- a/intelmq/tests/bots/parsers/dataplane/sshpwauth.txt
+++ b/intelmq/tests/bots/parsers/dataplane/sshpwauth.txt
@@ -70,7 +70,8 @@
 #
 NA           |  NA                              |  170.239.104.183  |  2016-12-01 04:26:48  |  sshpwauth
 4134         |  CHINANET-BACKBONE No.31,Jin-ro  |   117.21.224.121  |  2016-12-06 02:35:38  |  sshpwauth
+1            |  TEST-AS company | With | pipe   |  1.2.3.4          |  2024-04-02 12:00:00  |  sshpwauth
 #
 # Statistics
-#        ASNs: 1
-#   Addresses: 2
+#        ASNs: 2
+#   Addresses: 3

--- a/intelmq/tests/bots/parsers/dataplane/test_parser.py
+++ b/intelmq/tests/bots/parsers/dataplane/test_parser.py
@@ -198,6 +198,21 @@ SSH_AUTH_EVENT = [{'feed.url': 'https://dataplane.org/sshpwauth.txt',
                    'time.source': '2016-12-06T02:35:38+00:00',
                    'protocol.application': 'ssh',
                    'classification.type': 'brute-force',
+                   },
+                  {'feed.url': 'https://dataplane.org/sshpwauth.txt',
+                   'feed.name': 'SSH Password Authentication',
+                   '__type': 'Event',
+                   'time.observation': '2016-12-07T06:27:26+00:00',
+                   'raw': 'MSAgICAgICAgICAgIHwgIFRFU1QtQVMgY29tcGFueSB8IFdpdGggfCBwaXBlICAgfCAgMS4yLjMuNCAgICAgICAgICB8ICAyMDI0LTA0LTAyIDEyOjAwOjAwICB8ICBzc2hwd2F1dGg=',
+                   'event_description.text': 'Address has been seen attempting to remotely login to a host using SSH password '
+                                             'authentication. The source report lists hosts that are highly suspicious and '
+                                             'are likely conducting malicious SSH password authentication attacks.',
+                   'source.asn': 1,
+                   'source.ip': '1.2.3.4',
+                   'source.as_name': 'TEST-AS',
+                   'time.source': '2024-04-02T12:00:00+00:00',
+                   'protocol.application': 'ssh',
+                   'classification.type': 'brute-force',
                    }]
 
 
@@ -228,6 +243,7 @@ class TestDataplaneParserBot(test.BotTestCase, unittest.TestCase):
         self.run_bot()
         self.assertMessageEqual(0, SSH_AUTH_EVENT[0])
         self.assertMessageEqual(1, SSH_AUTH_EVENT[1])
+        self.assertMessageEqual(2, SSH_AUTH_EVENT[2])
 
 
 if __name__ == '__main__':  # pragma: no cover


### PR DESCRIPTION
At the time of writing, the sshpwauth.txt feed contains an AS name with a pipe character ('|').
AS262907 - BRASIL TECPAR | AMIGO | AVATO

The existing dataplane parser throws an error on that line, as it splits the data fields on just the pipe character.
From the feed header: "Each field is separated by a pipe symbol ('|') and at least two whitespace characters on either side."
Technically there are way more characters other that space that are whitespace characters, but just space seems to be used.
Hence we can split on '  |  ' instead to fix this line breaking.