### PR TITLE
Handle type parameter as a string and match by type instead of filena…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@
 
 ### Bots
 #### Collectors
+- `intelmq.bots.collectors.shadowserver.collector_reports_api.py`:
+  - Added support for the types parameter to be either a string or a list.
+  - Refactored to utilize the type field returned by the API to match the requested types instead of a sub-string match on the filename.
 
 #### Parsers
 - `intelmq.bots.parsers.shadowserver._config`:

--- a/intelmq/bots/collectors/shadowserver/collector_reports_api.py
+++ b/intelmq/bots/collectors/shadowserver/collector_reports_api.py
@@ -59,7 +59,8 @@ class ShadowServerAPICollectorBot(CollectorBot, HttpMixin, CacheMixin):
             self._report_list = self.reports.split(',')
         elif isinstance(self.reports, list):
             self._report_list = self.reports
-
+        if isinstance(self.types, str):
+            self.types = self.types.split(',')
         if self.country and self.country not in self._report_list:
             self.logger.warn("Deprecated parameter 'country' found. Please use 'reports' instead. The backwards-compatibility will be removed in IntelMQ version 4.0.0.")
             self._report_list.append(self.country)
@@ -110,8 +111,7 @@ class ShadowServerAPICollectorBot(CollectorBot, HttpMixin, CacheMixin):
             return None
 
         if self.types:
-            reports = [report for report in reports if any(rtype in report['file'] for rtype in self.types)]
-
+            reports = [report for report in reports if any(report['type'] == rtype for rtype in self.types)]
         return reports
 
     def _report_download(self, reportid: str):

--- a/intelmq/tests/bots/collectors/shadowserver/reports-list.json
+++ b/intelmq/tests/bots/collectors/shadowserver/reports-list.json
@@ -2,6 +2,7 @@
     {
         "report": "anarres@shadowserver.org",
         "file": "2020-08-02-scan_smb-anarres-geo.csv",
+	"type": "scan_smb",
         "id": "xNDSuwXrKnrLrDopU926rR75CAESMWesVCKsuyI8b8ncTv7GCX",
         "timestamp": "2020-08-02"
     },
@@ -9,17 +10,20 @@
         "report": "anarres@shadowserver.org",
         "id": "unnzVtn92tS9459rKIEz2J8qb7oJDv0Fa2feGUOiJLCDLqBXnN",
         "file": "2020-08-02-cisco_smart_install-anarres-geo.csv",
+	"type": "cisco_smart_install",
         "timestamp": "2020-08-02"
     },
     {
         "timestamp": "2020-08-02",
         "id": "EhngMTvBT7tD4ehUpVJNqW8TRZRI9N6ozsarxuick4ritIIxOG",
         "file": "2020-08-02-scan_adb-anarres-geo.csv",
+	"type": "scan_adb",
         "report": "anarres@shadowserver.org"
     },
     {
         "id": "GYb7n9SbR5jM2PMsfvo78r3G7tYF4v37koXEB8Kngs3ewCvHF4",
         "file": "2020-08-02-scan_rsync-anarres-geo.csv",
+	"type": "scan_rsync",
         "report": "anarres@shadowserver.org",
         "timestamp": "2020-08-02"
     },
@@ -27,6 +31,7 @@
         "timestamp": "2020-08-02",
         "report": "anarres@shadowserver.org",
         "file": "2020-08-02-scan_ldap_tcp-anarres-geo.csv",
+	"type": "scan_ldap_tcp",
         "id": "qxe9EGItMY7eyDQwPBwGgEP2VOpvZqnqSDRIJGkXy3UWVUC06B"
     }
 ]


### PR DESCRIPTION
The current version expects the `types` parameter to be a list:

```
parameters:
      types: [blocklist]
```
If the parameter is provided as a string instead all report types are matched.

This update adds support for the `types` parameter to be either a string or a list.

This update also utilizes the `type` field returned by the API to match the requested types instead of a sub-string match on the filename.