### PR TITLE
use PyMISP, ExpandedPyMISP is deprecated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 #### Collectors
 - `intelmq.bots.collectors.shadowserver.collector_reports_api.py`:
   - Fixed behaviour if parameter `types` value is empty string, behave the same way as not set, not like no type.
+- `intelmq.bots.collectors.misp`: Use `PyMISP` class instead of deprecated `ExpandedPyMISP` (PR#2532 by Radek Vyhnal)
 
 #### Parsers
 - `intelmq.bots.parsers.shadowserver._config`:
@@ -29,6 +30,7 @@
   - Fix to avoid schema download if not configured #2530.
 
 #### Experts
+- `intelmq.bots.experts.misp`: Use `PyMISP` class instead of deprecated `ExpandedPyMISP` (PR#2532 by Radek Vyhnal)
 
 #### Outputs
 

--- a/intelmq/bots/collectors/misp/collector.py
+++ b/intelmq/bots/collectors/misp/collector.py
@@ -25,10 +25,7 @@ from intelmq.lib.bot import CollectorBot
 from intelmq.lib.exceptions import MissingDependencyError
 
 try:
-    try:
-        from pymisp import ExpandedPyMISP as PyMISP
-    except ImportError:
-        from pymisp import PyMISP
+    from pymisp import PyMISP
 except ImportError:
     PyMISP = None
     import_fail_reason = 'import'

--- a/intelmq/bots/experts/misp/expert.py
+++ b/intelmq/bots/experts/misp/expert.py
@@ -17,9 +17,9 @@ from intelmq.lib.bot import ExpertBot
 from intelmq.lib.exceptions import MissingDependencyError
 
 try:
-    from pymisp import ExpandedPyMISP
+    from pymisp import PyMISP
 except ImportError:
-    ExpandedPyMISP = None
+    PyMISP = None
 
 
 class MISPExpertBot(ExpertBot):
@@ -28,13 +28,13 @@ class MISPExpertBot(ExpertBot):
     misp_url: str = "<insert url of MISP server (with trailing '/')>"
 
     def init(self):
-        if ExpandedPyMISP is None:
+        if PyMISP is None:
             raise MissingDependencyError('pymisp', '>=2.4.117.3')
 
         # Initialize MISP connection
-        self.misp = ExpandedPyMISP(self.misp_url,
-                                   self.misp_key,
-                                   self.http_verify_cert)
+        self.misp = PyMISP(self.misp_url,
+                           self.misp_key,
+                           self.http_verify_cert)
 
     def process(self):
         event = self.receive_message()


### PR DESCRIPTION
MISP related bots try to import the deprecated ExpandedPyMISP instead of PyMISP which produces the deprecation message in logs. 
As ExpandedPyMISP was introduced for the transition to Python3 quite some time ago, please consider merging this PR.

