### PR TITLE
sql: make severity an enum type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,18 @@ Please refer to the [NEWS](NEWS.md) for a list of changes which have an affect o
   ALTER TABLE events ADD "product.vulnerabilities" text;
   ```
 - added `severity` field to help with triaging received events (PR#2575 by Kamil Mańkowski).
-  To allow saving the field in PostgreSQL database in existing installations, the following schema update is necessary: `ALTER TABLE events ADD severity varchar(10);`.
+  To allow saving the field in PostgreSQL database in existing installations, the following schema update is necessary:
+  ```sql
+  CREATE TYPE severity_enum AS ENUM (
+    'critical',
+    'high',
+    'medium',
+    'low',
+    'info',
+    'undefined'
+  );
+  ALTER TABLE events ADD severity severity_enum;
+  ```
 - Implementing [IEP008](https://github.com/certtools/ieps/tree/main/008) introducing the `constituency` field for easier identification in
   multi-constituency setups. (PR#2573 by Kamil Mańkowski)
   To use in current PostgreSQL installations, a schema update may be

--- a/NEWS.md
+++ b/NEWS.md
@@ -22,6 +22,14 @@ Python `>=3.9` is now required, which is available on all platforms supported by
 To save new fields from IntelMQ Data Format in existing PostgreSQL instances, the following schema
 update is necessary:
 ```sql
+CREATE TYPE severity_enum AS ENUM (
+    'critical',
+    'high',
+    'medium',
+    'low',
+    'info',
+    'undefined'
+);
 ALTER TABLE events ADD "product.full_name" text;
 ALTER TABLE events ADD "product.name" text;
 ALTER TABLE events ADD "product.vendor" text;
@@ -29,6 +37,12 @@ ALTER TABLE events ADD "product.version" text;
 ALTER TABLE events ADD "product.vulnerabilities" text;
 ALTER TABLE events ADD severity varchar(10);
 ALTER TABLE events ADD "constituency" text;
+UPDATE events SET severity = (extra ->> 'severity')::severity_enum;
+```
+
+Optionally remove the severity field from the extra fields in existing entries:
+```sql
+UPDATE events SET extra = extra - 'severity';
 ```
 
 ### Configuration

--- a/intelmq/bin/intelmq_psql_initdb.py
+++ b/intelmq/bin/intelmq_psql_initdb.py
@@ -15,6 +15,7 @@ import json
 import os
 import sys
 import tempfile
+from textwrap import dedent
 
 from intelmq import HARMONIZATION_CONF_FILE
 
@@ -135,7 +136,17 @@ def generate(harmonization_file=HARMONIZATION_CONF_FILE, skip_events=False,
              separate_raws=False, partition_key=None, skip_or_replace=False,
              no_jsonb=False):
     FIELDS = {}
-    sql_lines = []
+
+    # ENUM for severity does not only save space, it first and foremost allows for easy sorting by severity (ascending sorting is critical to undefined)
+    sql_lines = dedent("""
+        CREATE TYPE severity_enum AS ENUM (
+            'critical',
+            'high',
+            'medium',
+            'low',
+            'info',
+            'undefined'
+        );""").strip().splitlines()
 
     try:
         print("INFO - Reading %s file" % harmonization_file)
@@ -154,7 +165,9 @@ def generate(harmonization_file=HARMONIZATION_CONF_FILE, skip_events=False,
                              'LowercaseString', 'UppercaseString', 'Registry',
                              'TLP', 'ClassificationTaxonomy',
                              ):
-            if 'length' in value:
+            if field == 'severity':
+                dbtype = 'severity_enum'
+            elif 'length' in value:
                 dbtype = 'varchar({})'.format(value['length'])
             else:
                 dbtype = 'text'

--- a/intelmq/tests/bin/initdb.sql
+++ b/intelmq/tests/bin/initdb.sql
@@ -1,3 +1,11 @@
+CREATE TYPE severity_enum AS ENUM (
+    'critical',
+    'high',
+    'medium',
+    'low',
+    'info',
+    'undefined'
+);
 CREATE TABLE events (
     "id" BIGSERIAL UNIQUE PRIMARY KEY,
     "classification.identifier" text,
@@ -58,7 +66,7 @@ CREATE TABLE events (
     "raw" text,
     "rtir_id" integer,
     "screenshot_url" text,
-    "severity" varchar(10),
+    "severity" severity_enum,
     "source.abuse_contact" text,
     "source.account" text,
     "source.allocated" timestamp with time zone,

--- a/intelmq/tests/bin/test_psql_initdb.py
+++ b/intelmq/tests/bin/test_psql_initdb.py
@@ -58,27 +58,6 @@ class TestPsqlInit(unittest.TestCase):
         fname = pkg_resources.resource_filename('intelmq', 'etc/harmonization.conf')
         self.assertEqual(psql_initdb.generate(fname).strip(), expected.strip())
 
-    def test_generating_events_schema(self):
-        expected_table = """
-        CREATE TABLE events (
-            "id" BIGSERIAL UNIQUE PRIMARY KEY,
-            "classification.identifier" text,
-            "raw" text,
-            "time.source" timestamp with time zone
-        );
-        """
-        expected_table = self._normalize_leading_whitespaces(expected_table)
-        expected_indexes = [
-            """CREATE INDEX "idx_events_classification.identifier" ON events USING btree ("classification.identifier");""",
-            """CREATE INDEX "idx_events_time.source" ON events USING btree ("time.source");"""
-        ]
-        generated = psql_initdb.generate(self.harmonization_path)
-
-        self.assertTrue(self._normalize_leading_whitespaces(generated).startswith(expected_table))
-
-        for index in expected_indexes:
-            self.assertIn(index, generated)
-
     def test_skip_generating_events_table_schema(self):
         generated = psql_initdb.generate(self.harmonization_path, skip_events=True)
 


### PR DESCRIPTION
makes sorting work natively
add instruction to news file how to migrate data
update tests and remove test function test_generating_events_schema: the full output file is compared anyway, no need to quirky test cases