### PR TITLE
install docs: fix bug and simplify

### DIFF
--- a/docs/admin/installation/linux-packages.md
+++ b/docs/admin/installation/linux-packages.md
@@ -27,10 +27,10 @@ Native packages are currently provided for the following Linux distributions:
 1. First, add the APT repository to the package manager:
 
 ```bash
-echo "deb [signed-by=/etc/apt/trusted.gpg.d/intelmq.gpg] http://download.opensuse.org/repositories/home:/sebix:/intelmq/Debian_$(lsb_release -rs)/ /" | sudo tee /etc/apt/sources.list.d/intelmq.list
-curl -fsSL "https://download.opensuse.org/repositories/home:sebix:intelmq/Debian_$(lsb_release -rs)/Release.key" | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/intelmq.gpg > /dev/null
+echo "deb [signed-by=/etc/apt/trusted.gpg.d/intelmq.asc] http://download.opensuse.org/repositories/home:/sebix:/intelmq/Debian_$(lsb_release -rs)/ /" | sudo tee /etc/apt/sources.list.d/intelmq.list
+curl -fsSL "https://download.opensuse.org/repositories/home:sebix:intelmq/Debian_$(lsb_release -rs)/Release.key" | sudo tee /etc/apt/trusted.gpg.d/intelmq.asc > /dev/null
 # if curl is not available:
-wget "https://download.opensuse.org/repositories/home:sebix:intelmq/xUbuntu_$(lsb_release -rs)/Release.key" -O - | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/intelmq.gpg > /dev/null
+wget "https://download.opensuse.org/repositories/home:sebix:intelmq/Debian_$(lsb_release -rs)/Release.key" -O - | sudo tee /etc/apt/trusted.gpg.d/intelmq.asc > /dev/null
 ```
 2. Install the IntelMQ (packages `intelmq-api` and `intelmq-manager` are optional)
 ```bash
@@ -63,10 +63,10 @@ deb http://[...].archive.ubuntu.com/ubuntu/ focal main universe
 
 3. Next, add the IntelMQ APT Repository for Ubuntu:
 ```bash
-echo "deb [signed-by=/etc/apt/trusted.gpg.d/intelmq.gpg] http://download.opensuse.org/repositories/home:/sebix:/intelmq/xUbuntu_$(lsb_release -rs)/ /" | sudo tee /etc/apt/sources.list.d/intelmq.list
-curl -fsSL "https://download.opensuse.org/repositories/home:sebix:intelmq/xUbuntu_$(lsb_release -rs)/Release.key" | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/intelmq.gpg > /dev/null
+echo "deb [signed-by=/etc/apt/trusted.gpg.d/intelmq.asc] http://download.opensuse.org/repositories/home:/sebix:/intelmq/xUbuntu_$(lsb_release -rs)/ /" | sudo tee /etc/apt/sources.list.d/intelmq.list
+curl -fsSL "https://download.opensuse.org/repositories/home:sebix:intelmq/xUbuntu_$(lsb_release -rs)/Release.key" | sudo tee /etc/apt/trusted.gpg.d/intelmq.asc > /dev/null
 # if curl is not available:
-wget "https://download.opensuse.org/repositories/home:sebix:intelmq/xUbuntu_$(lsb_release -rs)/Release.key" -O - | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/intelmq.gpg > /dev/null
+wget "https://download.opensuse.org/repositories/home:sebix:intelmq/xUbuntu_$(lsb_release -rs)/Release.key" -O - | sudo tee /etc/apt/trusted.gpg.d/intelmq.asc > /dev/null
 ```
 
 3. Now update the list of available packages and install the IntelMQ packages:


### PR DESCRIPTION
one command for Debian referenced a path for Ubuntu, which caused a 404

remove the necessity for gnupg (which is not installed by default)