### PR TITLE
Missing release steps, add changelog entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
 # CHANGELOG
 
 
-## 3.3.1 (unreleased)
+3.3.1 (unreleased)
+------------------
 
 ### Configuration
 
@@ -20,6 +21,9 @@
 #### Collectors
 
 #### Parsers
+- `intelmq.bots.parsers.shadowserver._config`:
+  - Fetch schema before first run (PR#2482 by elsif2, fixes #2480).
+- `intelmq.bots.parsers.dataplane.parser`: Use `  |  ` as field delimiter, fix parsing of AS names including `|` (PR#2488 by DigitalTrustCenter).
 
 #### Experts
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,37 @@
 # CHANGELOG
 
 
+## 3.3.1 (unreleased)
+
+### Configuration
+
+### Core
+
+### Development
+
+### Data Format
+
+### Bots
+#### Collectors
+
+#### Parsers
+
+#### Experts
+
+#### Outputs
+
+### Documentation
+
+### Packaging
+
+### Tests
+
+### Tools
+
+### Contrib
+
+### Known issues
+
 
 3.3.0 (2024-03-01)
 ------------------

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,8 +10,24 @@ This file lists all changes which have an affect on the administration of IntelM
 Please refer to the change log for a full list of changes.
 
 
-3.3.0 Feature release  (2024-03-01)
----------------------
+3.3.0 Bugfix release (unreleased)
+---------------------------------
+
+### Requirements
+
+### Tools
+
+### Data Format
+
+### Configuration
+
+### Libraries
+
+### Postgres databases
+
+
+3.3.0 Feature release (2024-03-01)
+----------------------------------
 
 ### Documentation
 The documentation is now available at [docs.intelmq.org](https://docs.intelmq.org/). Documentation has been updated and restructured into User, Administrator and Developer Guide. It provides modern look with various quality of life improvements. Big thanks to to @gethvi. 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,8 +1,14 @@
+intelmq (3.3.1~a1-1) UNRELEASED; urgency=medium
+
+  * 3.3.1 Bugfix release
+
+ -- Sebastian Wagner <sebix@sebix.at>  Thu, 04 Apr 2024 10:40:34 +0200
+
 intelmq (3.3.0-1) stable; urgency=medium
 
   * 3.3.0 Feature release
 
- -- Aaron Kaplan <aaron@lo-res.org>  Fr, 01 Mar 2024 14:19:00 +0100
+ -- Aaron Kaplan <aaron@lo-res.org>  Fri, 01 Mar 2024 14:19:00 +0100
 
 intelmq (3.2.1-2) stable; urgency=medium
 

--- a/intelmq/lib/upgrades.py
+++ b/intelmq/lib/upgrades.py
@@ -40,7 +40,7 @@ __all__ = ['v100_dev7_modify_syntax',
            'v310_shadowserver_feednames',
            'v320_update_turris_greylist_url',
            'v322_url_replacement',
-           'v322_removed_feeds_and_bots'
+           'v322_removed_feeds_and_bots',
            ]
 
 
@@ -979,6 +979,8 @@ UPGRADES = OrderedDict([
     ((3, 1, 0), (v310_feed_changes, v310_shadowserver_feednames)),
     ((3, 2, 0), (v320_update_turris_greylist_url,)),
     ((3, 2, 2), (v322_url_replacement, v322_removed_feeds_and_bots)),
+    ((3, 3, 0), ()),
+    ((3, 3, 1), ()),
 ])
 
 ALWAYS = (harmonization,)

--- a/intelmq/version.py
+++ b/intelmq/version.py
@@ -1,6 +1,6 @@
-# SPDX-FileCopyrightText: 2016-2023 Sebastian Wagner
+# SPDX-FileCopyrightText: 2016-2024 Sebastian Wagner
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
-__version_info__ = (3, 3, 0)
+__version_info__ = (3, 3, 1, 'alpha1')
 __version__ = '.'.join(map(str, __version_info__))


### PR DESCRIPTION
@aaronkaplan
the steps from https://docs.intelmq.org/latest/dev/release/#prepare-new-version were missing

- prepare version 3.3.1, fix changelog (missing steps after the last release)
- fix `dch: warning:     debian/changelog(l5): ignoring invalid week day 'Fr'` (changelog entry by @aaronkaplan for 3.3.0 release)
- doc: changelog entries for #2482 and #2488