### PR TITLE
default log levels: DEBUG for dev, INFO for stable

### DIFF
--- a/docs/dev/release.md
+++ b/docs/dev/release.md
@@ -30,8 +30,6 @@ These apply to all projects:
 
 - `intelmq/version.py`: Update the version.
 
-Eventually adapt the default log levels if necessary. Should be INFO for stable releases.
-
 ### IntelMQ API
 
 -   `intelmq_api/version.py`: Update the version.

--- a/intelmq/__init__.py
+++ b/intelmq/__init__.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2014 Tomás Lima
+# SPDX-FileCopyrightText: 2014 Tomás Lima, 2015-2020 nic.at GmbH, 2024 Institute for Common Good Technology
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
@@ -29,7 +29,12 @@ elif path == "opt":
     VAR_STATE_PATH = os.path.join(ROOT_DIR, "var/lib/bots/")
 
 
-DEFAULT_LOGGING_LEVEL = "INFO"
+if isinstance(__version_info__[-1], str) and __version_info__[-1][0].lower() in ('a', 'b', 'd'):
+    # for alpha, beta and dev instances, set default log level to DEBUG, for others, including RCs, use INFO
+    DEFAULT_LOGGING_LEVEL = "DEBUG"
+else:
+    DEFAULT_LOGGING_LEVEL = "INFO"
+
 HARMONIZATION_CONF_FILE = os.path.join(CONFIG_DIR, "harmonization.conf")
 RUNTIME_CONF_FILE = os.path.join(CONFIG_DIR, "runtime.yaml")
 old_runtime_conf_file = pathlib.Path(RUNTIME_CONF_FILE).with_suffix('.conf')


### PR DESCRIPTION
set the default log level (internal fallback value) to
- DEBUG if the version number indicates this is a preliminary release (alpha, beta, dev)
- INFO if the version number indicates a stable release (last part is integer, release candidate or anything else

removes the need to check and adappt this manually at every release or starts of development cycles

Please don't merge before 3.3.1 release is done.