### PR TITLE
pkg: remove obsolete parts from contrib

### DIFF
--- a/debian/intelmq-contrib.install
+++ b/debian/intelmq-contrib.install
@@ -1,9 +1,6 @@
 contrib/eventdb/ /usr/share/intelmq/contrib/
 contrib/example-extension-package/ /usr/share/intelmq/contrib/
 contrib/feeds-config-generator/ /usr/share/intelmq/contrib/
-contrib/logcheck/ /usr/share/intelmq/contrib/
-contrib/logrotate/ /usr/share/intelmq/contrib/
 contrib/malware_name_mapping/ /usr/share/intelmq/contrib/
 contrib/prettyprint/ /usr/share/intelmq/contrib/
 contrib/systemd/ /usr/share/intelmq/contrib/
-contrib/tmpfiles.d/ /usr/share/intelmq/contrib/


### PR DESCRIPTION
remove logcheck rules from install file, they are already installed correctly by the rules file
remove logrotate configuration, they are already installed by the main package
remove systemd tmpfiles.d directory, this directory needs to be used by the debian package itself