### PR TITLE
doc: fix parameter description shadowserver api

### DIFF
--- a/docs/user/bots.md
+++ b/docs/user/bots.md
@@ -960,7 +960,7 @@ The resulting reports contain the following special field:
 
 **`reports`**
 
-(required, string/array of strings) An array of strings (or a list of comma-separated values) of the mailing lists you want to process.
+(optional, string/array of strings) An array of strings (or a list of comma-separated values) of the mailing lists you want to process.
 
 **`types`**
 


### PR DESCRIPTION
The parameter `reports` is not required according to the source code

unset parameters means all reports are processed

please verify @elsif2 