### PR TITLE
fixup: smtp_batch: make compatible with introduction of bot_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Please refer to the [NEWS](NEWS.md) for a list of changes which have an affect o
 #### Experts
 
 #### Outputs
+- `intelmq.bots.outputs.smtp_batch.output`: Ignore parameter `bot_id` for parsing parameters (PR#2692 by Lukas Heindl, fixes #2666).
 
 ### Documentation
 - Updates to Contrib and Overview pages (PR#2672 by Sebastian Wagner).

--- a/intelmq/bots/outputs/smtp_batch/output.py
+++ b/intelmq/bots/outputs/smtp_batch/output.py
@@ -136,7 +136,7 @@ class SMTPBatchOutputBot(Bot):
 
         if parsed_args.cli:
             instance = cls(parsed_args.bot_id)
-            [setattr(instance, k, v) for k, v in vars(parsed_args).items()]
+            [setattr(instance, k, v) for k, v in vars(parsed_args).items() if k != "bot_id"]
             instance.cli_run()
         else:
             super().run(parsed_args=parsed_args)


### PR DESCRIPTION
The `bot_id`was introduced as property in #2509 which broke the output bot
This issue/incompatibility was noted in #2666.

Ideally we would had a test which would have spotted this issue prior to releasing the last version. But looking at the current tests, I'm unsure if we can cover this correctly (running an executable is not that nice for testing).