### PR TITLE
Fix invalid escape in HTTP collector test

### DIFF
--- a/intelmq/tests/bots/collectors/http/test_collector.py
+++ b/intelmq/tests/bots/collectors/http/test_collector.py
@@ -250,7 +250,7 @@ class TestHTTPCollectorBotAuthentication(test.BotTestCase, unittest.TestCase):
         captured = mocker.register_uri('GET', self.sysconfig['http_url'],
                             text='Foo Bar',
                             additional_matcher=check_authorization_header)
-        log_line = "Either 'http_username' or 'http_password' are given, but for HTTP Authentication, both must be set\."
+        log_line = r"Either 'http_username' or 'http_password' are given, but for HTTP Authentication, both must be set\."
         self.run_bot(parameters={'http_username': 'username'}, allowed_warning_count=1)
         self.assertLogMatches(log_line, 'WARNING')
         self.run_bot(parameters={'http_password': 'password'}, allowed_warning_count=1)


### PR DESCRIPTION
Summary:
- Fixes #2676.
- Uses a raw string for the HTTP authentication warning regex in the collector test.
- Preserves the existing literal-period regex match while avoiding the invalid escape sequence warning.

Validation:
- `git diff --check`
- `git diff --cached --check`
- Remote fork run `ReUse License Check` passed: https://github.com/Mirochill/intelmq/actions/runs/26413489212
- Remote fork run `Unit tests` passed: https://github.com/Mirochill/intelmq/actions/runs/26413489213

Not run locally: test suite.