### PR TITLE
sql output: handle empty string fields paramter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@
   - The requirement can only be installed on Python version < 3.12.
   - Add a check on the Python version and exit if incompatible.
   - Add a deprecation warning (PR#2544 by Sebastian Wagner)
+- `intelmq.bots.outputs.sql.output`:
+  - Treat an empty string `fields` parameter as unset parameter, fixing a crash in default configuration (PR#2548 by Sebastian Wagner, fixes #2548).
 
 ### Documentation
 

--- a/intelmq/bots/outputs/sql/output.py
+++ b/intelmq/bots/outputs/sql/output.py
@@ -43,9 +43,7 @@ class SQLOutputBot(OutputBot, SQLMixin):
     def process(self):
         event = self.receive_message().to_dict(jsondict_as_string=self.jsondict_as_string)
 
-        key_names = self.fields
-        if key_names is None:
-            key_names = event.keys()
+        key_names = self.fields or event.keys()
         valid_keys = [key for key in key_names if key in event]
         keys = '", "'.join(valid_keys)
         values = self.prepare_values(itemgetter_tuple(*valid_keys)(event))


### PR DESCRIPTION
Treat an empty string `fields` parameter as unset parameter, fixing a crash in default configuration

fixes certtools/intelmq#2548