### PR TITLE
splitreports: handle empty string chunk_size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Please refer to the [NEWS](NEWS.md) for a list of changes which have an affect o
 
 ### Core
 - Drop support for Python 3.8 (fixes #2616, PR#2617 by Sebastian Wagner).
+- `intelmq.lib.splitreports`: Handle bot parameter `chunk_size` values empty string, due to missing parameter typing checks (PR#2604 by Sebastian Wagner).
 
 ### Development
 

--- a/intelmq/lib/splitreports.py
+++ b/intelmq/lib/splitreports.py
@@ -151,7 +151,7 @@ def generate_reports(report_template: Report, infile: BinaryIO, chunk_size: Opti
     Yields:
         report: a Report object holding the chunk in the raw field
     """
-    if chunk_size is None:
+    if not chunk_size:  # None, empty string or False
         report = report_template.copy()
         data = infile.read()
         if data:


### PR DESCRIPTION
Handle bot parameter `chunk_size` values empty string, due to missing parameter typing checks