### PR TITLE
Fix shadowserver valueerror syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@
 #### Collectors
 
 #### Parsers
+- `intelmq.bots.parsers.shadowserver._config`:
+  - fix error message formatting if schema file is absent (PR#2528 by Sebastian Wagner).
 
 #### Experts
 

--- a/docs/user/bots.md
+++ b/docs/user/bots.md
@@ -2202,7 +2202,7 @@ For example using `curl -s https://interchange.shadowserver.org/intelmq/v1/schem
 
 (optional, boolean) If an existing `feed.name` should be overwritten.
 
-** `auto_update`**
+**`auto_update`**
 
 (optional, boolean) Enable automatic schema download.
 

--- a/intelmq/bots/parsers/shadowserver/_config.py
+++ b/intelmq/bots/parsers/shadowserver/_config.py
@@ -341,7 +341,7 @@ def reload():
             return
     else:
         if not __config.test_mode:
-            raise ValueError("The schema file does not exist: %r.", __config.schema_file)
+            raise ValueError(f"The schema file does not exist: {__config.schema_file}.")
 
     __config.feedname_mapping.clear()
     __config.filename_mapping.clear()


### PR DESCRIPTION
if schema file is absent

and  fix a syntax issue in shadowserver parser documentation