### PR TITLE
Shadowserver: Fix parameter 'reports' behaviour if empty string

### DIFF
--- a/intelmq/bots/collectors/shadowserver/collector_reports_api.py
+++ b/intelmq/bots/collectors/shadowserver/collector_reports_api.py
@@ -29,7 +29,7 @@ class ShadowServerAPICollectorBot(CollectorBot, HttpMixin, CacheMixin):
     Parameters:
         api_key (str): Your Shadowserver API key
         secret (str): Your Shadowserver API secret
-        country (str): DEPRECIATED The mailing list you want to download reports for (i.e. 'austria')
+        country (str): DEPRECATED The mailing list you want to download reports for (i.e. 'austria')
         reports (list):
             A list of strings or a comma-separated list of the mailing lists you want to process.
         types (list):

--- a/intelmq/bots/collectors/shadowserver/collector_reports_api.py
+++ b/intelmq/bots/collectors/shadowserver/collector_reports_api.py
@@ -56,7 +56,9 @@ class ShadowServerAPICollectorBot(CollectorBot, HttpMixin, CacheMixin):
             raise ValueError('No secret provided.')
 
         if isinstance(self.reports, str):
-            self._report_list = self.reports.split(',')
+            # if reports is an empty string (or only contains whitespace), behave as if the parameter is not set and select all reports
+            reports = self.reports.strip()
+            self._report_list = reports.split(',') if reports else []
         elif isinstance(self.reports, list):
             self._report_list = self.reports
         if isinstance(self.types, str):


### PR DESCRIPTION
if the parameter reports is an empty string (or only contains whitespace), behave as if the parameter is not set and select all reports

fixes #2521 