### PR TITLE
mail attachment: Remove deprecated parameter attach_unzip from default parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
   - Fixed timezone issue for collecting reports.
 - `intelmq.bots.collectors.shodan.collector_stream` (PR#2492 by Mikk Margus Möll):
   - Add `alert` parameter to Shodan stream collector to allow fetching streams by configured alert ID
+- `intelmq.bots.collectors.mail._lib`: Remove deprecated parameter `attach_unzip` from default parameters (PR#2511 by Sebastian Wagner).
 
 #### Parsers
 - `intelmq.bots.parsers.shadowserver._config`:

--- a/intelmq/bots/collectors/mail/_lib.py
+++ b/intelmq/bots/collectors/mail/_lib.py
@@ -17,7 +17,6 @@ except ImportError:
 
 
 class MailCollectorBot(CollectorBot):
-    attach_unzip = None
     mail_host = None
     ssl_ca_certificate = None
     mail_user = None
@@ -35,8 +34,8 @@ class MailCollectorBot(CollectorBot):
         if imbox is None:
             raise MissingDependencyError("imbox")
 
-        if self.attach_unzip is not None and not self.extract_files:
-            self.extract_files = True
+        if getattr(self, 'attach_unzip', None) is not None and hasattr(self, 'extract_files'):
+            setattr(self, 'extract_files', True)
             self.logger.warning("The parameter 'attach_unzip' is deprecated and will "
                                 "be removed in version 4.0. Use 'extract_files' instead.")
 


### PR DESCRIPTION
Remove deprecated parameter `attach_unzip` from default parameters so that IntelMQ Manager does not propose it for new bots

instead use getattr/hasattr in the code