### PR TITLE
ENH: utils: acquire groups of intelmq user in drop_privileges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Configuration
 
 ### Core
+- `intelmq.lib.utils.drop_privileges`: When IntelMQ is called as `root` and dropping the privileges to user `intelmq`, also set the non-primary groups associated with the `intelmq` user. Makes the behaviour of running intelmqctl as `root` closer to the behaviour of `sudo -u intelmq ...` (PR#2507 by Mikk Margus Möll).
 
 ### Development
 

--- a/intelmq/lib/utils.py
+++ b/intelmq/lib/utils.py
@@ -692,6 +692,7 @@ def drop_privileges() -> bool:
     """
     if os.geteuid() == 0:
         try:
+            os.setgroups([group.gr_gid for group in grp.getgrall() if 'intelmq' in group.gr_mem])
             os.setgid(grp.getgrnam('intelmq').gr_gid)
             os.setuid(pwd.getpwnam('intelmq').pw_uid)
         except (OSError, KeyError):


### PR DESCRIPTION
This adds additional, non-primary groups associated with the `intelmq` user when running `drop_privileges`. This makes the behaviour of running `intelmqctl` as root somewhat closer to the behaviour of running it via intelmq-manager, which runs  `sudo -u intelmqctl [...]`