### PR TITLE
doc: Fix and refresh links to mailing lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Please refer to the [NEWS](NEWS.md) for a list of changes which have an affect o
 #### Outputs
 
 ### Documentation
+- Fix and refresh links to mailing lists (PR# by Kamil Mańkowski)
 
 ### Packaging
 - Replace `/opt/intelmq` example paths in bots with variable `VAR_STATE_PATH` for correct paths in LSB-path setups like with packages (PR#2587 by Sebastian Wagner).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ Please refer to the [NEWS](NEWS.md) for a list of changes which have an affect o
 #### Outputs
 
 ### Documentation
-- Fix and refresh links to mailing lists (PR# by Kamil Mańkowski)
+- Fix and refresh links to mailing lists (PR#2609 by Kamil Mańkowski)
 
 ### Packaging
 - Replace `/opt/intelmq` example paths in bots with variable `VAR_STATE_PATH` for correct paths in LSB-path setups like with packages (PR#2587 by Sebastian Wagner).

--- a/docs/dev/intro.md
+++ b/docs/dev/intro.md
@@ -34,7 +34,7 @@ Similarly, if code does not get accepted upstream by the main developers, it is 
 ## Mailing list
 
 There is a separate mailing list for developers to discuss development topics:
-The [IntelMQ-DevArchive](https://lists.cert.at/pipermail/intelmq-dev/) is public as well.
+The [IntelMQ-DevArchive](https://lists.cert.at/mailman3/hyperkitty/list/intelmq-dev@lists.cert.at/) is public as well.
 
 ## GitHub
 

--- a/docs/help.md
+++ b/docs/help.md
@@ -26,7 +26,7 @@ To participate on GitHub, you first need to create an account on the platform.
 ## Mailing list
 
 The most traditional way is to ask your question, make a proposal or discuss a topic on the
-mailing [IntelMQ Users mailing list](https://lists.cert.t/cgi-bin/mailman/listinfo/intelmq-users). You need to subscribe to the mailing list before posting, but the archive is publicly available: [IntelMQ Users Archive](https://lists.cert.at/pipermail/intelmq-users/).
+mailing [IntelMQ Users mailing list](https://lists.cert.at/mailman3/hyperkitty/list/intelmq-users@lists.cert.at/). You need to subscribe to the mailing list before posting, but the archive is publicly available: [IntelMQ Users Archive](https://lists.cert.at/mailman3/hyperkitty/list/intelmq-users@lists.cert.at/latest).
 
 ## Assistance
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -54,7 +54,7 @@ It follows the following basic meta-guidelines:
 
 ## Contribute
 
-- Subscribe to the [IntelMQ Developers mailing list](https://lists.cert.at/cgi-bin/mailman/listinfo/intelmq-dev) and engage in discussions
+- Subscribe to the [IntelMQ Developers mailing list](https://lists.cert.at/mailman3/hyperkitty/list/intelmq-dev@lists.cert.at/) and engage in discussions
 - Report any errors and suggest improvements via [issues](https://github.com/certtools/intelmq/issues)
 - Read the Developer Guide and open a [pull request](https://github.com/certtools/intelmq/pulls)
 

--- a/docs/user/bots.md
+++ b/docs/user/bots.md
@@ -2611,7 +2611,7 @@ When using a whitelist field pattern and a small number of fields (keys), it bec
 exist in the events themselves. If a field does not exist, but is part of the hashing/deduplication, this field will be
 ignored. If such events should not get deduplicated, you need to filter them out before the deduplication process, e.g.
 using a sieve expert. See
-also [this discussion thread](https://lists.cert.at/pipermail/intelmq-users/2021-July/000370.html) on the mailing-list.
+also [this discussion thread](https://lists.cert.at/mailman3/hyperkitty/list/intelmq-users@lists.cert.at/thread/V6YTF4XGALC37C666LPWQ6KK6CLAR6T2/) on the mailing-list.
 
 **Configuration Example**
 


### PR DESCRIPTION
Some links in documentation were broken, some working but outdated

