### PR TITLE
Allow Sieve numeric matches on JSONDict children

### DIFF
--- a/intelmq/bots/experts/sieve/expert.py
+++ b/intelmq/bots/experts/sieve/expert.py
@@ -537,6 +537,11 @@ class SieveExpertBot(ExpertBot):
             if type not in valid_types:
                 raise TextXSemanticError(f"Incompatible type: {type}.", **position)
         except KeyError:
+            if any(
+                num_match.key.startswith(f"{key}.") and value["type"] == "JSONDict"
+                for key, value in SieveExpertBot._harmonization.items()
+            ):
+                return
             raise TextXSemanticError(f"Invalid key: {num_match.key}.", **position)
 
     @staticmethod

--- a/intelmq/tests/bots/experts/sieve/test_expert.py
+++ b/intelmq/tests/bots/experts/sieve/test_expert.py
@@ -585,6 +585,21 @@ class TestSieveExpertBot(test.BotTestCase, unittest.TestCase):
         exception = context.exception
         self.assertRegex(str(exception), r".*Incompatible type: FQDN\.$")
 
+    def test_numeric_extra_jsondict_match(self):
+        """Test numeric match for dynamic extra.* fields."""
+        self.sysconfig["file"] = os.path.join(
+            os.path.dirname(__file__),
+            "test_sieve_files/test_numeric_extra_jsondict.sieve",
+        )
+
+        event = EXAMPLE_INPUT.copy()
+        event["extra.min_amplification"] = 6
+        expected = event.copy()
+        expected["comment"] = "matched extra numeric field"
+        self.input_message = event
+        self.run_bot()
+        self.assertMessageEqual(0, expected)
+
     def test_exists_match(self):
         """Test :exists match"""
         self.sysconfig["file"] = os.path.join(

--- a/intelmq/tests/bots/experts/sieve/test_sieve_files/test_numeric_extra_jsondict.sieve
+++ b/intelmq/tests/bots/experts/sieve/test_sieve_files/test_numeric_extra_jsondict.sieve
@@ -1,0 +1,3 @@
+if extra.min_amplification > 5 {
+    add comment = "matched extra numeric field"
+}


### PR DESCRIPTION
Fixes #2599

## Summary

This updates Sieve numeric-match validation so fields below harmonization entries typed as `JSONDict` are not rejected during static validation.

For example, `extra` is typed as `JSONDict`, so a Sieve rule such as:

```sieve
if extra.min_amplification > 5 {
    ...
}
```

should be allowed to parse and then be evaluated at runtime against the event value.

Known harmonized fields are still statically checked against the existing numeric-compatible types.

## Testing

```bash
INTELMQ_ROOT_DIR=/mnt/c/Users/bhara/OneDrive/Desktop/Python/intelmq/intelmq \
INTELMQ_TEST_EXOTIC=1 \
PYTHONPATH=. \
python -m unittest intelmq.tests.bots.experts.sieve.test_expert
```

Result:

```text
Ran 61 tests in 10.918s

OK
```

Additional checks:

```bash
git diff --check
python -m compileall -q intelmq/bots/experts/sieve/expert.py intelmq/tests/bots/experts/sieve/test_expert.py
```
