### PR TITLE
tests: ruamel.yaml 0.18.13 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Please refer to the [NEWS](NEWS.md) for a list of changes which have an affect o
 ### Tests
 - `intelmq.tests.lib.test_pipeline.TestAmqp.test_acknowledge`: Skip on all Python versions when running on CI (PR#2602 by Sebastian Wagner).
 - `.github/workflows/codespell.yml`, `debian-package.yml`, `regexploit.yml`: Upgrade to `ubuntu-latest` runners (PR#2602 by Sebastian Wagner).
+- `intelmq.test.test_conf`: With changed behaviour in ruamel.yaml on line wrapping since version 0.18.13, only test the parsabilty of `runtime.yaml` (PR#2619 by Sebastian Wagner).
 
 ### Tools
 - `intelmq.bin.intelmq_psql_initdb`: Use `JSONB` type by default, Postgres supports it since version 9 (PR#2597 by Sebastian Wagner).

--- a/intelmq/tests/test_conf.py
+++ b/intelmq/tests/test_conf.py
@@ -82,14 +82,14 @@ class TestConf(unittest.TestCase):
                 self.assertGreater(value['length'], 0)
             getattr(harmonization, value['type'])
 
+    # Line wrapping behaves differently since ruamel.yaml version 0.18.13. Additionally it adds spaces at the end of continued lines.
+    # https://sourceforge.net/p/ruamel-yaml/code/ci/375c4db4c7c5fad61e149fc0690e50229df23ab3/
+    # So just test now that the file is parseable
     def test_runtime_syntax(self):
-        """ Test if runtime.yaml has correct syntax. """
+        """ Test if runtime.yaml has correct syntax (parseable). """
         with open(CONF_FILES['runtime']) as fhandle:
             fcontent = fhandle.read()
         interpreted = yaml.load(fcontent)
-        buf = io.BytesIO()
-        yaml.dump(interpreted, buf)
-        self.assertEqual(buf.getvalue().decode(), fcontent)
 
 
 class CerberusTests(unittest.TestCase):


### PR DESCRIPTION
Line wrapping behaves differently since ruamel.yaml version 0.18.13. Additionally it adds spaces at the end of continued lines. https://sourceforge.net/p/ruamel-yaml/code/ci/375c4db4c7c5fad61e149fc0690e50229df23ab3/ So just test now that the file is parseable