### PR TITLE
Fix stomp version checks

### DIFF
--- a/intelmq/bots/collectors/stomp/collector.py
+++ b/intelmq/bots/collectors/stomp/collector.py
@@ -10,9 +10,10 @@ except ImportError:
     stomp = None
 else:
     import stomp.exception
+from packaging.version import Version
 
 from intelmq.lib.bot import CollectorBot
-from intelmq.lib.mixins import StompMixin
+from intelmq.lib.mixins.stomp import StompMixin, stomp_version
 
 
 if stomp is not None:
@@ -28,7 +29,7 @@ if stomp is not None:
             self.connect_kwargs = connect_kwargs
             self.destination = destination
             super().__init__()
-            if stomp.__version__ >= (5, 0, 0):
+            if stomp_version() >= Version("5.0.0"):
                 # set the function directly, as the argument print_to_log logs to the generic logger
                 self._PrintingListener__print = n6stompcollector.logger.debug
 
@@ -112,13 +113,14 @@ class StompCollectorBot(CollectorBot, StompMixin):
         self.stomp_bot_runtime_initial_check()
 
         # (note: older versions of `stomp.py` do not play well with reconnects)
-        self._auto_reconnect = (stomp.__version__ >= (4, 1, 21))
+        installed_version = stomp_version()
+        self._auto_reconnect = (installed_version >= Version("4.1.21"))
 
         self.__conn, connect_kwargs = self.prepare_stomp_connection()
         self.__conn.set_listener('', StompListener(self, self.__conn, self.exchange,
                                                    connect_kwargs=connect_kwargs))
         connect_and_subscribe(self.__conn, self.logger, self.exchange,
-                              start=stomp.__version__ < (4, 1, 20),
+                              start=installed_version < Version("4.1.20"),
                               connect_kwargs=connect_kwargs)
 
     def shutdown(self):

--- a/intelmq/bots/outputs/stomp/output.py
+++ b/intelmq/bots/outputs/stomp/output.py
@@ -8,9 +8,10 @@ try:
     import stomp
 except ImportError:
     stomp = None
+from packaging.version import Version
 
 from intelmq.lib.bot import OutputBot
-from intelmq.lib.mixins import StompMixin
+from intelmq.lib.mixins.stomp import StompMixin, stomp_version
 
 
 class StompOutputBot(OutputBot, StompMixin):
@@ -62,7 +63,7 @@ class StompOutputBot(OutputBot, StompMixin):
         self.logger.debug('Connecting.')
         # based on the documentation at:
         # https://github.com/jasonrbriggs/stomp.py/wiki/Simple-Example
-        if stomp.__version__ < (4, 1, 20):
+        if stomp_version() < Version("4.1.20"):
             self._conn.start()
         self._conn.connect(**self._connect_kwargs)
         self.logger.debug('Connected.')

--- a/intelmq/lib/mixins/stomp.py
+++ b/intelmq/lib/mixins/stomp.py
@@ -8,6 +8,8 @@ import enum
 import os
 import ssl
 import sys
