### PR TITLE
FIX: handle init failure on incorrect current event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 #### Experts
 
 #### Outputs
+- `intelmq.bots.outputs.misp.output_feed`: handle failures if saved current event wasn't saved or is incorrect (PR by Kamil Mankowski).
 
 ### Documentation
 


### PR DESCRIPTION
If event hold in current event wasn't saved correctly, the bot is unable to start and handle any event.

In our case, the file wasn't created at all. I'm not sure yet why (I suspect some trouble by reloading), but such a problem shouldn't stop the bot from working.