### PR TITLE
Drop privileges before creating temporary directory

### DIFF
--- a/intelmq/tests/bin/test_intelmqctl.py
+++ b/intelmq/tests/bin/test_intelmqctl.py
@@ -65,6 +65,8 @@ class TestIntelMQController(unittest.TestCase):
     def setUp(self):
         super().setUp()
 
+        utils.drop_privileges()
+
         self.tmp_config_dir = TemporaryDirectory()
 
         self.tmp_runtime = f"{self.tmp_config_dir.name}/runtime.yaml"


### PR DESCRIPTION
Otherwise, when the tests are run as root, the temporary directory gets created as root, but the cleanup code runs with dropped privileges, so it cannot remove it.
