### PR TITLE
Fixed behaviour if parameter `types` value is empty string, behave th…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
 
 ### Bots
 #### Collectors
+- `intelmq.bots.collectors.shadowserver.collector_reports_api.py`:
+  - Fixed behaviour if parameter `types` value is empty string, behave the same way as not set, not like no type.
 
 #### Parsers
 - `intelmq.bots.parsers.shadowserver._config`:


### PR DESCRIPTION
This fixes the issue of the _types_ list being empty when the runtime config is generated with the web manager:

```
   parameters:
     types: ''
```

A similar fix was made for _reports_ previously.