### PR TITLE
bot debugger: read message from stdin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Please refer to the [NEWS](NEWS.md) for a list of changes which have an affect o
 ### Tests
 
 ### Tools
+- `intelmq.lib.bot_debugger`:  Optionally read input messages from stdin instead of parameter value (PR#2678 by Sebastian Wager).
 
 ### Contrib
 

--- a/docs/admin/management/intelmq.md
+++ b/docs/admin/management/intelmq.md
@@ -349,9 +349,20 @@ file-output:  * Message from cli will be used when processing.
 ...
 ```
 
+You can also read the message from stdin (one line):
+
+```bash
+> intelmqctl run file-output process -m -
+...
+Reading message from stdin (one line):
+{"source.ip":"10.2.3.4"}
+file-output:  * Message from cli will be used when processing.
+...
+```
+
 If you wish to display the processed message as well, you the
 **--show-sent|-s** flag. Then, if sent through (either with
-`--dryrun` or without), the message gets displayed as well.
+`--dryrun` or without), the resulting message gets displayed as well.
 
 ### disable
 

--- a/intelmq/bin/intelmqctl.py
+++ b/intelmq/bin/intelmqctl.py
@@ -143,7 +143,7 @@ class IntelMQController():
         intelmqctl list [bots|queues|queues-and-status]
         intelmqctl log bot-id [number-of-lines [log-level]]
         intelmqctl run bot-id message [get|pop|send]
-        intelmqctl run bot-id process [--msg|--dryrun]
+        intelmqctl run bot-id process [--msg|--dryrun|--show-sent]
         intelmqctl run bot-id console
         intelmqctl clear queue-id
         intelmqctl check
@@ -280,8 +280,8 @@ Get some debugging output on the settings and the environment (to be extended):
                                             help='Never really pop the message from the input pipeline '
                                                  'nor send to output pipeline.')
             parser_run_process.add_argument('--msg', '-m',
-                                            help='Trick the bot to process this JSON '
-                                                 'instead of the Message in its pipeline.')
+                                            help='Trick the bot to process this JSON message from the parameter '
+                                                 "instead of the Message in its pipeline. Read from stdin (one line) with '-'.")
             parser_run_process.set_defaults(run_subcommand="process")
             parser_run.set_defaults(func=self.bot_run)
 

--- a/intelmq/lib/bot_debugger.py
+++ b/intelmq/lib/bot_debugger.py
@@ -173,6 +173,10 @@ class BotDebugger:
 
     def arg2msg(self, msg):
         default_type = "Report" if (self.runtime_configuration.get("group", None) == "Parser" or isinstance(self.instance, ParserBot)) else "Event"
+        if msg == '-':
+            print('Reading message from stdin (one line):')
+            msg = input()
+
         try:
             msg = MessageFactory.unserialize(msg, default_type=default_type)
         except (Exception, KeyError, TypeError, ValueError) as exc:


### PR DESCRIPTION
Optionally read input messages from stdin instead of parameter value

```
intelmqctl run file-output process -m -
...
Reading message from stdin (one line):
{"source.ip":"10.2.3.4"}
file-output:  * Message from cli will be used when processing.
```