+from importlib.metadata import PackageNotFoundError, version
+from packaging.version import Version
 from typing import (
     Any,
     Callable,
@@ -25,6 +27,16 @@ else:
     import stomp.transport
 
 from intelmq.lib.exceptions import MissingDependencyError
+
+
+def stomp_version() -> Version:
+    try:
+        return Version(version("stomp.py"))
+    except PackageNotFoundError:
+        stomp_module_version = stomp.__version__
+        if isinstance(stomp_module_version, tuple):
+            stomp_module_version = ".".join(str(part) for part in stomp_module_version)
+        return Version(stomp_module_version)
 
 
 class StompMixin:
@@ -121,9 +133,10 @@ class StompMixin:
         if stomp is None:
             raise MissingDependencyError('stomp',
                                          additional_text=cls._DEPENDENCY_NAME_REMARK)
-        if stomp.__version__ < (4, 1, 12):
+        installed_version = stomp_version()
+        if installed_version < Version("4.1.12"):
             raise MissingDependencyError('stomp', version="4.1.12",
-                                         installed=stomp.__version__,
+                                         installed=str(installed_version),
                                          additional_text=cls._DEPENDENCY_NAME_REMARK)
 
     @classmethod

--- a/intelmq/tests/bots/outputs/stomp/test_output.py
+++ b/intelmq/tests/bots/outputs/stomp/test_output.py
@@ -4,6 +4,27 @@
 
 # -*- coding: utf-8 -*-
 import os
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+from packaging.version import Version
 
 if os.environ.get('INTELMQ_TEST_EXOTIC'):
     import intelmq.bots.outputs.stomp.output
+
+from intelmq.bots.outputs.stomp.output import StompOutputBot
+
+
+def test_connect_with_string_stomp_version(monkeypatch):
+    bot = StompOutputBot.__new__(StompOutputBot)
+    bot.logger = Mock()
+    bot._connect_kwargs = {"wait": True}
+    bot._conn = SimpleNamespace(start=Mock(), connect=Mock())
+
+    monkeypatch.setattr("intelmq.bots.outputs.stomp.output.stomp_version",
+                        lambda: Version("8.2.0"))
+
+    bot.connect()
+
+    bot._conn.start.assert_not_called()
+    bot._conn.connect.assert_called_once_with(wait=True)

--- a/intelmq/tests/lib/test_stomp_mixin.py
+++ b/intelmq/tests/lib/test_stomp_mixin.py
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: 2026 BharatDeva
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+from types import SimpleNamespace
+
+from importlib.metadata import PackageNotFoundError
+from packaging.version import Version
+
+import intelmq.lib.mixins.stomp as stomp
+
+
+def test_stomp_version_uses_distribution_metadata(monkeypatch):
+    monkeypatch.setattr(stomp, "version", lambda _: "8.2.0")
+    monkeypatch.setattr(stomp, "stomp", SimpleNamespace(__version__=(4, 1, 12)))
+
+    assert stomp.stomp_version() == Version("8.2.0")
+
+
+def test_stomp_version_falls_back_to_tuple_module_version(monkeypatch):
+    def missing_distribution(_):
+        raise PackageNotFoundError
+
+    monkeypatch.setattr(stomp, "version", missing_distribution)
+    monkeypatch.setattr(stomp, "stomp", SimpleNamespace(__version__=(4, 1, 12)))
+
+    assert stomp.stomp_version() == Version("4.1.12")


### PR DESCRIPTION
# Description

Fixes certtools/intelmq#2600.

`stomp.py` 8.2.0 changed `stomp.__version__` from a tuple to a string. The STOMP collector and output bots compared that value directly with tuple literals, so the version checks could fail before the bots finished initialization or connection setup.

This change adds a small shared `stomp_version()` helper in the STOMP mixin module. It prefers `importlib.metadata.version(stomp.py)`, which is the stable package metadata interface, and falls back to `stomp.__version__` for environments where only the module version is available. The collector and output bot now compare `packaging.version.Version` objects instead of comparing raw module attributes.

The fallback keeps compatibility with older tuple-style module versions while supporting newer string-style versions.

# Testing

Ran locally in WSL Ubuntu with Python 3.12.3:

- `PYTHONPATH=. .venv-wsl-pr/bin/python -m pytest -o addopts= intelmq/tests/lib/test_stomp_mixin.py intelmq/tests/bots/outputs/stomp/test_output.py`
  - `3 passed`
- `PYTHONPATH=. .venv-wsl-pr/bin/python -m compileall -q intelmq/bots/collectors/stomp intelmq/bots/outputs/stomp intelmq/lib/mixins/stomp.py intelmq/tests/lib/test_stomp_mixin.py`
  - passed
- `git diff --check origin/develop...HEAD`
  - passed