### PR TITLE
remove deprecated parameter for YAML loader & dumper

### DIFF
--- a/intelmq/lib/utils.py
+++ b/intelmq/lib/utils.py
@@ -219,7 +219,7 @@ def load_configuration(configuration_filepath: str) -> dict:
     if os.path.exists(configuration_filepath):
         with open(configuration_filepath) as fpconfig:
             try:
-                config = YAML(typ="unsafe", pure=True).load(fpconfig)
+                config = YAML(pure=True).load(fpconfig)
             except ScannerError as exc:
                 if "found character '\\t' that cannot start any token" in exc.problem:
                     fpconfig.seek(0)
@@ -260,7 +260,7 @@ def write_configuration(configuration_filepath: str,
         pathlib.Path(configuration_filepath + '.bak').write_text(config.read_text())
     with open(configuration_filepath, 'w') as handle:
         if useyaml:
-            YAML(typ="unsafe", pure=True).dump(content, handle)
+            YAML(pure=True).dump(content, handle)
         else:
             json.dump(content, fp=handle, indent=4,
                       sort_keys=True,


### PR DESCRIPTION
typ='unsafe' is deprecated

fixes https://github.com/certtools/intelmq/issues/2489

Please don't merge before 3.3.1 release is done.