### PR TITLE
cleanmx, MISP: replace deprecated utcfromtimestamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@
   - fix error message formatting if schema file is absent (PR#2528 by Sebastian Wagner).
 - `intelmq.bots.parsers.shadowserver.parser`:
   - Fix to avoid schema download if not configured #2530.
+- `intelmq.bots.parsers.misp.parser`: Replace deprecated datetime function `utcfromtimestamp` for Ubuntu 24.04 compatibility (PR#2577 by Sebastian Wagner, fixes #2576, #2571).
+- `intelmq.bots.parsers.cleanmx.parser`: Replace deprecated datetime function `utcfromtimestamp` for Ubuntu 24.04 compatibility (PR#2577 by Sebastian Wagner, fixes #2576, #2571).
 
 #### Experts
 - `intelmq.bots.experts.securitytxt`:

--- a/intelmq/bots/parsers/cleanmx/parser.py
+++ b/intelmq/bots/parsers/cleanmx/parser.py
@@ -1,14 +1,14 @@
-# SPDX-FileCopyrightText: 2016 Sebastian Wagner
+# SPDX-FileCopyrightText: 2016 nic.at GmbH, 2025 Institute for Common Good Technology - Sebastian Wagner
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
 from collections import OrderedDict
-from datetime import datetime
 from xml.etree import ElementTree
 
 from intelmq.lib import utils
 from intelmq.lib.bot import ParserBot
 from intelmq.lib.exceptions import ConfigurationError
+from intelmq.lib.harmonization import DateTime
 
 PHISHING = OrderedDict([
     ("line", "__IGNORE__"),
@@ -140,7 +140,7 @@ class CleanMXParserBot(ParserBot):
 
                 if key == "time.source":
                     try:
-                        value = (datetime.utcfromtimestamp(int(value)).isoformat() + " UTC")
+                        value = DateTime.from_timestamp(value)
                     except TypeError as e:
                         self.logger.warning(
                             'No valid "first" field epoch time found, skipping '

--- a/intelmq/bots/parsers/misp/parser.py
+++ b/intelmq/bots/parsers/misp/parser.py
@@ -1,14 +1,14 @@
-# SPDX-FileCopyrightText: 2016 kralca
+# SPDX-FileCopyrightText: 2016 kralca, 2025 Institute for Common Good Technology - Sebastian Wagner
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
 # -*- coding: utf-8 -*-
 import json
-from datetime import datetime
 from urllib.parse import urljoin
 
 from intelmq.lib import utils
 from intelmq.lib.bot import ParserBot
+from intelmq.lib.harmonization import DateTime
 
 
 class MISPParserBot(ParserBot):
@@ -120,8 +120,7 @@ class MISPParserBot(ParserBot):
                 event.add('malware.name', malware_variant, raise_failure=False)
                 event.add('classification.type', classifier)
                 event.add('classification.identifier', identifier)
-                event.add('time.source', '{} UTC'.format(
-                          datetime.utcfromtimestamp(float(timestamp))))
+                event.add('time.source', DateTime.from_timestamp(timestamp))
                 self.send_message(event)
 
         self.acknowledge_message()


### PR DESCRIPTION
in intelmq.bots.parsers.misp.parser and intelmq.bots.parsers.cleanmx.parser Replace the deprecated datetime function `utcfromtimestamp` for Ubuntu 24.04 compatibility with fromtimestamp(..., UTC)

fixes https://github.com/certtools/intelmq/issues/2576 related to https://github.com/certtools/intelmq/issues/2571