### PR TITLE
Handle missing intelmqdump defaults

### DIFF
--- a/intelmq/bin/intelmqdump.py
+++ b/intelmq/bin/intelmqdump.py
@@ -191,6 +191,7 @@ def main(argv=None):
     try:
         defaults = utils.get_global_settings()
     except Exception:
+        defaults = {}
         log_level = DEFAULT_LOGGING_LEVEL
 
     try:
@@ -207,7 +208,6 @@ def main(argv=None):
     readline.parse_and_bind("tab: complete")
     readline.set_completer_delims('')
 
-    defaults = utils.get_global_settings()
     runtime_config = utils.get_runtime()
     pipeline_pipes = {}
     logging_paths = {defaults.get('logging_path', DEFAULT_LOGGING_PATH)}

--- a/intelmq/tests/bin/test_intelmqdump.py
+++ b/intelmq/tests/bin/test_intelmqdump.py
@@ -110,6 +110,18 @@ class TestIntelMQDump(unittest.TestCase):
 
     @skip_installation()
     @mock.patch.object(intelmqdump, "input", return_value='q')
+    def test_list_dumps_when_defaults_cannot_be_loaded(self, _):
+        self._prepare_empty_dump('test-1')
+
+        intelmqdump.utils.get_global_settings.side_effect = OSError("missing runtime")
+
+        with mock.patch.object(intelmqdump, "DEFAULT_LOGGING_PATH", self.tmp_log_dir.name):
+            output = self._run_main([])
+
+        self.assertIn("0: test-1 empty file", output[1])
+
+    @skip_installation()
+    @mock.patch.object(intelmqdump, "input", return_value='q')
     def test_list_dumps_for_all_bots_from_custom_locations(self, _):
         self.global_config = {"logging_path": self.tmp_log_dir.name}
         self._prepare_empty_dump('bot-1/test-1')


### PR DESCRIPTION
﻿Fixes #2702

## Description
`intelmqdump` already handled failures while loading global settings by falling back to the default log level. However, the `defaults` variable was not initialized in that exception path, so the following logging setup could raise another exception before the tool had a chance to continue.

This change uses an empty defaults mapping when global settings cannot be loaded, and reuses the same mapping instead of calling `get_global_settings()` a second time immediately afterwards.

## Tests
I ran the intelmqdump tests under WSL because the module imports Unix `fcntl` and cannot run on native Windows:

```text
INTELMQ_TEST_INSTALLATION=1 PYTHONWARNINGS=ignore::PendingDeprecationWarning /home/codexuser/codex-work/intelmq/.venv/bin/python -m unittest intelmq.tests.bin.test_intelmqdump.TestIntelMQDump.test_list_dumps_when_defaults_cannot_be_loaded intelmq.tests.bin.test_intelmqdump.TestIntelMQDump.test_list_dumps_for_all_bots_from_default_log_path
# Ran 2 tests in 0.010s
# OK
```

```text
INTELMQ_TEST_INSTALLATION=1 PYTHONWARNINGS=ignore::PendingDeprecationWarning /home/codexuser/codex-work/intelmq/.venv/bin/python -m unittest intelmq.tests.bin.test_intelmqdump
# Ran 9 tests in 0.093s
# OK
```

The `/opt/intelmq/var/run/` permission messages are emitted by the existing controller setup in these tests; they were present while the tests completed successfully.
