### PR TITLE
Fix workflows: AMQP test skip, Update Ubuntu runner

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -18,7 +18,7 @@ on:
 jobs:
   codespell:
     name: Find and notify about common misspellings
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     # This should not fail the whole workflow run
     continue-on-error: true
 

--- a/.github/workflows/debian-package.yml
+++ b/.github/workflows/debian-package.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       # Fixes https://github.com/actions/virtual-environments/issues/3080
       STORAGE_OPTS: overlay.mount_program=/usr/bin/fuse-overlayfs

--- a/.github/workflows/regexploit.yml
+++ b/.github/workflows/regexploit.yml
@@ -27,6 +27,8 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v3
     - name: Install regexploit
-      run: pip install regexploit
+      #run: pip install regexploit
+      # See https://github.com/doyensec/regexploit/pull/16
+      run: pip install git+https://github.com/sebix/regexploit.git@unsupported-ops-yaml
     - name: Run regexploit
       run: /home/runner/work/intelmq/intelmq/.github/workflows/scripts/regexploit.sh

--- a/.github/workflows/regexploit.yml
+++ b/.github/workflows/regexploit.yml
@@ -19,7 +19,7 @@ on:
 jobs:
   regexploit:
     name: Find regular expressions which are vulnerable to ReDoS
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     # This should not fail the whole workflow run
     continue-on-error: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Please refer to the [NEWS](NEWS.md) for a list of changes which have an affect o
 - Replace `/opt/intelmq` example paths in bots with variable `VAR_STATE_PATH` for correct paths in LSB-path setups like with packages (PR#2587 by Sebastian Wagner).
 
 ### Tests
+- `intelmq.tests.lib.test_pipeline.TestAmqp.test_acknowledge`: Skip on all Python versions when running on CI (PR#2602 by Sebastian Wagner).
 - `.github/workflows/codespell.yml`, `debian-package.yml`, `regexploit.yml`: Upgrade to `ubuntu-latest` runners (PR#2602 by Sebastian Wagner).
 
 ### Tools

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Please refer to the [NEWS](NEWS.md) for a list of changes which have an affect o
 - Replace `/opt/intelmq` example paths in bots with variable `VAR_STATE_PATH` for correct paths in LSB-path setups like with packages (PR#2587 by Sebastian Wagner).
 
 ### Tests
+- `.github/workflows/codespell.yml`, `debian-package.yml`, `regexploit.yml`: Upgrade to `ubuntu-latest` runners (PR#2602 by Sebastian Wagner).
 
 ### Tools
 

--- a/intelmq/tests/bots/collectors/http/test_collector.py
+++ b/intelmq/tests/bots/collectors/http/test_collector.py
@@ -107,7 +107,7 @@ class TestHTTPCollectorBot(test.BotTestCase, unittest.TestCase):
         output['feed.url'] = 'http://localhost/foobar.gz'
         del output['extra.file_name']
         self.assertMessageEqual(0, output)
-        self.assertLogMatches('Report downloaded \(29B\).', 'INFO')
+        self.assertLogMatches(r'Report downloaded \(29B\).', 'INFO')
 
     def test_zip_auto(self, mocker):
         """

--- a/intelmq/tests/bots/collectors/mail/test_collector_url.py
+++ b/intelmq/tests/bots/collectors/mail/test_collector_url.py
@@ -56,4 +56,4 @@ class TestMailURLCollectorBot(test.BotTestCase, unittest.TestCase):
         with mock.patch('imbox.Imbox', new=MockedTxtImbox):
             self.run_bot()
         self.assertMessageEqual(0, REPORT_FOOBARTXT)
-        self.assertLogMatches('Report downloaded \(9B\).', 'INFO')
+        self.assertLogMatches(r'Report downloaded \(9B\).', 'INFO')

--- a/intelmq/tests/lib/test_pipeline.py
+++ b/intelmq/tests/lib/test_pipeline.py
@@ -266,8 +266,7 @@ class TestAmqp(unittest.TestCase):
         self.pipe.reject_message()
         self.assertEqual(SAMPLES['normal'][1], self.pipe.receive())
 
-    @unittest.skipIf(os.getenv('CI') == 'true' and sys.version_info[:2] in ((3, 8), (3, 11), (3, 12)),
-                     'Fails on CI with Python 3.8 and 3.11')
+    @unittest.skipIf(os.getenv('CI') == 'true', 'Fails on CI')
     def test_acknowledge(self):
         self.pipe.send(SAMPLES['normal'][0])
         self.pipe.receive()


### PR DESCRIPTION
- fix workflows: update ubuntu-20.04 to ubuntu-latest:
  ubuntu-20.04 is no longer available as runner
- tests: skip AMQP test_acknowledge always on CI
  independent of Python versions, as the test is a bit flaky for unknown reasons
- regexploit: use a fork instead of pypi for python >= 3.11 compatibility
  see doyensec/regexploit#16 for an error description


