### PR TITLE
Fix: Allow database update when file doesn't exist

### DIFF
--- a/intelmq/bots/experts/asn_lookup/expert.py
+++ b/intelmq/bots/experts/asn_lookup/expert.py
@@ -123,10 +123,12 @@ class ASNLookupExpertBot(ExpertBot):
             raise MissingDependencyError("pyasn")
 
         for database_path in set(bots.values()):
-            if not Path(database_path).is_file():
-                raise ValueError('Database file does not exist or is not a file.')
-            elif not os.access(database_path, os.W_OK):
-                raise ValueError('Database file is not writeable.')
+            database_file = Path(database_path)
+            if database_file.is_file():
+                # File exists, check if it's writeable
+                if not os.access(database_path, os.W_OK):
+                    raise ValueError('Database file is not writeable.')
+            # If file doesn't exist, the directory will be created later when downloading
 
         try:
             if verbose:


### PR DESCRIPTION
## Description

This PR fixes issue #2689 where the `--update-database` command fails if the database file doesn't already exist.

## Problem

The current implementation checks if the database file exists before attempting to download it:

```python
for database_path in set(bots.values()):
    if not Path(database_path).is_file():
        raise ValueError('Database file does not exist or is not a file.')
```

This is counterintuitive for an update command that should create the file.

## Solution

The fix changes the validation logic to:
1. Only check write permissions if the file already exists
2. Allow the download logic to create the file and parent directories as needed

The download logic already handles directory creation:
```python
for database_path in set(bots.values()):
    database_dir = Path(database_path).parent
    database_dir.mkdir(parents=True, exist_ok=True)
    pyasn.mrtx.dump_prefixes_to_file(prefixes, database_path)
```

## Testing

This fix allows users to run `intelmq.bots.experts.asn_lookup.expert --update-database` successfully even when the database file doesn't exist yet.

Fixes #2689