### PR TITLE
Handle missing debugger parameters

### DIFF
--- a/intelmq/lib/bot_debugger.py
+++ b/intelmq/lib/bot_debugger.py
@@ -210,7 +210,10 @@ class BotDebugger:
                     if bot_id == "global":
                         config[bot_id]["logging_level"] = logging_level
                     else:
-                        config[bot_id]['parameters']["logging_level"] = logging_level
+                        parameters = config[bot_id].get('parameters')
+                        if parameters is None:
+                            parameters = config[bot_id]['parameters'] = {}
+                        parameters["logging_level"] = logging_level
                 if "global" not in config:
                     config["global"] = {"logging_level": logging_level}
             return config

--- a/intelmq/tests/lib/test_bot_debugger.py
+++ b/intelmq/tests/lib/test_bot_debugger.py
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: 2026 Mirochill
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+# -*- coding: utf-8 -*-
+
+import unittest
+from unittest import mock
+
+from intelmq.lib import utils
+from intelmq.lib.bot_debugger import BotDebugger
+
+
+class TestBotDebugger(unittest.TestCase):
+
+    def test_generate_get_runtime_adds_missing_parameters(self):
+        runtime = {
+            "collector": {"module": "intelmq.bots.collectors.http.collector_http"},
+            "parser": {
+                "module": "intelmq.bots.parsers.generic.parser_csv",
+                "parameters": None,
+            },
+            "expert": {
+                "module": "intelmq.bots.experts.filter.expert",
+                "parameters": {"field": "source.ip"},
+            },
+        }
+        debugger = BotDebugger.__new__(BotDebugger)
+
+        with mock.patch.object(utils, "load_configuration", return_value=runtime):
+            config = debugger.generate_get_runtime("DEBUG")()
+
+        self.assertEqual(config["collector"]["parameters"], {"logging_level": "DEBUG"})
+        self.assertEqual(config["parser"]["parameters"], {"logging_level": "DEBUG"})
+        self.assertEqual(
+            config["expert"]["parameters"],
+            {"field": "source.ip", "logging_level": "DEBUG"},
+        )
+        self.assertEqual(config["global"], {"logging_level": "DEBUG"})
+
+
+if __name__ == '__main__':  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
Fixes #2683

# Description

`BotDebugger.generate_get_runtime()` injects the selected `logging_level` into every runtime entry before the bot starts. Sparse runtime configs can omit `parameters` for a bot, or set it to null, which currently raises before the debugger can continue.

This treats missing or null bot parameters as an empty mapping before adding `logging_level`, while preserving any existing parameters.

# Tests

Not run locally.

Remote fork checks passed:

- ReUse License Check
- Unit tests