### PR TITLE
pkg: replace hardcoded /opt/intelmq/ paths with variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Please refer to the [NEWS](NEWS.md) for a list of changes which have an affect o
 ### Documentation
 
 ### Packaging
+- Replace `/opt/intelmq` example paths in bots with variable `VAR_STATE_PATH` for correct paths in LSB-path setups like with packages (PR#2587 by Sebastian Wagner).
 
 ### Tests
 

--- a/debian/control
+++ b/debian/control
@@ -22,7 +22,9 @@ Build-Depends: debhelper (>= 4.1.16),
                quilt,
                rsync,
                safe-rm,
-               python3-pytest-cov
+               python3-pytest-cov,
+               findutils,
+               sed
 X-Python3-Version: >= 3.7
 Standards-Version: 3.9.6
 Homepage: https://github.com/certtools/intelmq/

--- a/debian/sedfile
+++ b/debian/sedfile
@@ -1,5 +1,5 @@
-s/opt\/intelmq\/var\/run/var\/run\/intelmq/g
-s/opt\/intelmq\/var\/log/var\/log\/intelmq/g
-s/opt\/intelmq\/var\/lib/var\/lib\/intelmq/g
-s/opt\/intelmq\/etc\//etc\/intelmq\//g
-s/opt\/intelmq/etc\/intelmq/g
+s%opt/intelmq/var/run%var/run/intelmq%g
+s%opt/intelmq/var/log%var/log/intelmq%g
+s%opt/intelmq/var/lib%var/lib/intelmq%g
+s%opt/intelmq/etc%etc/intelmq%g
+s%opt/intelmq%etc/intelmq%g

--- a/intelmq/bots/experts/domain_valid/expert.py
+++ b/intelmq/bots/experts/domain_valid/expert.py
@@ -16,6 +16,7 @@ import sys
 
 import requests.exceptions
 
+from intelmq import VAR_STATE_PATH
 from intelmq.lib.bot import ExpertBot
 from intelmq.lib.exceptions import MissingDependencyError, ConfigurationError
 from intelmq.lib.utils import get_bots_settings, create_request_session
@@ -24,7 +25,7 @@ from intelmq.bin.intelmqctl import IntelMQController
 
 class DomainValidExpertBot(ExpertBot):
     domain_field: str = 'source.fqdn'
-    tlds_domains_list: str = '/opt/intelmq/var/lib/bots/domain_valid/tlds-alpha-by-domain.txt'
+    tlds_domains_list: str = f"{VAR_STATE_PATH}domain_valid/tlds-alpha-by-domain.txt"
 
     def init(self):
         if validators is None:

--- a/intelmq/bots/experts/maxmind_geoip/expert.py
+++ b/intelmq/bots/experts/maxmind_geoip/expert.py
@@ -14,6 +14,7 @@ import pathlib
 import requests
 import tarfile
 
+from intelmq import VAR_STATE_PATH
 from intelmq.lib.bot import ExpertBot
 from intelmq.lib.exceptions import MissingDependencyError
 from intelmq.lib.utils import get_bots_settings, create_request_session
@@ -27,7 +28,7 @@ except ImportError:
 
 class GeoIPExpertBot(ExpertBot):
     """Add geolocation information from a local MaxMind database to events (country, city, longitude, latitude)"""
-    database: str = "/opt/intelmq/var/lib/bots/maxmind_geoip/GeoLite2-City.mmdb"  # TODO: should be pathlib.Path
+    database: str = f"{VAR_STATE_PATH}maxmind_geoip/GeoLite2-City.mmdb"  # TODO: should be pathlib.Path
     license_key: str = "<insert Maxmind license key>"
     overwrite: bool = False
     use_registered: bool = False

--- a/intelmq/bots/experts/modify/expert.py
+++ b/intelmq/bots/experts/modify/expert.py
@@ -9,6 +9,7 @@ Modify Expert bot let's you manipulate all fields with a config file.
 import re
 import sys
 
+from intelmq import VAR_STATE_PATH
 from intelmq.lib.bot import ExpertBot
 from intelmq.lib.utils import load_configuration
 
@@ -37,7 +38,7 @@ class MatchGroupMapping:
 class ModifyExpertBot(ExpertBot):
     """Perform arbitrary changes to event's fields based on regular-expression-based rules on different values. See the bot's documentation for some examples"""
     case_sensitive: bool = True
-    configuration_path: str = "/opt/intelmq/var/lib/bots/modify/modify.conf"  # TODO: should be pathlib.Path
+    configuration_path: str = f"{VAR_STATE_PATH}modify/modify.conf"  # TODO: should be pathlib.Path
     maximum_matches = None
     overwrite: bool = True
 

--- a/intelmq/bots/experts/recordedfuture_iprisk/expert.py
+++ b/intelmq/bots/experts/recordedfuture_iprisk/expert.py
@@ -14,6 +14,7 @@ import tarfile
 import pathlib
 import requests
 
+from intelmq import VAR_STATE_PATH
 from intelmq.lib.bot import ExpertBot
 from intelmq.lib.utils import get_bots_settings, create_request_session
 from intelmq.bin.intelmqctl import IntelMQController
@@ -22,7 +23,7 @@ from intelmq.bin.intelmqctl import IntelMQController
 class RecordedFutureIPRiskExpertBot(ExpertBot):
     """Adds the Risk Score from RecordedFuture IPRisk associated with source.ip or destination.ip with a local database"""
     api_token: str = "<insert Recorded Future IPRisk API token>"
-    database: str = "/opt/intelmq/var/lib/bots/recordedfuture_iprisk/rfiprisk.dat"  # TODO: should be pathlib.Path
+    database: str = f"{VAR_STATE_PATH}recordedfuture_iprisk/rfiprisk.dat"  # TODO: should be pathlib.Path
     overwrite: bool = False
     autoupdate_cached_database: bool = True  # Activate/deactivate update-database functionality
 

--- a/intelmq/bots/experts/sieve/expert.py
+++ b/intelmq/bots/experts/sieve/expert.py
@@ -20,6 +20,7 @@ from datetime import datetime, timedelta, timezone
 from typing import Callable, Dict, Optional, Union
 from enum import Enum, auto
 
+from intelmq import VAR_STATE_PATH
 import intelmq.lib.exceptions as exceptions
 from intelmq import HARMONIZATION_CONF_FILE
 from intelmq.lib import utils
@@ -55,7 +56,7 @@ class SieveExpertBot(ExpertBot):
 
     _harmonization = None
     file: str = (
-        "/opt/intelmq/var/lib/bots/sieve/filter.sieve"  # TODO: should be pathlib.Path
+        f"{VAR_STATE_PATH}sieve/filter.sieve"  # TODO: should be pathlib.Path
     )
 
     def init(self) -> None:

--- a/intelmq/bots/experts/tor_nodes/expert.py
+++ b/intelmq/bots/experts/tor_nodes/expert.py
@@ -11,6 +11,7 @@ import sys
 import pathlib
 import requests
 
+from intelmq import VAR_STATE_PATH
 from intelmq.lib.bot import ExpertBot
 from intelmq.lib.utils import get_bots_settings, create_request_session
 from intelmq.bin.intelmqctl import IntelMQController
@@ -18,7 +19,7 @@ from intelmq.bin.intelmqctl import IntelMQController
 
 class TorExpertBot(ExpertBot):
     """Check if the IP address is a Tor Exit Node based on a local database of TOR nodes"""
-    database: str = "/opt/intelmq/var/lib/bots/tor_nodes/tor_nodes.dat"  # TODO: pathlib.Path
+    database: str = f"{VAR_STATE_PATH}tor_nodes/tor_nodes.dat"  # TODO: pathlib.Path
     overwrite: bool = False
     autoupdate_cached_database: bool = True  # Activate/deactivate update-database functionality
 

--- a/intelmq/bots/outputs/bro_file/output.py
+++ b/intelmq/bots/outputs/bro_file/output.py
@@ -10,6 +10,7 @@ import os
 from collections import defaultdict
 from pathlib import Path
 
+from intelmq import VAR_STATE_PATH
 from intelmq.lib.bot import OutputBot
 
 BRO_INDICATOR_MAP = {
@@ -24,7 +25,7 @@ BRO_HEADER = "#fields\tindicator\tindicator_type\tmeta.desc\tmeta.cif_confidence
 class BroFileOutputBot(OutputBot):
     _file = None
     encoding_errors_mode = 'strict'
-    file: str = "/opt/intelmq/var/lib/bots/file-output/bro"
+    file: str = f"{VAR_STATE_PATH}file-output/bro"
     format_filename: bool = False
     hierarchical_output: bool = False
     keep_raw_field: bool = False

--- a/intelmq/bots/outputs/file/output.py
+++ b/intelmq/bots/outputs/file/output.py
@@ -8,6 +8,7 @@ import os
 from collections import defaultdict
 from pathlib import Path
 
+from intelmq import VAR_STATE_PATH
 from intelmq.lib.bot import OutputBot
 
 
@@ -15,7 +16,7 @@ class FileOutputBot(OutputBot):
     """Write events to a file"""
     _file = None
     encoding_errors_mode = 'strict'
-    file: str = "/opt/intelmq/var/lib/bots/file-output/events.txt"  # TODO: should be pathlib.Path
+    file: str = f"{VAR_STATE_PATH}file-output/events.txt"  # TODO: should be pathlib.Path
     format_filename: bool = False
     hierarchical_output: bool = False
     keep_raw_field: bool = False

--- a/intelmq/bots/outputs/files/output.py
+++ b/intelmq/bots/outputs/files/output.py
@@ -9,20 +9,22 @@ import os
 import socket
 import time
 from os import path
+
+from intelmq import VAR_STATE_PATH
 from intelmq.lib.bot import OutputBot
 from intelmq.lib.exceptions import ConfigurationError
 
 
 class FilesOutputBot(OutputBot):
     """Write events lockfree into separate files"""
-    dir: str = "/opt/intelmq/var/lib/bots/files-output/incoming"  # TODO: could be path
+    dir: str = f"{VAR_STATE_PATH}files-output/incoming"  # TODO: could be path
     hierarchical_output: bool = False
     keep_raw_field: bool = False
     message_jsondict_as_string: bool = False
     message_with_type: bool = False
     single_key: bool = False
     suffix: str = ".json"
-    tmp: str = "/opt/intelmq/var/lib/bots/files-output/tmp"  # TODO: could be path
+    tmp: str = f"{VAR_STATE_PATH}files-output/tmp"  # TODO: could be path
 
     def init(self):
         self.tmp = self._ensure_path(self.tmp)

--- a/intelmq/bots/outputs/misp/output_feed.py
+++ b/intelmq/bots/outputs/misp/output_feed.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from uuid import uuid4
 import re
 
+from intelmq import VAR_STATE_PATH
 from intelmq.lib.bot import OutputBot
 from intelmq.lib.exceptions import MissingDependencyError
 from intelmq.lib.utils import parse_relative
@@ -34,7 +35,7 @@ class MISPFeedOutputBot(OutputBot):
     interval_event: str = "1 hour"
     misp_org_name = None
     misp_org_uuid = None
-    output_dir: str = "/opt/intelmq/var/lib/bots/mispfeed-output"  # TODO: should be path
+    output_dir: str = f"{VAR_STATE_PATH}mispfeed-output"  # TODO: should be path
     _is_multithreadable: bool = False
 
     @staticmethod

--- a/intelmq/bots/outputs/rpz_file/output.py
+++ b/intelmq/bots/outputs/rpz_file/output.py
@@ -10,6 +10,7 @@ import os
 from collections import defaultdict
 from pathlib import Path
 
+from intelmq import VAR_STATE_PATH
 from intelmq.lib.bot import OutputBot
 
 RPZ_INDICATOR_MAP = {
@@ -30,7 +31,7 @@ class RpzFileOutputBot(OutputBot):
     _is_multithreadable = False
 
     encoding_errors_mode = 'strict'
-    file: str = "/opt/intelmq/var/lib/bots/file-output/rpz"
+    file: str = f"{VAR_STATE_PATH}file-output/rpz"
 
     cname: str = ""
     organization_name: str = ''


### PR DESCRIPTION
in all setups with other paths, like with the packages, the example/default paths with /opt/ are incorrect. Instead, just use the variable from the intelmq package