### PR TITLE
ENH: add alert parameter to Shodan stream collector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
 
 ### Bots
 #### Collectors
+- `intelmq.bots.collectors.shodan.collector_stream` (PR#2492 by Mikk Margus Möll):
+  - Add `alert` parameter to Shodan stream collector to allow fetching streams by configured alert ID
 
 #### Parsers
 - `intelmq.bots.parsers.shadowserver._config`:

--- a/docs/user/bots.md
+++ b/docs/user/bots.md
@@ -994,6 +994,10 @@ Only the proxy is used (requires `shodan-python > 1.8.1`). Certificate is always
 
 () A list of countries to query for. If it is a string, it will be spit by `,`.
 
+**`alert`**
+
+() Alert ID from monitor.shodan.io.
+
 If the stream is interrupted, the connection will be aborted using the timeout parameter. No error will be logged if the
 number of consecutive connection fails does not reach the parameter
 `error_max_retries`. Instead of errors, an INFO message is logged. This is a measurement against too frequent ERROR


### PR DESCRIPTION
This PR adds the option to fetch Shodan Stream results with the Shodan Stream collector by alert ID, which can be configured from `monitor.shodan.io`