### PR TITLE
Fix Modify bot regex matching for numeric fields; add regression test

### DIFF
--- a/intelmq/bots/experts/modify/expert.py
+++ b/intelmq/bots/experts/modify/expert.py
@@ -71,18 +71,10 @@ class ModifyExpertBot(ExpertBot):
             if name not in event:
                 return None
             if is_re_pattern(rule):
-                if isinstance(event[name], (int, float)):
                     match = rule.search(str(event[name]))
                     if match is None:
                         return None
-                    else:
-                        matches[name] = match
-                else:
-                    match = rule.search(event[name])
-                    if match is None:
-                        return None
-                    else:
-                        matches[name] = match
+                    matches[name] = match
             else:  # rule is boolean, int, float, etc
                 if event[name] != rule:
                     return None

--- a/intelmq/tests/bots/experts/modify/test_expert.py
+++ b/intelmq/tests/bots/experts/modify/test_expert.py
@@ -144,6 +144,22 @@ class TestModifyExpertBot(test.BotTestCase, unittest.TestCase):
         del out['classification.identifier']
         self.assertMessageEqual(0, out)
 
+def test_modify_regex_without_parentheses_matches_same_as_with_parentheses():
+    import re
+    from intelmq.bots.experts.modify.expert import ModifyExpertBot
+    from intelmq.lib.message import Event
+
+    bot = ModifyExpertBot.__new__(ModifyExpertBot)
+
+    event = Event()
+    event.add("extra.test", "12.3")
+
+    cond_no_parens = {"extra.test": re.compile(r"^12\.[34]")}
+    cond_with_parens = {"extra.test": re.compile(r"^(12\.[34])")}
+
+    assert bot.matches("no-parens", event, cond_no_parens) is not None
+    assert bot.matches("with-parens", event, cond_with_parens) is not None
+
 
 if __name__ == '__main__':  # pragma: no cover
     unittest.main()


### PR DESCRIPTION
Fixes #2686
## Summary
Fix ModifyExpertBot regex matching so regex rules are always applied to the string version of the field value. This prevents cases where regex matching can behave differently depending on value type.

## What changed
- ModifyExpertBot: always run `rule.search(str(event[name]))` for regex conditions.
- Added a regression test to ensure regex without parentheses matches same as with parentheses.

## Testing
- pytest -q intelmq/tests/bots/experts/modify/test_expert.py
