### PR TITLE
fix (smtp_batch): CLI overwriting params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,9 @@ Please refer to the [NEWS](NEWS.md) for a list of changes which have an affect o
 #### Experts
 
 #### Outputs
-- `intelmq.bots.outputs.smtp_batch.output`: Ignore parameter `bot_id` for parsing parameters (PR#2692 by Lukas Heindl, fixes #2666).
+- `intelmq.bots.outputs.smtp_batch.output`:
+  - Ignore parameter `bot_id` for parsing parameters (PR#2692 by Lukas Heindl, fixes #2666).
+  - Fix CLI overwriting params over the defaults (PR#2699 by Edvard Rejthar).
 
 ### Documentation
 - Updates to Contrib and Overview pages (PR#2672 by Sebastian Wagner).

--- a/intelmq/bots/outputs/smtp_batch/output.py
+++ b/intelmq/bots/outputs/smtp_batch/output.py
@@ -1,19 +1,20 @@
 # SPDX-FileCopyrightText: 2022 CSIRT.cz <https://csirt.cz>
 # SPDX-License-Identifier: AGPL-3.0-or-later
 import csv
-from dataclasses import dataclass
 import datetime
 import json
 import os
 import sys
-from tempfile import NamedTemporaryFile
 import time
-from typing import Any, Iterable, Optional, Dict, List
 import zipfile
+from argparse import Namespace
 from base64 import b64decode
 from collections import OrderedDict
-from io import StringIO
+from dataclasses import dataclass
 from hashlib import sha256
+from io import StringIO
+from tempfile import NamedTemporaryFile
+from typing import Any, Dict, Iterable, List, Optional
 
 from redis.exceptions import TimeoutError
 
@@ -132,7 +133,9 @@ class SMTPBatchOutputBot(Bot):
     @classmethod
     def run(cls, parsed_args=None):
         if not parsed_args:
-            parsed_args = cls._create_argparser().parse_args()
+            # filter out None values as to not rewrite the defaults
+            namespace = cls._create_argparser().parse_args()
+            parsed_args = Namespace(**{k: v for k, v in vars(namespace).items() if v is not None})
 
         if parsed_args.cli:
             instance = cls(parsed_args.bot_id)


### PR DESCRIPTION
Tiny fix, argparse made shadow over the defaults. When the user did not specify ex. gpg_key in CLI, the None value overwritten the config file value and no GPG appeared.