### PR TITLE
Create missing ASN lookup database file

### DIFF
--- a/intelmq/bots/experts/asn_lookup/expert.py
+++ b/intelmq/bots/experts/asn_lookup/expert.py
@@ -123,9 +123,10 @@ class ASNLookupExpertBot(ExpertBot):
             raise MissingDependencyError("pyasn")
 
         for database_path in set(bots.values()):
-            if not Path(database_path).is_file():
+            database_path = Path(database_path)
+            if database_path.exists() and not database_path.is_file():
                 raise ValueError('Database file does not exist or is not a file.')
-            elif not os.access(database_path, os.W_OK):
+            elif database_path.exists() and not os.access(database_path, os.W_OK):
                 raise ValueError('Database file is not writeable.')
 
         try:

--- a/intelmq/tests/bots/experts/asn_lookup/test_expert.py
+++ b/intelmq/tests/bots/experts/asn_lookup/test_expert.py
@@ -7,11 +7,17 @@
 Testing asn_lookup with a faked local database
 """
 
+import bz2
+import tempfile
 import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
 
 import pkg_resources
 
 import intelmq.lib.test as test
+from intelmq.bots.experts.asn_lookup import expert as asn_lookup_expert
 from intelmq.bots.experts.asn_lookup.expert import ASNLookupExpertBot
 
 ASN_DB = pkg_resources.resource_filename('intelmq', 'tests/bots/experts/asn_lookup/ipasn.dat')
@@ -40,6 +46,7 @@ EXAMPLE_OUTPUT6 = {"__type": "Event",
                    "source.network": "2001:500:88::/48",
                    }
 
+
 @test.skip_exotic()
 class TestASNLookupExpertBot(test.BotTestCase, unittest.TestCase):
     """
@@ -60,6 +67,44 @@ class TestASNLookupExpertBot(test.BotTestCase, unittest.TestCase):
         self.input_message = EXAMPLE_INPUT6
         self.run_bot()
         self.assertMessageEqual(0, EXAMPLE_OUTPUT6)
+
+
+class TestASNLookupDatabaseUpdate(unittest.TestCase):
+    def test_update_database_creates_missing_database_file(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            database_path = Path(tmp_dir) / "asn_lookup" / "ipasn.dat"
+
+            responses = [
+                SimpleNamespace(text='href="2026.05/"', status_code=200, url="months"),
+                SimpleNamespace(text='href="rib.20260509.0000.bz2"', status_code=200, url="ribs"),
+                SimpleNamespace(content=bz2.compress(b"rib"), status_code=200, url="rib"),
+            ]
+            session = SimpleNamespace(get=mock.Mock(side_effect=responses))
+
+            def dump_prefixes_to_file(prefixes, target_path):
+                Path(target_path).write_text("created", encoding="utf-8")
+
+            mocked_pyasn = SimpleNamespace(
+                mrtx=SimpleNamespace(
+                    parse_mrt_file=mock.Mock(return_value=["prefixes"]),
+                    dump_prefixes_to_file=mock.Mock(side_effect=dump_prefixes_to_file),
+                )
+            )
+
+            with mock.patch.object(asn_lookup_expert, "pyasn", mocked_pyasn), \
+                    mock.patch.object(asn_lookup_expert, "get_bots_settings", return_value={
+                        "asn-lookup": {
+                            "module": "intelmq.bots.experts.asn_lookup.expert",
+                            "parameters": {"database": str(database_path)},
+                        }
+                    }), \
+                    mock.patch.object(asn_lookup_expert, "create_request_session", return_value=session), \
+                    mock.patch.object(asn_lookup_expert, "IntelMQController") as controller:
+                ASNLookupExpertBot.update_database()
+
+            self.assertTrue(database_path.is_file())
+            self.assertEqual(database_path.read_text(encoding="utf-8"), "created")
+            controller.return_value.bot_reload.assert_called_once_with("asn-lookup")
 
 
 if __name__ == '__main__':  # pragma: no cover


### PR DESCRIPTION
﻿Fixes #2689

## Description
The ASN lookup updater currently checks that each configured database path already exists as a file before it downloads and parses the RouteViews data. That makes a first-time database update fail unless the target file is manually created first.

This change keeps the safety checks for paths that already exist, but allows a missing target file so the updater can create the parent directory and write the generated pyasn database as intended.

## Tests
I ran the focused regression test and the ASN lookup test module under WSL:

```text
PYTHONWARNINGS=ignore::PendingDeprecationWarning /home/codexuser/codex-work/intelmq/.venv/bin/python -m unittest intelmq.tests.bots.experts.asn_lookup.test_expert.TestASNLookupDatabaseUpdate.test_update_database_creates_missing_database_file
# Ran 1 test in 0.005s
# OK
```

```text
PYTHONWARNINGS=ignore::PendingDeprecationWarning /home/codexuser/codex-work/intelmq/.venv/bin/python -m unittest intelmq.tests.bots.experts.asn_lookup.test_expert
# Ran 5 tests in 0.007s
# OK (skipped=4)
```

The skipped tests are the existing exotic ASN lookup tests, which require the optional test flag/dependency path. The new update-database regression test ran successfully.

```text
/home/codexuser/codex-work/intelmq/.venv/bin/python -m flake8 intelmq/bots/experts/asn_lookup/expert.py intelmq/tests/bots/experts/asn_lookup/test_expert.py
# no output
```

```text
git diff --check
# clean
```
